### PR TITLE
added 7 more options for longer Sleep Shutdown wait intervals

### DIFF
--- a/muxtweakgen/main.c
+++ b/muxtweakgen/main.c
@@ -260,6 +260,27 @@ void restore_tweak_options() {
         case 600:
             lv_dropdown_set_selected(ui_droShutdown, 7);
             break;
+        case 1200:
+            lv_dropdown_set_selected(ui_droShutdown, 8);
+            break;
+        case 1800:
+            lv_dropdown_set_selected(ui_droShutdown, 9);
+            break;
+        case 2700:
+            lv_dropdown_set_selected(ui_droShutdown, 10);
+            break;
+        case 3600:
+            lv_dropdown_set_selected(ui_droShutdown, 11);
+            break;
+        case 7200:
+            lv_dropdown_set_selected(ui_droShutdown, 12);
+            break;
+        case 10800:
+            lv_dropdown_set_selected(ui_droShutdown, 13);
+            break;
+        case 14400:
+            lv_dropdown_set_selected(ui_droShutdown, 14);
+            break;
         default:
             lv_dropdown_set_selected(ui_droShutdown, 0);
             break;
@@ -427,6 +448,27 @@ void save_tweak_options() {
             break;
         case 7:
             idx_shutdown = 600;
+            break;
+        case 8:
+            idx_shutdown = 1200;
+            break;
+        case 9:
+            idx_shutdown = 1800;
+            break;
+        case 10:
+            idx_shutdown = 2700;
+            break;
+        case 11:
+            idx_shutdown = 3600;
+            break;
+        case 12:
+            idx_shutdown = 7200;
+            break;
+        case 13:
+            idx_shutdown = 10800;
+            break;
+        case 14:
+            idx_shutdown = 14400;
             break;
         default:
             idx_shutdown = -1;

--- a/muxtweakgen/ui/ui_scrTweakGeneral.c
+++ b/muxtweakgen/ui/ui_scrTweakGeneral.c
@@ -857,7 +857,7 @@ void ui_scrTweakGeneral_screen_init(void)
     ui_droShutdown = lv_dropdown_create(ui_pnlHighlight);
     lv_dropdown_set_dir(ui_droShutdown, LV_DIR_LEFT);
     lv_dropdown_set_options(ui_droShutdown,
-                            "Disabled\nInstant\n10 Seconds\n30 Seconds\n60 Seconds\n2 Minutes\n5 Minutes\n10 Minutes");
+                            "Disabled\nInstant\n10 Seconds\n30 Seconds\n60 Seconds\n2 Minutes\n5 Minutes\n10 Minutes\n20 Minutes\n30 Minutes\n45 Minutes\n1 Hour\n2 Hours\n3 Hours\n4 Hours");
     lv_dropdown_set_selected_highlight(ui_droShutdown, false);
     lv_obj_set_width(ui_droShutdown, 640);
     lv_obj_set_height(ui_droShutdown, 28);


### PR DESCRIPTION
- expanded the 'Sleep Shutdown' options dropdown to allow longer wait periods than just 10 minutes
- added: 20, 30, 45 minutes, and 1, 2, 3, 4 hours