### PR TITLE
muOS Frontend - panel font support

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -1288,6 +1288,35 @@ void load_font_glyph(const char *program, lv_obj_t *element) {
     }
 }
 
+void load_font_section(const char *program, const char *section, lv_obj_t *element) {
+    printf("\t\t\t\tTRYING TO LOAD %s FONT\n", section);
+
+    if (config.SETTINGS.ADVANCED.FONT) {
+        char theme_font_section_default[MAX_BUFFER_SIZE];
+        char theme_font_section[MAX_BUFFER_SIZE];
+        snprintf(theme_font_section_default, sizeof(theme_font_section_default),
+                 "%s/MUOS/theme/active/font/%s/default.bin", device.STORAGE.ROM.MOUNT, section);
+        snprintf(theme_font_section, sizeof(theme_font_section),
+                 "%s/MUOS/theme/active/font/%s/%s.bin", device.STORAGE.ROM.MOUNT, section, program);
+        if (file_exist(theme_font_section)) {
+            char theme_font_section_fs[MAX_BUFFER_SIZE];
+            snprintf(theme_font_section_fs, sizeof(theme_font_section_fs),
+                     "M:%s/MUOS/theme/active/font/%s/%s.bin", device.STORAGE.ROM.MOUNT, section, program);
+            lv_obj_set_style_text_font(element, lv_font_load(theme_font_section_fs),
+                                       LV_PART_MAIN | LV_STATE_DEFAULT);
+        } else {
+            if (file_exist(theme_font_section_default)) {
+                char theme_font_section_default_fs[MAX_BUFFER_SIZE];
+                snprintf(theme_font_section_default_fs, sizeof(theme_font_section_default_fs),
+                         "M:%s/MUOS/theme/active/font/%s/default.bin", device.STORAGE.ROM.MOUNT, section);
+                lv_obj_set_style_text_font(element, lv_font_load(theme_font_section_default_fs),
+                                           LV_PART_MAIN | LV_STATE_DEFAULT);
+                printf("\t\t\t\tLOADED DEFAULT %s FONT (%s)\n", section, theme_font_section_default_fs);
+            }
+        }
+    }
+}
+
 int is_network_connected() {
     if (!config.NETWORK.ENABLED) return 0;
     if (!config.VISUAL.NETWORK) return 0;

--- a/common/common.h
+++ b/common/common.h
@@ -196,6 +196,8 @@ void load_font_text(const char *program, lv_obj_t *screen);
 
 void load_font_glyph(const char *program, lv_obj_t *element);
 
+void load_font_section(const char *program, const char *section, lv_obj_t *element);
+
 int is_network_connected();
 
 void process_visual_element(enum visual_type visual, lv_obj_t *element);

--- a/common/options.h
+++ b/common/options.h
@@ -28,3 +28,5 @@
 
 #define BRIGHT_PERC "/tmp/current_brightness_percent"
 #define VOLUME_PERC "/tmp/current_volume_percent"
+
+#define FONT_PANEL_FOLDER "panel"

--- a/muxapp/main.c
+++ b/muxapp/main.c
@@ -773,6 +773,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrApp);
+    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxapp/main.c
+++ b/muxapp/main.c
@@ -773,7 +773,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrApp);
-    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxarchive/main.c
+++ b/muxarchive/main.c
@@ -833,6 +833,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrArchive);
+    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxarchive/main.c
+++ b/muxarchive/main.c
@@ -833,7 +833,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrArchive);
-    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxassign/main.c
+++ b/muxassign/main.c
@@ -1074,7 +1074,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrAssign);
-    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxassign/main.c
+++ b/muxassign/main.c
@@ -1074,6 +1074,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrAssign);
+    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxconfig/main.c
+++ b/muxconfig/main.c
@@ -539,6 +539,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrConfig);
+    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxconfig/main.c
+++ b/muxconfig/main.c
@@ -539,7 +539,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrConfig);
-    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxdevice/main.c
+++ b/muxdevice/main.c
@@ -582,6 +582,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrDevice);
+    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxdevice/main.c
+++ b/muxdevice/main.c
@@ -582,7 +582,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrDevice);
-    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxinfo/main.c
+++ b/muxinfo/main.c
@@ -517,6 +517,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrInfo);
+    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxinfo/main.c
+++ b/muxinfo/main.c
@@ -517,7 +517,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrInfo);
-    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxlaunch/main.c
+++ b/muxlaunch/main.c
@@ -576,7 +576,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrLaunch);
-    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxlaunch/main.c
+++ b/muxlaunch/main.c
@@ -576,6 +576,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrLaunch);
+    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxnetprofile/main.c
+++ b/muxnetprofile/main.c
@@ -751,7 +751,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrNetProfile);
-    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxnetprofile/main.c
+++ b/muxnetprofile/main.c
@@ -751,6 +751,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrNetProfile);
+    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxnetscan/main.c
+++ b/muxnetscan/main.c
@@ -705,6 +705,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrNetScan);
+    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxnetscan/main.c
+++ b/muxnetscan/main.c
@@ -705,7 +705,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrNetScan);
-    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxnetwork/main.c
+++ b/muxnetwork/main.c
@@ -1828,7 +1828,8 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrNetwork);
-    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlHighlight);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxnetwork/main.c
+++ b/muxnetwork/main.c
@@ -1828,6 +1828,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrNetwork);
+    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxplore/main.c
+++ b/muxplore/main.c
@@ -1781,7 +1781,7 @@ void init_elements() {
 
 void init_fonts() {
     load_font_text(mux_prog, ui_scrExplore);
-    load_font_section(mux_prog, "panel", ui_pnlContent);
+    load_font_section(mux_prog, FONT_PANEL_FOLDER, ui_pnlContent);
 }
 
 void glyph_task() {

--- a/muxplore/main.c
+++ b/muxplore/main.c
@@ -1781,6 +1781,7 @@ void init_elements() {
 
 void init_fonts() {
     load_font_text(mux_prog, ui_scrExplore);
+    load_font_section(mux_prog, "panel", ui_pnlContent);
 }
 
 void glyph_task() {

--- a/muxrtc/main.c
+++ b/muxrtc/main.c
@@ -901,7 +901,8 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrRTC);
-    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlHighlight);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxrtc/main.c
+++ b/muxrtc/main.c
@@ -901,6 +901,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrRTC);
+    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxstorage/main.c
+++ b/muxstorage/main.c
@@ -773,6 +773,7 @@ int main(int argc, char *argv[]) {
 
     load_font_text(basename(argv[0]), ui_scrStorage);
     load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlHighlight);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxstorage/main.c
+++ b/muxstorage/main.c
@@ -772,7 +772,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrStorage);
-    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxstorage/main.c
+++ b/muxstorage/main.c
@@ -772,6 +772,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrStorage);
+    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxsysinfo/main.c
+++ b/muxsysinfo/main.c
@@ -635,6 +635,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrSysInfo);
+    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxsysinfo/main.c
+++ b/muxsysinfo/main.c
@@ -635,7 +635,8 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrSysInfo);
-    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlHighlight);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxtask/main.c
+++ b/muxtask/main.c
@@ -748,7 +748,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrTask);
-    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxtask/main.c
+++ b/muxtask/main.c
@@ -748,6 +748,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrTask);
+    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxtheme/main.c
+++ b/muxtheme/main.c
@@ -760,7 +760,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrTheme);
-    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxtheme/main.c
+++ b/muxtheme/main.c
@@ -760,6 +760,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrTheme);
+    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxtimezone/main.c
+++ b/muxtimezone/main.c
@@ -684,6 +684,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrTimezone);
+    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxtimezone/main.c
+++ b/muxtimezone/main.c
@@ -684,7 +684,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrTimezone);
-    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxtweakadv/main.c
+++ b/muxtweakadv/main.c
@@ -962,6 +962,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrTweakAdvanced);
+    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxtweakadv/main.c
+++ b/muxtweakadv/main.c
@@ -962,7 +962,8 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrTweakAdvanced);
-    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlHighlight);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxtweakgen/main.c
+++ b/muxtweakgen/main.c
@@ -1178,7 +1178,8 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrTweakGeneral);
-    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlHighlight);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxtweakgen/main.c
+++ b/muxtweakgen/main.c
@@ -1178,6 +1178,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrTweakGeneral);
+    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxvisual/main.c
+++ b/muxvisual/main.c
@@ -764,7 +764,8 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrVisual);
-    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlHighlight);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxvisual/main.c
+++ b/muxvisual/main.c
@@ -764,6 +764,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrVisual);
+    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxwebserv/main.c
+++ b/muxwebserv/main.c
@@ -700,6 +700,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrWebServices);
+    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxwebserv/main.c
+++ b/muxwebserv/main.c
@@ -700,7 +700,8 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrWebServices);
-    load_font_section(basename(argv[0]), "panel", ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlHighlight);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;


### PR DESCRIPTION
Added ability to set font used for panel content such as muxplore, muxfavourites, muxhistory

This isolates the changes just to items in the list allowing headers, footers, and the info screen to continue using the default fonts

![image](https://github.com/user-attachments/assets/a707a505-40a3-4687-823d-5282f5ab6413)
