### PR TITLE
Adding hdmi support for rotated devices (RG28XX for now).

### DIFF
--- a/common/device.c
+++ b/common/device.c
@@ -131,6 +131,9 @@ void load_device(struct mux_device *device) {
     strncpy(device->SCREEN.DEVICE, get_ini_string(muos_device, "screen", "device", "/dev/fb0"),
             MAX_BUFFER_SIZE - 1);
     device->SCREEN.DEVICE[MAX_BUFFER_SIZE - 1] = '\0';
+    strncpy(device->SCREEN.HDMI, get_ini_string(muos_device, "screen", "hdmi", "/sys/devices/platform/soc/6000000.hdmi/extcon/hdmi/state"),
+            MAX_BUFFER_SIZE - 1);
+    device->SCREEN.HDMI[MAX_BUFFER_SIZE - 1] = '\0';
     device->SCREEN.BRIGHT = get_ini_int(muos_device, "screen", "bright", 90);
     device->SCREEN.BUFFER = get_ini_hex(muos_device, "screen", "buffer");
     device->SCREEN.WIDTH = get_ini_int(muos_device, "screen", "width", 640);

--- a/common/device.h
+++ b/common/device.h
@@ -91,6 +91,7 @@ struct mux_device {
 
     struct {
         char DEVICE[MAX_BUFFER_SIZE];
+        char HDMI[MAX_BUFFER_SIZE];
         int16_t BRIGHT;
         uint32_t BUFFER;
         int16_t WIDTH;

--- a/lvgl/drivers/display/fbdev.h
+++ b/lvgl/drivers/display/fbdev.h
@@ -52,6 +52,13 @@ void fbdev_get_sizes(uint32_t *width, uint32_t *height, uint32_t *dpi);
 void fbdev_set_offset(uint32_t xoffset, uint32_t yoffset);
 
 
+/**
+ * Check for hdmi state and adapt according to the current device
+ * @param disp driver pointer to display driver which active screen should be get.
+ */
+
+void fbdev_hdmi_rotate(lv_disp_drv_t * driver);
+
 /**********************
  *      MACROS
  **********************/

--- a/lvgl/src/core/lv_disp.c
+++ b/lvgl/src/core/lv_disp.c
@@ -6,10 +6,10 @@
 /*********************
  *      INCLUDES
  *********************/
+#include <stdio.h>
 #include "lv_disp.h"
 #include "../misc/lv_math.h"
 #include "../core/lv_refr.h"
-
 /*********************
  *      DEFINES
  *********************/

--- a/lvgl/src/core/lv_disp.h
+++ b/lvgl/src/core/lv_disp.h
@@ -49,6 +49,11 @@ typedef enum {
  **********************/
 
 /**
+ * Check for hdmi state and adapt according to the current device
+ * @param disp driver pointer to display driver which active screen should be get.
+ */
+
+/**
  * Return with a pointer to the active screen
  * @param disp pointer to display which active screen should be get. (NULL to use the default
  * screen)

--- a/lvgl/src/hal/lv_hal_disp.c
+++ b/lvgl/src/hal/lv_hal_disp.c
@@ -8,8 +8,10 @@
 /*********************
  *      INCLUDES
  *********************/
+#include <stdio.h>
 #include <stdint.h>
 #include <stddef.h>
+#include <time.h>
 #include "lv_hal.h"
 #include "../misc/lv_mem.h"
 #include "../misc/lv_gc.h"
@@ -18,6 +20,7 @@
 #include "../core/lv_refr.h"
 #include "../core/lv_theme.h"
 #include "../draw/sw/lv_draw_sw.h"
+#include "../../drivers/display/fbdev.h"
 
 #if LV_USE_THEME_DEFAULT
     #include "../extra/themes/default/lv_theme_default.h"
@@ -162,6 +165,9 @@ lv_disp_t * lv_disp_drv_register(lv_disp_drv_t * driver)
     if(!disp) {
         return NULL;
     }
+
+    //check if the device is hdmi and swap the resolution accordingly if it has a rotated screen
+    fbdev_hdmi_rotate(driver);
 
     /*Create a draw context if not created yet*/
     if(driver->draw_ctx == NULL) {


### PR DESCRIPTION
HDMI was not working quite well in rotated screens (RG28XX). this was thought to be configurable with a simple fbset but unfortunatly was impossible as the result was a screen with edges being turnicated. 

There are few possible fixes for this:
- Upgrade lvgl to v9 which handles rotation better . This is quite a pain as lvgl has changed a lot of their display initialization process which in turn force us to change the logic for every single mux app. 
- compile the whole mux apps with sdl driver as rotations will be handeled by the patched SDL lib . This was my last resort if nothing worked. 
- Modify the buffer writing algorithm and include an hdmi check. which what have been done here. 

The main culprit for the restricted hdmi output (screen being cut from edges) was that lvgl pulls the display information from the framebuffer itself and have as a constant. and afterward use it in the buffer writing algorithm. in the RG28XX this means that the width will be fixed as 480 px . normally this is ok in other devices but in the RG28XX , when connecting to HDMI the screen orientation flips to a landscape orientation. and as the line length in bytes were calculated based on the pulled information from the framebuffer this will result in buffer being written till 480 px only . resulting in the following screen 

![image](https://github.com/user-attachments/assets/23f90cc1-80ce-4caf-8414-4168ee33fcd2)

calculating the size of the line length based on vinfo.xres which can be modified will have the desired effect.

## Changes:
- added hdmi config in the common/device portion.
- adding a hdmi check before registering the display driver to accomedate for resolution changes in rotated displays.
- the buffer writing algorithm is modified to calculate the size of the width bytes dynamically in runtime instead of getting hardcodded framebuffer specs. this will allow for resolution changes in the future.