### PR TITLE
Fix str_compare when one string is a prefix of the other

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -171,7 +171,7 @@ int str_compare(const void *a, const void *b) {
         str2++;
     }
 
-    return 0;
+    return *str1 - *str2;
 }
 
 int str_startswith(const char *a, const char *b) {


### PR DESCRIPTION
See [this Discord message](https://discord.com/channels/1152022492001603615/1261339446570385439/1265344781291225150) for additional context.

It appears that when comparing two strings of different length where one is a prefix of the other (like "GB" and "GBA", etc.), `str_compare` currently returns 0 (equal) rather than sorting the shorter string before the longer one.

This leads to things like names in the content list (e.g., folder pairs like "Game Boy"/"Game Boy Advance" or "PlayStation"/PlayStation Portable") showing up in arbitrary order, and that order changing after reboots (as `qsort` likely isn't a stable sort, and it's not clear what order we get the names from the filesystem API anyway).

I don't have a muOS dev environment set up at the moment, but I verified the bug and fix in an [isolated test case](https://gist.github.com/bcat/04c67d71a1bd755df4e05ca08efd6f82). I'm sorry for not having cycles right now to actually rebuild the frontend to test on a real device, but it's a one-line fix and I figured sending a PR was reasonably safe. :)