### PR TITLE
muxassign assign.json - remove whitespace from keys

### DIFF
--- a/muxassign/main.c
+++ b/muxassign/main.c
@@ -942,7 +942,7 @@ int main(int argc, char *argv[]) {
         if (json_valid(read_text_from_file(assign_file))) {
             struct json auto_assign_config = json_object_get(
                     json_parse(read_text_from_file(assign_file)),
-                    str_tolower(get_last_dir(rom_dir)));
+                    str_tolower(str_remchar(get_last_dir(rom_dir), ' ')));
 
             if (json_exists(auto_assign_config)) {
                 char ass_config[MAX_BUFFER_SIZE];


### PR DESCRIPTION
This is combined with a [PR on muOS/internal](https://github.com/MustardOS/internal/pull/117), to remove whitespace from the keys in assign.json. I also created some basic external [test cases](https://github.com/Matsyir/internal/tree/assign-json-testcases/assign-json-testcases) in nodejs to ensure this isn't problematic (more detail on other PR).

This change should make a ton of alternate spellings with or without spaces get detected, and also allow us to populate assign.json quicker/more in-depth.

I don't really know C or how to compile this project, so please ensure this code makes sense & that I didn't miss any related integrations with assign.json. Did my best with what I could find. This PR attempts to simply remove spaces from the folder name, before lowercasing it and comparing with the json keys. I used a function from the same custom/common string library that was used to lowercase the folder name.