### PR TITLE
muOS Frontend - Add panel font and radius

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -598,32 +598,12 @@ uint32_t get_ini_hex(mini_t *ini_config, const char *section, const char *key) {
     return result;
 }
 
-int16_t get_ini_int(mini_t *ini_config, const char *section, const char *key, enum element_type type) {
+int16_t get_ini_int(mini_t *ini_config, const char *section, const char *key, int16_t default_value) {
     const char *meta = mini_get_string(ini_config, section, key, "NOT FOUND");
 
     int16_t result;
     if (strcmp(meta, "NOT FOUND") == 0) {
-        switch (type) {
-            case MISC_PAD:
-                result = 0;
-                break;
-            case MISC_WIDTH:
-                result = device.SCREEN.WIDTH;
-                break;
-            case LABEL:
-                result = (int16_t)
-                strtol("0", NULL, 10);
-                break;
-            case VALUE:
-                result = (int16_t)
-                strtol("255", NULL, 10);
-                break;
-            case IGNORE:
-            default:
-                result = (int16_t)
-                strtol(get_random_int(), NULL, 10);
-                break;
-        }
+        result = default_value;
     } else {
         result = (int16_t)
         strtol(meta, NULL, 10);

--- a/common/common.c
+++ b/common/common.c
@@ -1288,6 +1288,35 @@ void load_font_glyph(const char *program, lv_obj_t *element) {
     }
 }
 
+void load_font_section(const char *program, const char *section, lv_obj_t *element) {
+    printf("\t\t\t\tTRYING TO LOAD %s FONT\n", section);
+
+    if (config.SETTINGS.ADVANCED.FONT) {
+        char theme_font_section_default[MAX_BUFFER_SIZE];
+        char theme_font_section[MAX_BUFFER_SIZE];
+        snprintf(theme_font_section_default, sizeof(theme_font_section_default),
+                 "%s/MUOS/theme/active/font/%s/default.bin", device.STORAGE.ROM.MOUNT, section);
+        snprintf(theme_font_section, sizeof(theme_font_section),
+                 "%s/MUOS/theme/active/font/%s/%s.bin", device.STORAGE.ROM.MOUNT, section, program);
+        if (file_exist(theme_font_section)) {
+            char theme_font_section_fs[MAX_BUFFER_SIZE];
+            snprintf(theme_font_section_fs, sizeof(theme_font_section_fs),
+                     "M:%s/MUOS/theme/active/font/%s/%s.bin", device.STORAGE.ROM.MOUNT, section, program);
+            lv_obj_set_style_text_font(element, lv_font_load(theme_font_section_fs),
+                                       LV_PART_MAIN | LV_STATE_DEFAULT);
+        } else {
+            if (file_exist(theme_font_section_default)) {
+                char theme_font_section_default_fs[MAX_BUFFER_SIZE];
+                snprintf(theme_font_section_default_fs, sizeof(theme_font_section_default_fs),
+                         "M:%s/MUOS/theme/active/font/%s/default.bin", device.STORAGE.ROM.MOUNT, section);
+                lv_obj_set_style_text_font(element, lv_font_load(theme_font_section_default_fs),
+                                           LV_PART_MAIN | LV_STATE_DEFAULT);
+                printf("\t\t\t\tLOADED DEFAULT %s FONT (%s)\n", section, theme_font_section_default_fs);
+            }
+        }
+    }
+}
+
 int is_network_connected() {
     if (!config.NETWORK.ENABLED) return 0;
     if (!config.VISUAL.NETWORK) return 0;

--- a/common/common.h
+++ b/common/common.h
@@ -196,6 +196,8 @@ void load_font_text(const char *program, lv_obj_t *screen);
 
 void load_font_glyph(const char *program, lv_obj_t *element);
 
+void load_font_section(const char *program, const char *section, lv_obj_t *element);
+
 int is_network_connected();
 
 void process_visual_element(enum visual_type visual, lv_obj_t *element);

--- a/common/common.h
+++ b/common/common.h
@@ -114,7 +114,7 @@ const char *get_random_int();
 
 uint32_t get_ini_hex(mini_t *ini_config, const char *section, const char *key);
 
-int16_t get_ini_int(mini_t *ini_config, const char *section, const char *key, enum element_type type);
+int16_t get_ini_int(mini_t *ini_config, const char *section, const char *key, int16_t default_value);
 
 int set_ini_int(mini_t *ini_config, const char *section, const char *key, int value);
 

--- a/common/options.h
+++ b/common/options.h
@@ -28,3 +28,5 @@
 
 #define BRIGHT_PERC "/tmp/current_brightness_percent"
 #define VOLUME_PERC "/tmp/current_volume_percent"
+
+#define FONT_PANEL_FOLDER "panel"

--- a/common/theme.c
+++ b/common/theme.c
@@ -226,6 +226,8 @@ void load_theme(struct theme_config *theme, struct mux_config *config, struct mu
 
     theme->MISC.STATIC_ALIGNMENT = get_ini_int(muos_theme, "misc", "STATIC_ALIGNMENT", 255);
     theme->MISC.CONTENT.PADDING_LEFT = get_ini_int(muos_theme, "misc", "CONTENT_PADDING_LEFT", 0);
+    theme->MISC.CONTENT.PADDING_TOP = get_ini_int(muos_theme, "misc", "CONTENT_PADDING_TOP", 0);
+    theme->MISC.CONTENT.HEIGHT = get_ini_int(muos_theme, "misc", "CONTENT_HEIGHT", 392);
     theme->MISC.CONTENT.WIDTH = get_ini_int(muos_theme, "misc", "CONTENT_WIDTH", device->SCREEN.WIDTH);
     theme->MISC.ANIMATED_BACKGROUND = get_ini_int(muos_theme, "misc", "ANIMATED_BACKGROUND", 255);
     theme->MISC.IMAGE_OVERLAY = get_ini_int(muos_theme, "misc", "IMAGE_OVERLAY", 255);

--- a/common/theme.c
+++ b/common/theme.c
@@ -127,6 +127,7 @@ void load_theme(struct theme_config *theme, struct mux_config *config, struct mu
     theme->LIST_DEFAULT.INDICATOR_ALPHA = get_ini_int(muos_theme, "list", "LIST_DEFAULT_INDICATOR_ALPHA", 255);
     theme->LIST_DEFAULT.TEXT = get_ini_hex(muos_theme, "list", "LIST_DEFAULT_TEXT");
     theme->LIST_DEFAULT.TEXT_ALPHA = get_ini_int(muos_theme, "list", "LIST_DEFAULT_TEXT_ALPHA", 255);
+    theme->LIST_DEFAULT.BACKGROUND_GRADIENT = (theme->LIST_DEFAULT.GRADIENT_START  == 255) ? theme->LIST_DEFAULT.BACKGROUND : theme->SYSTEM.BACKGROUND;
 
     theme->LIST_DISABLED.TEXT = get_ini_hex(muos_theme, "list", "LIST_DISABLED_TEXT");
     theme->LIST_DISABLED.TEXT_ALPHA = get_ini_int(muos_theme, "list", "LIST_DISABLED_TEXT_ALPHA", 255);
@@ -139,6 +140,7 @@ void load_theme(struct theme_config *theme, struct mux_config *config, struct mu
     theme->LIST_FOCUS.INDICATOR_ALPHA = get_ini_int(muos_theme, "list", "LIST_FOCUS_INDICATOR_ALPHA", 255);
     theme->LIST_FOCUS.TEXT = get_ini_hex(muos_theme, "list", "LIST_FOCUS_TEXT");
     theme->LIST_FOCUS.TEXT_ALPHA = get_ini_int(muos_theme, "list", "LIST_FOCUS_TEXT_ALPHA", 255);
+    theme->LIST_FOCUS.BACKGROUND_GRADIENT = (theme->LIST_FOCUS.GRADIENT_START  == 255) ? theme->LIST_FOCUS.BACKGROUND : theme->SYSTEM.BACKGROUND;
 
     theme->IMAGE_LIST.ALPHA = get_ini_int(muos_theme, "image_list", "IMAGE_LIST_ALPHA", 255);
     theme->IMAGE_LIST.RADIUS = get_ini_int(muos_theme, "image_list", "IMAGE_LIST_RADIUS", 3);

--- a/common/theme.c
+++ b/common/theme.c
@@ -23,14 +23,6 @@ void load_theme(struct theme_config *theme, struct mux_config *config, struct mu
     theme->SYSTEM.BACKGROUND = get_ini_hex(muos_theme, "background", "BACKGROUND");
     theme->SYSTEM.BACKGROUND_ALPHA = get_ini_int(muos_theme, "background", "BACKGROUND_ALPHA", 255);
 
-    theme->MUX.ITEM.COUNT = get_ini_int(muos_theme, "mux", "item_count", device->MUX.ITEM.COUNT);
-    theme->MUX.ITEM.HEIGHT = get_ini_int(muos_theme, "mux", "item_height", device->MUX.ITEM.HEIGHT);
-    theme->MUX.ITEM.PANEL = get_ini_int(muos_theme, "mux", "item_panel", device->MUX.ITEM.PANEL);
-    theme->MUX.ITEM.PREV_LOW = get_ini_int(muos_theme, "mux", "item_prev_low", device->MUX.ITEM.PREV_LOW);
-    theme->MUX.ITEM.PREV_HIGH = get_ini_int(muos_theme, "mux", "item_prev_high", device->MUX.ITEM.PREV_HIGH);
-    theme->MUX.ITEM.NEXT_LOW = get_ini_int(muos_theme, "mux", "item_next_low", device->MUX.ITEM.NEXT_LOW);
-    theme->MUX.ITEM.NEXT_HIGH = get_ini_int(muos_theme, "mux", "item_next_high", device->MUX.ITEM.NEXT_HIGH);
-
     theme->FONT.HEADER_PAD_TOP = get_ini_int(muos_theme, "font", "FONT_HEADER_PAD_TOP", 0);
     theme->FONT.HEADER_PAD_BOTTOM = get_ini_int(muos_theme, "font", "FONT_HEADER_PAD_BOTTOM", 0);
     theme->FONT.HEADER_ICON_PAD_TOP = get_ini_int(muos_theme, "font", "FONT_HEADER_ICON_PAD_TOP", 0);
@@ -225,6 +217,7 @@ void load_theme(struct theme_config *theme, struct mux_config *config, struct mu
     theme->ROLL.BORDER_RADIUS = get_ini_int(muos_theme, "roll", "ROLL_BORDER_RADIUS", 255);
 
     theme->MISC.STATIC_ALIGNMENT = get_ini_int(muos_theme, "misc", "STATIC_ALIGNMENT", 255);
+    theme->MUX.ITEM.COUNT = get_ini_int(muos_theme, "misc", "CONTENT_ITEM_COUNT", device->MUX.ITEM.COUNT);
     theme->MISC.CONTENT.PADDING_LEFT = get_ini_int(muos_theme, "misc", "CONTENT_PADDING_LEFT", 0);
     theme->MISC.CONTENT.PADDING_TOP = get_ini_int(muos_theme, "misc", "CONTENT_PADDING_TOP", 0);
     theme->MISC.CONTENT.HEIGHT = get_ini_int(muos_theme, "misc", "CONTENT_HEIGHT", 392);
@@ -232,6 +225,17 @@ void load_theme(struct theme_config *theme, struct mux_config *config, struct mu
     theme->MISC.ANIMATED_BACKGROUND = get_ini_int(muos_theme, "misc", "ANIMATED_BACKGROUND", 255);
     theme->MISC.IMAGE_OVERLAY = get_ini_int(muos_theme, "misc", "IMAGE_OVERLAY", 255);
     theme->MISC.NAVIGATION_TYPE = get_ini_int(muos_theme, "misc", "NAVIGATION_TYPE", 255);
+
+    if (theme->MISC.CONTENT.HEIGHT < 100) theme->MISC.CONTENT.HEIGHT = 100;
+    if (theme->MISC.CONTENT.HEIGHT > device->SCREEN.HEIGHT) theme->MISC.CONTENT.HEIGHT = device->SCREEN.HEIGHT;
+    if (theme->MUX.ITEM.COUNT < 5) theme->MUX.ITEM.COUNT = 5;
+    if (theme->MUX.ITEM.COUNT > 13) theme->MUX.ITEM.COUNT = 13;
+    theme->MUX.ITEM.PANEL = theme->MISC.CONTENT.HEIGHT /  theme->MUX.ITEM.COUNT;
+    theme->MUX.ITEM.HEIGHT = theme->MUX.ITEM.PANEL - 2;
+    theme->MUX.ITEM.PREV_LOW = theme->MUX.ITEM.COUNT / 2 - 1;
+    theme->MUX.ITEM.PREV_HIGH = theme->MUX.ITEM.COUNT / 2 + 1;
+    theme->MUX.ITEM.NEXT_LOW = theme->MUX.ITEM.COUNT / 2;
+    theme->MUX.ITEM.NEXT_HIGH = theme->MUX.ITEM.COUNT / 2 + 1;
 
     mini_free(muos_theme);
 }

--- a/common/theme.c
+++ b/common/theme.c
@@ -21,206 +21,215 @@ void load_theme(struct theme_config *theme, struct mux_config *config, struct mu
     mini_t * muos_theme = mini_try_load(scheme);
 
     theme->SYSTEM.BACKGROUND = get_ini_hex(muos_theme, "background", "BACKGROUND");
-    theme->SYSTEM.BACKGROUND_ALPHA = get_ini_int(muos_theme, "background", "BACKGROUND_ALPHA", IGNORE);
+    theme->SYSTEM.BACKGROUND_ALPHA = get_ini_int(muos_theme, "background", "BACKGROUND_ALPHA", 255);
 
-    theme->FONT.HEADER_PAD_TOP = get_ini_int(muos_theme, "font", "FONT_HEADER_PAD_TOP", LABEL);
-    theme->FONT.HEADER_PAD_BOTTOM = get_ini_int(muos_theme, "font", "FONT_HEADER_PAD_BOTTOM", LABEL);
-    theme->FONT.HEADER_ICON_PAD_TOP = get_ini_int(muos_theme, "font", "FONT_HEADER_ICON_PAD_TOP", LABEL);
-    theme->FONT.HEADER_ICON_PAD_BOTTOM = get_ini_int(muos_theme, "font", "FONT_HEADER_ICON_PAD_BOTTOM", LABEL);
-    theme->FONT.FOOTER_PAD_TOP = get_ini_int(muos_theme, "font", "FONT_FOOTER_PAD_TOP", LABEL);
-    theme->FONT.FOOTER_PAD_BOTTOM = get_ini_int(muos_theme, "font", "FONT_FOOTER_PAD_BOTTOM", LABEL);
-    theme->FONT.FOOTER_ICON_PAD_TOP = get_ini_int(muos_theme, "font", "FONT_FOOTER_ICON_PAD_TOP", LABEL);
-    theme->FONT.FOOTER_ICON_PAD_BOTTOM = get_ini_int(muos_theme, "font", "FONT_FOOTER_ICON_PAD_BOTTOM", LABEL);
-    theme->FONT.MESSAGE_PAD_TOP = get_ini_int(muos_theme, "font", "FONT_MESSAGE_PAD_TOP", LABEL);
-    theme->FONT.MESSAGE_PAD_BOTTOM = get_ini_int(muos_theme, "font", "FONT_MESSAGE_PAD_BOTTOM", LABEL);
-    theme->FONT.MESSAGE_ICON_PAD_TOP = get_ini_int(muos_theme, "font", "FONT_MESSAGE_ICON_PAD_TOP", LABEL);
-    theme->FONT.MESSAGE_ICON_PAD_BOTTOM = get_ini_int(muos_theme, "font", "FONT_MESSAGE_ICON_PAD_BOTTOM", LABEL);
-    theme->FONT.LIST_PAD_TOP = get_ini_int(muos_theme, "font", "FONT_LIST_PAD_TOP", LABEL);
-    theme->FONT.LIST_PAD_BOTTOM = get_ini_int(muos_theme, "font", "FONT_LIST_PAD_BOTTOM", LABEL);
-    theme->FONT.LIST_ICON_PAD_TOP = get_ini_int(muos_theme, "font", "FONT_LIST_ICON_PAD_TOP", LABEL);
-    theme->FONT.LIST_ICON_PAD_BOTTOM = get_ini_int(muos_theme, "font", "FONT_LIST_ICON_PAD_BOTTOM", LABEL);
+    theme->MUX.ITEM.COUNT = get_ini_int(muos_theme, "mux", "item_count", device->MUX.ITEM.COUNT);
+    theme->MUX.ITEM.HEIGHT = get_ini_int(muos_theme, "mux", "item_height", device->MUX.ITEM.HEIGHT);
+    theme->MUX.ITEM.PANEL = get_ini_int(muos_theme, "mux", "item_panel", device->MUX.ITEM.PANEL);
+    theme->MUX.ITEM.PREV_LOW = get_ini_int(muos_theme, "mux", "item_prev_low", device->MUX.ITEM.PREV_LOW);
+    theme->MUX.ITEM.PREV_HIGH = get_ini_int(muos_theme, "mux", "item_prev_high", device->MUX.ITEM.PREV_HIGH);
+    theme->MUX.ITEM.NEXT_LOW = get_ini_int(muos_theme, "mux", "item_next_low", device->MUX.ITEM.NEXT_LOW);
+    theme->MUX.ITEM.NEXT_HIGH = get_ini_int(muos_theme, "mux", "item_next_high", device->MUX.ITEM.NEXT_HIGH);
 
-    theme->STATUS.PADDING_RIGHT = get_ini_int(muos_theme, "status", "PADDING_RIGHT", MISC_PAD);
+    theme->FONT.HEADER_PAD_TOP = get_ini_int(muos_theme, "font", "FONT_HEADER_PAD_TOP", 0);
+    theme->FONT.HEADER_PAD_BOTTOM = get_ini_int(muos_theme, "font", "FONT_HEADER_PAD_BOTTOM", 0);
+    theme->FONT.HEADER_ICON_PAD_TOP = get_ini_int(muos_theme, "font", "FONT_HEADER_ICON_PAD_TOP", 0);
+    theme->FONT.HEADER_ICON_PAD_BOTTOM = get_ini_int(muos_theme, "font", "FONT_HEADER_ICON_PAD_BOTTOM", 0);
+    theme->FONT.FOOTER_PAD_TOP = get_ini_int(muos_theme, "font", "FONT_FOOTER_PAD_TOP", 0);
+    theme->FONT.FOOTER_PAD_BOTTOM = get_ini_int(muos_theme, "font", "FONT_FOOTER_PAD_BOTTOM", 0);
+    theme->FONT.FOOTER_ICON_PAD_TOP = get_ini_int(muos_theme, "font", "FONT_FOOTER_ICON_PAD_TOP", 0);
+    theme->FONT.FOOTER_ICON_PAD_BOTTOM = get_ini_int(muos_theme, "font", "FONT_FOOTER_ICON_PAD_BOTTOM", 0);
+    theme->FONT.MESSAGE_PAD_TOP = get_ini_int(muos_theme, "font", "FONT_MESSAGE_PAD_TOP", 0);
+    theme->FONT.MESSAGE_PAD_BOTTOM = get_ini_int(muos_theme, "font", "FONT_MESSAGE_PAD_BOTTOM", 0);
+    theme->FONT.MESSAGE_ICON_PAD_TOP = get_ini_int(muos_theme, "font", "FONT_MESSAGE_ICON_PAD_TOP", 0);
+    theme->FONT.MESSAGE_ICON_PAD_BOTTOM = get_ini_int(muos_theme, "font", "FONT_MESSAGE_ICON_PAD_BOTTOM", 0);
+    theme->FONT.LIST_PAD_TOP = get_ini_int(muos_theme, "font", "FONT_LIST_PAD_TOP", 0);
+    theme->FONT.LIST_PAD_BOTTOM = get_ini_int(muos_theme, "font", "FONT_LIST_PAD_BOTTOM", 0);
+    theme->FONT.LIST_ICON_PAD_TOP = get_ini_int(muos_theme, "font", "FONT_LIST_ICON_PAD_TOP", 0);
+    theme->FONT.LIST_ICON_PAD_BOTTOM = get_ini_int(muos_theme, "font", "FONT_LIST_ICON_PAD_BOTTOM", 0);
+
+    theme->STATUS.PADDING_RIGHT = get_ini_int(muos_theme, "status", "PADDING_RIGHT", 0);
 
     theme->STATUS.BATTERY.NORMAL = get_ini_hex(muos_theme, "battery", "BATTERY_NORMAL");
     theme->STATUS.BATTERY.ACTIVE = get_ini_hex(muos_theme, "battery", "BATTERY_ACTIVE");
     theme->STATUS.BATTERY.LOW = get_ini_hex(muos_theme, "battery", "BATTERY_LOW");
-    theme->STATUS.BATTERY.NORMAL_ALPHA = get_ini_int(muos_theme, "battery", "BATTERY_NORMAL_ALPHA", VALUE);
-    theme->STATUS.BATTERY.ACTIVE_ALPHA = get_ini_int(muos_theme, "battery", "BATTERY_ACTIVE_ALPHA", VALUE);
-    theme->STATUS.BATTERY.LOW_ALPHA = get_ini_int(muos_theme, "battery", "BATTERY_LOW_ALPHA", VALUE);
+    theme->STATUS.BATTERY.NORMAL_ALPHA = get_ini_int(muos_theme, "battery", "BATTERY_NORMAL_ALPHA", 255);
+    theme->STATUS.BATTERY.ACTIVE_ALPHA = get_ini_int(muos_theme, "battery", "BATTERY_ACTIVE_ALPHA", 255);
+    theme->STATUS.BATTERY.LOW_ALPHA = get_ini_int(muos_theme, "battery", "BATTERY_LOW_ALPHA", 255);
 
     theme->STATUS.NETWORK.NORMAL = get_ini_hex(muos_theme, "network", "NETWORK_NORMAL");
     theme->STATUS.NETWORK.ACTIVE = get_ini_hex(muos_theme, "network", "NETWORK_ACTIVE");
-    theme->STATUS.NETWORK.NORMAL_ALPHA = get_ini_int(muos_theme, "network", "NETWORK_NORMAL_ALPHA", VALUE);
-    theme->STATUS.NETWORK.ACTIVE_ALPHA = get_ini_int(muos_theme, "network", "NETWORK_ACTIVE_ALPHA", VALUE);
+    theme->STATUS.NETWORK.NORMAL_ALPHA = get_ini_int(muos_theme, "network", "NETWORK_NORMAL_ALPHA", 255);
+    theme->STATUS.NETWORK.ACTIVE_ALPHA = get_ini_int(muos_theme, "network", "NETWORK_ACTIVE_ALPHA", 255);
 
     theme->STATUS.BLUETOOTH.NORMAL = get_ini_hex(muos_theme, "bluetooth", "BLUETOOTH_NORMAL");
     theme->STATUS.BLUETOOTH.ACTIVE = get_ini_hex(muos_theme, "bluetooth", "BLUETOOTH_ACTIVE");
-    theme->STATUS.BLUETOOTH.NORMAL_ALPHA = get_ini_int(muos_theme, "bluetooth", "BLUETOOTH_NORMAL_ALPHA", VALUE);
-    theme->STATUS.BLUETOOTH.ACTIVE_ALPHA = get_ini_int(muos_theme, "bluetooth", "BLUETOOTH_ACTIVE_ALPHA", VALUE);
+    theme->STATUS.BLUETOOTH.NORMAL_ALPHA = get_ini_int(muos_theme, "bluetooth", "BLUETOOTH_NORMAL_ALPHA", 255);
+    theme->STATUS.BLUETOOTH.ACTIVE_ALPHA = get_ini_int(muos_theme, "bluetooth", "BLUETOOTH_ACTIVE_ALPHA", 255);
 
     theme->DATETIME.TEXT = get_ini_hex(muos_theme, "date", "DATETIME_TEXT");
-    theme->DATETIME.ALPHA = get_ini_int(muos_theme, "date", "DATETIME_ALPHA", VALUE);
-    theme->DATETIME.PADDING_LEFT = get_ini_int(muos_theme, "date", "PADDING_LEFT", MISC_PAD);
+    theme->DATETIME.ALPHA = get_ini_int(muos_theme, "date", "DATETIME_ALPHA", 255);
+    theme->DATETIME.PADDING_LEFT = get_ini_int(muos_theme, "date", "PADDING_LEFT", 0);
 
     theme->FOOTER.BACKGROUND = get_ini_hex(muos_theme, "footer", "FOOTER_BACKGROUND");
-    theme->FOOTER.BACKGROUND_ALPHA = get_ini_int(muos_theme, "footer", "FOOTER_BACKGROUND_ALPHA", IGNORE);
+    theme->FOOTER.BACKGROUND_ALPHA = get_ini_int(muos_theme, "footer", "FOOTER_BACKGROUND_ALPHA", 255);
     theme->FOOTER.TEXT = get_ini_hex(muos_theme, "footer", "FOOTER_TEXT");
-    theme->FOOTER.TEXT_ALPHA = get_ini_int(muos_theme, "footer", "FOOTER_TEXT_ALPHA", VALUE);
+    theme->FOOTER.TEXT_ALPHA = get_ini_int(muos_theme, "footer", "FOOTER_TEXT_ALPHA", 255);
 
     theme->HEADER.BACKGROUND = get_ini_hex(muos_theme, "header", "HEADER_BACKGROUND");
-    theme->HEADER.BACKGROUND_ALPHA = get_ini_int(muos_theme, "header", "HEADER_BACKGROUND_ALPHA", IGNORE);
+    theme->HEADER.BACKGROUND_ALPHA = get_ini_int(muos_theme, "header", "HEADER_BACKGROUND_ALPHA", 255);
     theme->HEADER.TEXT = get_ini_hex(muos_theme, "header", "HEADER_TEXT");
-    theme->HEADER.TEXT_ALPHA = get_ini_int(muos_theme, "header", "HEADER_TEXT_ALPHA", VALUE);
+    theme->HEADER.TEXT_ALPHA = get_ini_int(muos_theme, "header", "HEADER_TEXT_ALPHA", 255);
 
     theme->HELP.BACKGROUND = get_ini_hex(muos_theme, "help", "HELP_BACKGROUND");
-    theme->HELP.BACKGROUND_ALPHA = get_ini_int(muos_theme, "help", "HELP_BACKGROUND_ALPHA", IGNORE);
+    theme->HELP.BACKGROUND_ALPHA = get_ini_int(muos_theme, "help", "HELP_BACKGROUND_ALPHA", 255);
     theme->HELP.BORDER = get_ini_hex(muos_theme, "help", "HELP_BORDER");
-    theme->HELP.BORDER_ALPHA = get_ini_int(muos_theme, "help", "HELP_BORDER_ALPHA", IGNORE);
+    theme->HELP.BORDER_ALPHA = get_ini_int(muos_theme, "help", "HELP_BORDER_ALPHA", 255);
     theme->HELP.CONTENT = get_ini_hex(muos_theme, "help", "HELP_CONTENT");
     theme->HELP.TITLE = get_ini_hex(muos_theme, "help", "HELP_TITLE");
     theme->HELP.RADIUS = get_ini_hex(muos_theme, "help", "HELP_RADIUS");
 
-    theme->NAV.ALIGNMENT = get_ini_int(muos_theme, "navigation", "ALIGNMENT", VALUE);
+    theme->NAV.ALIGNMENT = get_ini_int(muos_theme, "navigation", "ALIGNMENT", 255);
 
     theme->NAV.A.GLYPH = get_ini_hex(muos_theme, "navigation", "NAV_A_GLYPH");
-    theme->NAV.A.GLYPH_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_A_GLYPH_ALPHA", VALUE);
+    theme->NAV.A.GLYPH_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_A_GLYPH_ALPHA", 255);
     theme->NAV.A.TEXT = get_ini_hex(muos_theme, "navigation", "NAV_A_TEXT");
-    theme->NAV.A.TEXT_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_A_TEXT_ALPHA", VALUE);
+    theme->NAV.A.TEXT_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_A_TEXT_ALPHA", 255);
 
     theme->NAV.B.GLYPH = get_ini_hex(muos_theme, "navigation", "NAV_B_GLYPH");
-    theme->NAV.B.GLYPH_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_B_GLYPH_ALPHA", VALUE);
+    theme->NAV.B.GLYPH_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_B_GLYPH_ALPHA", 255);
     theme->NAV.B.TEXT = get_ini_hex(muos_theme, "navigation", "NAV_B_TEXT");
-    theme->NAV.B.TEXT_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_B_TEXT_ALPHA", VALUE);
+    theme->NAV.B.TEXT_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_B_TEXT_ALPHA", 255);
 
     theme->NAV.C.GLYPH = get_ini_hex(muos_theme, "navigation", "NAV_C_GLYPH");
-    theme->NAV.C.GLYPH_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_C_GLYPH_ALPHA", VALUE);
+    theme->NAV.C.GLYPH_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_C_GLYPH_ALPHA", 255);
     theme->NAV.C.TEXT = get_ini_hex(muos_theme, "navigation", "NAV_C_TEXT");
-    theme->NAV.C.TEXT_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_C_TEXT_ALPHA", VALUE);
+    theme->NAV.C.TEXT_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_C_TEXT_ALPHA", 255);
 
     theme->NAV.X.GLYPH = get_ini_hex(muos_theme, "navigation", "NAV_X_GLYPH");
-    theme->NAV.X.GLYPH_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_X_GLYPH_ALPHA", VALUE);
+    theme->NAV.X.GLYPH_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_X_GLYPH_ALPHA", 255);
     theme->NAV.X.TEXT = get_ini_hex(muos_theme, "navigation", "NAV_X_TEXT");
-    theme->NAV.X.TEXT_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_X_TEXT_ALPHA", VALUE);
+    theme->NAV.X.TEXT_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_X_TEXT_ALPHA", 255);
 
     theme->NAV.Y.GLYPH = get_ini_hex(muos_theme, "navigation", "NAV_Y_GLYPH");
-    theme->NAV.Y.GLYPH_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_Y_GLYPH_ALPHA", VALUE);
+    theme->NAV.Y.GLYPH_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_Y_GLYPH_ALPHA", 255);
     theme->NAV.Y.TEXT = get_ini_hex(muos_theme, "navigation", "NAV_Y_TEXT");
-    theme->NAV.Y.TEXT_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_Y_TEXT_ALPHA", VALUE);
+    theme->NAV.Y.TEXT_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_Y_TEXT_ALPHA", 255);
 
     theme->NAV.Z.GLYPH = get_ini_hex(muos_theme, "navigation", "NAV_Z_GLYPH");
-    theme->NAV.Z.GLYPH_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_Z_GLYPH_ALPHA", VALUE);
+    theme->NAV.Z.GLYPH_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_Z_GLYPH_ALPHA", 255);
     theme->NAV.Z.TEXT = get_ini_hex(muos_theme, "navigation", "NAV_Z_TEXT");
-    theme->NAV.Z.TEXT_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_Z_TEXT_ALPHA", VALUE);
+    theme->NAV.Z.TEXT_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_Z_TEXT_ALPHA", 255);
 
     theme->NAV.MENU.GLYPH = get_ini_hex(muos_theme, "navigation", "NAV_MENU_GLYPH");
-    theme->NAV.MENU.GLYPH_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_MENU_GLYPH_ALPHA", VALUE);
+    theme->NAV.MENU.GLYPH_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_MENU_GLYPH_ALPHA", 255);
     theme->NAV.MENU.TEXT = get_ini_hex(muos_theme, "navigation", "NAV_MENU_TEXT");
-    theme->NAV.MENU.TEXT_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_MENU_TEXT_ALPHA", VALUE);
+    theme->NAV.MENU.TEXT_ALPHA = get_ini_int(muos_theme, "navigation", "NAV_MENU_TEXT_ALPHA", 255);
 
+    theme->LIST_DEFAULT.RADIUS = get_ini_int(muos_theme, "list", "LIST_DEFAULT_RADIUS", 0);
     theme->LIST_DEFAULT.BACKGROUND = get_ini_hex(muos_theme, "list", "LIST_DEFAULT_BACKGROUND");
-    theme->LIST_DEFAULT.BACKGROUND_ALPHA = get_ini_int(muos_theme, "list", "LIST_DEFAULT_BACKGROUND_ALPHA", IGNORE);
-    theme->LIST_DEFAULT.GRADIENT_START = get_ini_int(muos_theme, "list", "LIST_DEFAULT_GRADIENT_START", IGNORE);
-    theme->LIST_DEFAULT.GRADIENT_STOP = get_ini_int(muos_theme, "list", "LIST_DEFAULT_GRADIENT_STOP", IGNORE);
+    theme->LIST_DEFAULT.BACKGROUND_ALPHA = get_ini_int(muos_theme, "list", "LIST_DEFAULT_BACKGROUND_ALPHA", 255);
+    theme->LIST_DEFAULT.GRADIENT_START = get_ini_int(muos_theme, "list", "LIST_DEFAULT_GRADIENT_START", 0);
+    theme->LIST_DEFAULT.GRADIENT_STOP = get_ini_int(muos_theme, "list", "LIST_DEFAULT_GRADIENT_STOP", 200);
     theme->LIST_DEFAULT.INDICATOR = get_ini_hex(muos_theme, "list", "LIST_DEFAULT_INDICATOR");
-    theme->LIST_DEFAULT.INDICATOR_ALPHA = get_ini_int(muos_theme, "list", "LIST_DEFAULT_INDICATOR_ALPHA", VALUE);
+    theme->LIST_DEFAULT.INDICATOR_ALPHA = get_ini_int(muos_theme, "list", "LIST_DEFAULT_INDICATOR_ALPHA", 255);
     theme->LIST_DEFAULT.TEXT = get_ini_hex(muos_theme, "list", "LIST_DEFAULT_TEXT");
-    theme->LIST_DEFAULT.TEXT_ALPHA = get_ini_int(muos_theme, "list", "LIST_DEFAULT_TEXT_ALPHA", VALUE);
+    theme->LIST_DEFAULT.TEXT_ALPHA = get_ini_int(muos_theme, "list", "LIST_DEFAULT_TEXT_ALPHA", 255);
 
     theme->LIST_DISABLED.TEXT = get_ini_hex(muos_theme, "list", "LIST_DISABLED_TEXT");
-    theme->LIST_DISABLED.TEXT_ALPHA = get_ini_int(muos_theme, "list", "LIST_DISABLED_TEXT_ALPHA", VALUE);
+    theme->LIST_DISABLED.TEXT_ALPHA = get_ini_int(muos_theme, "list", "LIST_DISABLED_TEXT_ALPHA", 255);
 
     theme->LIST_FOCUS.BACKGROUND = get_ini_hex(muos_theme, "list", "LIST_FOCUS_BACKGROUND");
-    theme->LIST_FOCUS.BACKGROUND_ALPHA = get_ini_int(muos_theme, "list", "LIST_FOCUS_BACKGROUND_ALPHA", IGNORE);
-    theme->LIST_FOCUS.GRADIENT_START = get_ini_int(muos_theme, "list", "LIST_FOCUS_GRADIENT_START", IGNORE);
-    theme->LIST_FOCUS.GRADIENT_STOP = get_ini_int(muos_theme, "list", "LIST_FOCUS_GRADIENT_STOP", IGNORE);
+    theme->LIST_FOCUS.BACKGROUND_ALPHA = get_ini_int(muos_theme, "list", "LIST_FOCUS_BACKGROUND_ALPHA", 255);
+    theme->LIST_FOCUS.GRADIENT_START = get_ini_int(muos_theme, "list", "LIST_FOCUS_GRADIENT_START", 0);
+    theme->LIST_FOCUS.GRADIENT_STOP = get_ini_int(muos_theme, "list", "LIST_FOCUS_GRADIENT_STOP", 200);
     theme->LIST_FOCUS.INDICATOR = get_ini_hex(muos_theme, "list", "LIST_FOCUS_INDICATOR");
-    theme->LIST_FOCUS.INDICATOR_ALPHA = get_ini_int(muos_theme, "list", "LIST_FOCUS_INDICATOR_ALPHA", IGNORE);
+    theme->LIST_FOCUS.INDICATOR_ALPHA = get_ini_int(muos_theme, "list", "LIST_FOCUS_INDICATOR_ALPHA", 255);
     theme->LIST_FOCUS.TEXT = get_ini_hex(muos_theme, "list", "LIST_FOCUS_TEXT");
-    theme->LIST_FOCUS.TEXT_ALPHA = get_ini_int(muos_theme, "list", "LIST_FOCUS_TEXT_ALPHA", VALUE);
+    theme->LIST_FOCUS.TEXT_ALPHA = get_ini_int(muos_theme, "list", "LIST_FOCUS_TEXT_ALPHA", 255);
 
-    theme->IMAGE_LIST.ALPHA = get_ini_int(muos_theme, "image_list", "IMAGE_LIST_ALPHA", VALUE);
-    theme->IMAGE_LIST.RADIUS = get_ini_int(muos_theme, "image_list", "IMAGE_LIST_RADIUS", IGNORE);
+    theme->IMAGE_LIST.ALPHA = get_ini_int(muos_theme, "image_list", "IMAGE_LIST_ALPHA", 255);
+    theme->IMAGE_LIST.RADIUS = get_ini_int(muos_theme, "image_list", "IMAGE_LIST_RADIUS", 3);
     theme->IMAGE_LIST.RECOLOUR = get_ini_hex(muos_theme, "image_list", "IMAGE_LIST_RECOLOUR");
-    theme->IMAGE_LIST.RECOLOUR_ALPHA = get_ini_int(muos_theme, "image_list", "IMAGE_LIST_RECOLOUR_ALPHA", IGNORE);
+    theme->IMAGE_LIST.RECOLOUR_ALPHA = get_ini_int(muos_theme, "image_list", "IMAGE_LIST_RECOLOUR_ALPHA", 255);
 
-    theme->IMAGE_PREVIEW.ALPHA = get_ini_int(muos_theme, "image_list", "IMAGE_PREVIEW_ALPHA", VALUE);
-    theme->IMAGE_PREVIEW.RADIUS = get_ini_int(muos_theme, "image_list", "IMAGE_PREVIEW_RADIUS", IGNORE);
+    theme->IMAGE_PREVIEW.ALPHA = get_ini_int(muos_theme, "image_list", "IMAGE_PREVIEW_ALPHA", 255);
+    theme->IMAGE_PREVIEW.RADIUS = get_ini_int(muos_theme, "image_list", "IMAGE_PREVIEW_RADIUS", 3);
     theme->IMAGE_PREVIEW.RECOLOUR = get_ini_hex(muos_theme, "image_list", "IMAGE_PREVIEW_RECOLOUR");
-    theme->IMAGE_PREVIEW.RECOLOUR_ALPHA = get_ini_int(muos_theme, "image_list", "IMAGE_PREVIEW_RECOLOUR_ALPHA", IGNORE);
+    theme->IMAGE_PREVIEW.RECOLOUR_ALPHA = get_ini_int(muos_theme, "image_list", "IMAGE_PREVIEW_RECOLOUR_ALPHA", 255);
 
     theme->CHARGER.BACKGROUND = get_ini_hex(muos_theme, "charging", "CHARGER_BACKGROUND");
-    theme->CHARGER.BACKGROUND_ALPHA = get_ini_int(muos_theme, "charging", "CHARGER_BACKGROUND_ALPHA", IGNORE);
+    theme->CHARGER.BACKGROUND_ALPHA = get_ini_int(muos_theme, "charging", "CHARGER_BACKGROUND_ALPHA", 255);
     theme->CHARGER.TEXT = get_ini_hex(muos_theme, "charging", "CHARGER_TEXT");
-    theme->CHARGER.TEXT_ALPHA = get_ini_int(muos_theme, "charging", "CHARGER_TEXT_ALPHA", VALUE);
-    theme->CHARGER.Y_POS = get_ini_int(muos_theme, "charging", "CHARGER_Y_POS", LABEL);
+    theme->CHARGER.TEXT_ALPHA = get_ini_int(muos_theme, "charging", "CHARGER_TEXT_ALPHA", 255);
+    theme->CHARGER.Y_POS = get_ini_int(muos_theme, "charging", "CHARGER_Y_POS", 0);
 
     theme->VERBOSE_BOOT.BACKGROUND = get_ini_hex(muos_theme, "verbose", "VERBOSE_BOOT_BACKGROUND");
-    theme->VERBOSE_BOOT.BACKGROUND_ALPHA = get_ini_int(muos_theme, "verbose", "VERBOSE_BOOT_BACKGROUND_ALPHA", IGNORE);
+    theme->VERBOSE_BOOT.BACKGROUND_ALPHA = get_ini_int(muos_theme, "verbose", "VERBOSE_BOOT_BACKGROUND_ALPHA", 255);
     theme->VERBOSE_BOOT.TEXT = get_ini_hex(muos_theme, "verbose", "VERBOSE_BOOT_TEXT");
-    theme->VERBOSE_BOOT.TEXT_ALPHA = get_ini_int(muos_theme, "verbose", "VERBOSE_BOOT_TEXT_ALPHA", VALUE);
-    theme->VERBOSE_BOOT.Y_POS = get_ini_int(muos_theme, "verbose", "VERBOSE_BOOT_Y_POS", LABEL);
+    theme->VERBOSE_BOOT.TEXT_ALPHA = get_ini_int(muos_theme, "verbose", "VERBOSE_BOOT_TEXT_ALPHA", 255);
+    theme->VERBOSE_BOOT.Y_POS = get_ini_int(muos_theme, "verbose", "VERBOSE_BOOT_Y_POS", 0);
 
     theme->OSK.BACKGROUND = get_ini_hex(muos_theme, "keyboard", "OSK_BACKGROUND");
-    theme->OSK.BACKGROUND_ALPHA = get_ini_int(muos_theme, "keyboard", "OSK_BACKGROUND_ALPHA", IGNORE);
+    theme->OSK.BACKGROUND_ALPHA = get_ini_int(muos_theme, "keyboard", "OSK_BACKGROUND_ALPHA", 255);
     theme->OSK.BORDER = get_ini_hex(muos_theme, "keyboard", "OSK_BORDER");
-    theme->OSK.BORDER_ALPHA = get_ini_int(muos_theme, "keyboard", "OSK_BORDER_ALPHA", IGNORE);
-    theme->OSK.RADIUS = get_ini_int(muos_theme, "keyboard", "OSK_RADIUS", IGNORE);
+    theme->OSK.BORDER_ALPHA = get_ini_int(muos_theme, "keyboard", "OSK_BORDER_ALPHA", 255);
+    theme->OSK.RADIUS = get_ini_int(muos_theme, "keyboard", "OSK_RADIUS", 3);
     theme->OSK.TEXT = get_ini_hex(muos_theme, "keyboard", "OSK_TEXT");
-    theme->OSK.TEXT_ALPHA = get_ini_int(muos_theme, "keyboard", "OSK_TEXT_ALPHA", VALUE);
+    theme->OSK.TEXT_ALPHA = get_ini_int(muos_theme, "keyboard", "OSK_TEXT_ALPHA", 255);
     theme->OSK.TEXT_FOCUS = get_ini_hex(muos_theme, "keyboard", "OSK_TEXT_FOCUS");
-    theme->OSK.TEXT_FOCUS_ALPHA = get_ini_int(muos_theme, "keyboard", "OSK_TEXT_FOCUS_ALPHA", VALUE);
+    theme->OSK.TEXT_FOCUS_ALPHA = get_ini_int(muos_theme, "keyboard", "OSK_TEXT_FOCUS_ALPHA", 255);
     theme->OSK.ITEM.BACKGROUND = get_ini_hex(muos_theme, "keyboard", "OSK_ITEM_BACKGROUND");
-    theme->OSK.ITEM.BACKGROUND_ALPHA = get_ini_int(muos_theme, "keyboard", "OSK_ITEM_BACKGROUND_ALPHA", IGNORE);
+    theme->OSK.ITEM.BACKGROUND_ALPHA = get_ini_int(muos_theme, "keyboard", "OSK_ITEM_BACKGROUND_ALPHA", 255);
     theme->OSK.ITEM.BACKGROUND_FOCUS = get_ini_hex(muos_theme, "keyboard", "OSK_ITEM_BACKGROUND_FOCUS");
-    theme->OSK.ITEM.BACKGROUND_FOCUS_ALPHA = get_ini_int(muos_theme, "keyboard", "OSK_ITEM_BACKGROUND_FOCUS_ALPHA", IGNORE);
+    theme->OSK.ITEM.BACKGROUND_FOCUS_ALPHA = get_ini_int(muos_theme, "keyboard", "OSK_ITEM_BACKGROUND_FOCUS_ALPHA", 255);
     theme->OSK.ITEM.BORDER = get_ini_hex(muos_theme, "keyboard", "OSK_ITEM_BORDER");
-    theme->OSK.ITEM.BORDER_ALPHA = get_ini_int(muos_theme, "keyboard", "OSK_ITEM_BORDER_ALPHA", IGNORE);
+    theme->OSK.ITEM.BORDER_ALPHA = get_ini_int(muos_theme, "keyboard", "OSK_ITEM_BORDER_ALPHA", 255);
     theme->OSK.ITEM.BORDER_FOCUS = get_ini_hex(muos_theme, "keyboard", "OSK_ITEM_BORDER_FOCUS");
-    theme->OSK.ITEM.BORDER_FOCUS_ALPHA = get_ini_int(muos_theme, "keyboard", "OSK_ITEM_BORDER_FOCUS_ALPHA", IGNORE);
-    theme->OSK.ITEM.RADIUS = get_ini_int(muos_theme, "keyboard", "OSK_ITEM_RADIUS", IGNORE);
+    theme->OSK.ITEM.BORDER_FOCUS_ALPHA = get_ini_int(muos_theme, "keyboard", "OSK_ITEM_BORDER_FOCUS_ALPHA", 255);
+    theme->OSK.ITEM.RADIUS = get_ini_int(muos_theme, "keyboard", "OSK_ITEM_RADIUS", 3);
 
     theme->MESSAGE.BACKGROUND = get_ini_hex(muos_theme, "notification", "MSG_BACKGROUND");
-    theme->MESSAGE.BACKGROUND_ALPHA = get_ini_int(muos_theme, "notification", "MSG_BACKGROUND_ALPHA", IGNORE);
+    theme->MESSAGE.BACKGROUND_ALPHA = get_ini_int(muos_theme, "notification", "MSG_BACKGROUND_ALPHA", 255);
     theme->MESSAGE.BORDER = get_ini_hex(muos_theme, "notification", "MSG_BORDER");
-    theme->MESSAGE.BORDER_ALPHA = get_ini_int(muos_theme, "notification", "MSG_BORDER_ALPHA", IGNORE);
-    theme->MESSAGE.RADIUS = get_ini_int(muos_theme, "notification", "MSG_RADIUS", IGNORE);
+    theme->MESSAGE.BORDER_ALPHA = get_ini_int(muos_theme, "notification", "MSG_BORDER_ALPHA", 255);
+    theme->MESSAGE.RADIUS = get_ini_int(muos_theme, "notification", "MSG_RADIUS", 3);
     theme->MESSAGE.TEXT = get_ini_hex(muos_theme, "notification", "MSG_TEXT");
-    theme->MESSAGE.TEXT_ALPHA = get_ini_int(muos_theme, "notification", "MSG_TEXT_ALPHA", VALUE);
+    theme->MESSAGE.TEXT_ALPHA = get_ini_int(muos_theme, "notification", "MSG_TEXT_ALPHA", 255);
 
     theme->BAR.PANEL_BACKGROUND = get_ini_hex(muos_theme, "bar", "BAR_BACKGROUND");
-    theme->BAR.PANEL_BACKGROUND_ALPHA = get_ini_int(muos_theme, "bar", "BAR_BACKGROUND_ALPHA", IGNORE);
+    theme->BAR.PANEL_BACKGROUND_ALPHA = get_ini_int(muos_theme, "bar", "BAR_BACKGROUND_ALPHA", 255);
     theme->BAR.PANEL_BORDER = get_ini_hex(muos_theme, "bar", "BAR_BORDER");
-    theme->BAR.PANEL_BORDER_ALPHA = get_ini_int(muos_theme, "bar", "BAR_BORDER_ALPHA", IGNORE);
-    theme->BAR.PANEL_BORDER_RADIUS = get_ini_int(muos_theme, "bar", "BAR_RADIUS", IGNORE);
+    theme->BAR.PANEL_BORDER_ALPHA = get_ini_int(muos_theme, "bar", "BAR_BORDER_ALPHA", 255);
+    theme->BAR.PANEL_BORDER_RADIUS = get_ini_int(muos_theme, "bar", "BAR_RADIUS", 3);
     theme->BAR.PROGRESS_MAIN_BACKGROUND = get_ini_hex(muos_theme, "bar", "BAR_PROGRESS_BACKGROUND");
-    theme->BAR.PROGRESS_MAIN_BACKGROUND_ALPHA = get_ini_int(muos_theme, "bar", "BAR_PROGRESS_BACKGROUND_ALPHA", IGNORE);
+    theme->BAR.PROGRESS_MAIN_BACKGROUND_ALPHA = get_ini_int(muos_theme, "bar", "BAR_PROGRESS_BACKGROUND_ALPHA", 255);
     theme->BAR.PROGRESS_ACTIVE_BACKGROUND = get_ini_hex(muos_theme, "bar", "BAR_PROGRESS_ACTIVE_BACKGROUND");
-    theme->BAR.PROGRESS_ACTIVE_BACKGROUND_ALPHA = get_ini_int(muos_theme, "bar", "BAR_PROGRESS_ACTIVE_BACKGROUND_ALPHA", IGNORE);
-    theme->BAR.PROGRESS_RADIUS = get_ini_int(muos_theme, "bar", "BAR_PROGRESS_RADIUS", IGNORE);
+    theme->BAR.PROGRESS_ACTIVE_BACKGROUND_ALPHA = get_ini_int(muos_theme, "bar", "BAR_PROGRESS_ACTIVE_BACKGROUND_ALPHA", 255);
+    theme->BAR.PROGRESS_RADIUS = get_ini_int(muos_theme, "bar", "BAR_PROGRESS_RADIUS", 3);
     theme->BAR.ICON = get_ini_hex(muos_theme, "bar", "BAR_ICON");
-    theme->BAR.ICON_ALPHA = get_ini_int(muos_theme, "bar", "BAR_ICON_ALPHA", VALUE);
+    theme->BAR.ICON_ALPHA = get_ini_int(muos_theme, "bar", "BAR_ICON_ALPHA", 255);
 
     theme->ROLL.TEXT = get_ini_hex(muos_theme, "roll", "ROLL_TEXT");
-    theme->ROLL.TEXT_ALPHA = get_ini_int(muos_theme, "roll", "ROLL_TEXT_ALPHA", IGNORE);
+    theme->ROLL.TEXT_ALPHA = get_ini_int(muos_theme, "roll", "ROLL_TEXT_ALPHA", 255);
     theme->ROLL.BACKGROUND = get_ini_hex(muos_theme, "roll", "ROLL_BACKGROUND");
-    theme->ROLL.BACKGROUND_ALPHA = get_ini_int(muos_theme, "roll", "ROLL_BACKGROUND_ALPHA", IGNORE);
-    theme->ROLL.RADIUS = get_ini_int(muos_theme, "roll", "ROLL_RADIUS", IGNORE);
+    theme->ROLL.BACKGROUND_ALPHA = get_ini_int(muos_theme, "roll", "ROLL_BACKGROUND_ALPHA", 255);
+    theme->ROLL.RADIUS = get_ini_int(muos_theme, "roll", "ROLL_RADIUS", 3);
     theme->ROLL.SELECT_TEXT = get_ini_hex(muos_theme, "roll", "ROLL_SELECT_TEXT");
-    theme->ROLL.SELECT_TEXT_ALPHA = get_ini_int(muos_theme, "roll", "ROLL_SELECT_TEXT_ALPHA", IGNORE);
+    theme->ROLL.SELECT_TEXT_ALPHA = get_ini_int(muos_theme, "roll", "ROLL_SELECT_TEXT_ALPHA", 255);
     theme->ROLL.SELECT_BACKGROUND = get_ini_hex(muos_theme, "roll", "ROLL_SELECT_BACKGROUND");
-    theme->ROLL.SELECT_BACKGROUND_ALPHA = get_ini_int(muos_theme, "roll", "ROLL_SELECT_BACKGROUND_ALPHA", IGNORE);
-    theme->ROLL.SELECT_RADIUS = get_ini_int(muos_theme, "roll", "ROLL_SELECT_RADIUS", IGNORE);
+    theme->ROLL.SELECT_BACKGROUND_ALPHA = get_ini_int(muos_theme, "roll", "ROLL_SELECT_BACKGROUND_ALPHA", 255);
+    theme->ROLL.SELECT_RADIUS = get_ini_int(muos_theme, "roll", "ROLL_SELECT_RADIUS", 3);
     theme->ROLL.BORDER_COLOUR = get_ini_hex(muos_theme, "roll", "ROLL_BORDER_COLOUR");
-    theme->ROLL.BORDER_ALPHA = get_ini_int(muos_theme, "roll", "ROLL_BORDER_ALPHA", VALUE);
-    theme->ROLL.BORDER_RADIUS = get_ini_int(muos_theme, "roll", "ROLL_BORDER_RADIUS", VALUE);
+    theme->ROLL.BORDER_ALPHA = get_ini_int(muos_theme, "roll", "ROLL_BORDER_ALPHA", 255);
+    theme->ROLL.BORDER_RADIUS = get_ini_int(muos_theme, "roll", "ROLL_BORDER_RADIUS", 255);
 
-    theme->MISC.STATIC_ALIGNMENT = get_ini_int(muos_theme, "misc", "STATIC_ALIGNMENT", VALUE);
-    theme->MISC.CONTENT.PADDING_LEFT = get_ini_int(muos_theme, "misc", "CONTENT_PADDING_LEFT", MISC_PAD);
-    theme->MISC.CONTENT.WIDTH = get_ini_int(muos_theme, "misc", "CONTENT_WIDTH", MISC_WIDTH);
-    theme->MISC.ANIMATED_BACKGROUND = get_ini_int(muos_theme, "misc", "ANIMATED_BACKGROUND", VALUE);
-    theme->MISC.IMAGE_OVERLAY = get_ini_int(muos_theme, "misc", "IMAGE_OVERLAY", VALUE);
-    theme->MISC.NAVIGATION_TYPE = get_ini_int(muos_theme, "misc", "NAVIGATION_TYPE", VALUE);
+    theme->MISC.STATIC_ALIGNMENT = get_ini_int(muos_theme, "misc", "STATIC_ALIGNMENT", 255);
+    theme->MISC.CONTENT.PADDING_LEFT = get_ini_int(muos_theme, "misc", "CONTENT_PADDING_LEFT", 0);
+    theme->MISC.CONTENT.WIDTH = get_ini_int(muos_theme, "misc", "CONTENT_WIDTH", device->SCREEN.WIDTH);
+    theme->MISC.ANIMATED_BACKGROUND = get_ini_int(muos_theme, "misc", "ANIMATED_BACKGROUND", 255);
+    theme->MISC.IMAGE_OVERLAY = get_ini_int(muos_theme, "misc", "IMAGE_OVERLAY", 255);
+    theme->MISC.NAVIGATION_TYPE = get_ini_int(muos_theme, "misc", "NAVIGATION_TYPE", 255);
 
     mini_free(muos_theme);
 }

--- a/common/theme.h
+++ b/common/theme.h
@@ -144,6 +144,7 @@ struct theme_config {
     struct {
         int16_t RADIUS;
         uint32_t BACKGROUND;
+        uint32_t BACKGROUND_GRADIENT;
         int16_t BACKGROUND_ALPHA;
         int16_t GRADIENT_START;
         int16_t GRADIENT_STOP;
@@ -160,6 +161,7 @@ struct theme_config {
 
     struct {
         uint32_t BACKGROUND;
+        uint32_t BACKGROUND_GRADIENT;
         int16_t BACKGROUND_ALPHA;
         int16_t GRADIENT_START;
         int16_t GRADIENT_STOP;

--- a/common/theme.h
+++ b/common/theme.h
@@ -270,6 +270,8 @@ struct theme_config {
         int16_t NAVIGATION_TYPE;
         struct {
             int16_t PADDING_LEFT;
+            int16_t PADDING_TOP;
+            int16_t HEIGHT;
             int16_t WIDTH;
         } CONTENT;
     } MISC;

--- a/common/theme.h
+++ b/common/theme.h
@@ -11,6 +11,18 @@ struct theme_config {
     } SYSTEM;
 
     struct {
+        struct {
+            int16_t COUNT;
+            int16_t HEIGHT;
+            int16_t PANEL;
+            int16_t PREV_LOW;
+            int16_t PREV_HIGH;
+            int16_t NEXT_LOW;
+            int16_t NEXT_HIGH;
+        } ITEM;
+    } MUX;
+
+    struct {
         int16_t HEADER_PAD_TOP;
         int16_t HEADER_PAD_BOTTOM;
         int16_t HEADER_ICON_PAD_TOP;
@@ -130,6 +142,7 @@ struct theme_config {
     } NAV;
 
     struct {
+        int16_t RADIUS;
         uint32_t BACKGROUND;
         int16_t BACKGROUND_ALPHA;
         int16_t GRADIENT_START;

--- a/muxapp/main.c
+++ b/muxapp/main.c
@@ -773,6 +773,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrApp);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxapp/main.c
+++ b/muxapp/main.c
@@ -127,7 +127,7 @@ void create_app_items() {
 
         lv_obj_t * ui_pnlApp = lv_obj_create(ui_pnlContent);
         lv_obj_set_width(ui_pnlApp, device.MUX.WIDTH);
-        lv_obj_set_height(ui_pnlApp, device.MUX.ITEM.HEIGHT);
+        lv_obj_set_height(ui_pnlApp, theme.MUX.ITEM.HEIGHT);
         lv_obj_set_scrollbar_mode(ui_pnlApp, LV_SCROLLBAR_MODE_OFF);
         lv_obj_set_style_align(ui_pnlApp, LV_ALIGN_CENTER, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_obj_set_style_bg_opa(ui_pnlApp, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -143,7 +143,7 @@ void create_app_items() {
         lv_label_set_text(ui_lblAppItem, app_store);
 
         lv_obj_set_width(ui_lblAppItem, device.MUX.WIDTH);
-        lv_obj_set_height(ui_lblAppItem, device.MUX.ITEM.HEIGHT);
+        lv_obj_set_height(ui_lblAppItem, theme.MUX.ITEM.HEIGHT);
 
         lv_obj_set_style_border_width(ui_lblAppItem, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_obj_set_style_border_side(ui_lblAppItem, LV_BORDER_SIDE_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -212,7 +212,7 @@ void create_app_items() {
         }
 
         lv_obj_set_width(ui_lblAppItemGlyph, device.MUX.WIDTH);
-        lv_obj_set_height(ui_lblAppItemGlyph, device.MUX.ITEM.HEIGHT);
+        lv_obj_set_height(ui_lblAppItemGlyph, theme.MUX.ITEM.HEIGHT);
 
         lv_obj_set_style_border_width(ui_lblAppItemGlyph, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
 
@@ -249,16 +249,16 @@ void create_app_items() {
 
 void list_nav_prev(int steps) {
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index >= 1 && ui_count > device.MUX.ITEM.COUNT) {
+        if (current_item_index >= 1 && ui_count > theme.MUX.ITEM.COUNT) {
             current_item_index--;
             nav_prev(ui_group, 1);
             nav_prev(ui_group_glyph, 1);
-            if (current_item_index > device.MUX.ITEM.PREV_LOW &&
-                current_item_index < (ui_count - device.MUX.ITEM.PREV_HIGH)) {
-                content_panel_y -= device.MUX.ITEM.PANEL;
+            if (current_item_index > theme.MUX.ITEM.PREV_LOW &&
+                current_item_index < (ui_count - theme.MUX.ITEM.PREV_HIGH)) {
+                content_panel_y -= theme.MUX.ITEM.PANEL;
                 lv_obj_scroll_to_y(ui_pnlContent, content_panel_y, LV_ANIM_OFF);
             }
-        } else if (current_item_index >= 0 && ui_count <= device.MUX.ITEM.COUNT) {
+        } else if (current_item_index >= 0 && ui_count <= theme.MUX.ITEM.COUNT) {
             if (current_item_index > 0) {
                 current_item_index--;
                 nav_prev(ui_group, 1);
@@ -273,18 +273,18 @@ void list_nav_prev(int steps) {
 
 void list_nav_next(int steps) {
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index < (ui_count - 1) && ui_count > device.MUX.ITEM.COUNT) {
+        if (current_item_index < (ui_count - 1) && ui_count > theme.MUX.ITEM.COUNT) {
             if (current_item_index < (ui_count - 1)) {
                 current_item_index++;
                 nav_next(ui_group, 1);
                 nav_next(ui_group_glyph, 1);
-                if (current_item_index >= device.MUX.ITEM.NEXT_HIGH &&
-                    current_item_index < (ui_count - device.MUX.ITEM.NEXT_LOW)) {
-                    content_panel_y += device.MUX.ITEM.PANEL;
+                if (current_item_index >= theme.MUX.ITEM.NEXT_HIGH &&
+                    current_item_index < (ui_count - theme.MUX.ITEM.NEXT_LOW)) {
+                    content_panel_y += theme.MUX.ITEM.PANEL;
                     lv_obj_scroll_to_y(ui_pnlContent, content_panel_y, LV_ANIM_OFF);
                 }
             }
-        } else if (current_item_index < ui_count && ui_count <= device.MUX.ITEM.COUNT) {
+        } else if (current_item_index < ui_count && ui_count <= theme.MUX.ITEM.COUNT) {
             if (current_item_index < (ui_count - 1)) {
                 current_item_index++;
                 nav_next(ui_group, 1);
@@ -380,12 +380,12 @@ void *joystick_task() {
                                     safe_quit = 1;
                                 } else if (ev.code == device.RAW_INPUT.BUTTON.L1) {
                                     if (current_item_index >= 0 && current_item_index < ui_count) {
-                                        list_nav_prev(device.MUX.ITEM.COUNT);
+                                        list_nav_prev(theme.MUX.ITEM.COUNT);
                                         lv_task_handler();
                                     }
                                 } else if (ev.code == device.RAW_INPUT.BUTTON.R1) {
                                     if (current_item_index >= 0 && current_item_index < ui_count) {
-                                        list_nav_next(device.MUX.ITEM.COUNT);
+                                        list_nav_next(theme.MUX.ITEM.COUNT);
                                         lv_task_handler();
                                     }
                                 }
@@ -411,7 +411,7 @@ void *joystick_task() {
                                  ev.value <= ((device.INPUT.AXIS_MIN >> 2) * -1)) ||
                                 ev.value == -1) {
                                 if (current_item_index == 0) {
-                                    int y = (ui_count - device.MUX.ITEM.COUNT) * device.MUX.ITEM.PANEL;
+                                    int y = (ui_count - theme.MUX.ITEM.COUNT) * theme.MUX.ITEM.PANEL;
                                     lv_obj_scroll_to_y(ui_pnlContent, y, LV_ANIM_OFF);
                                     content_panel_y = y;
                                     current_item_index = ui_count - 1;
@@ -451,7 +451,7 @@ void *joystick_task() {
             }
         }
 
-        if (ui_count > device.MUX.ITEM.COUNT && (JOYUP_pressed || JOYDOWN_pressed)) {
+        if (ui_count > theme.MUX.ITEM.COUNT && (JOYUP_pressed || JOYDOWN_pressed)) {
             if (nav_hold > 2) {
                 if (nav_delay > 16) {
                     nav_delay -= 16;
@@ -829,7 +829,7 @@ int main(int argc, char *argv[]) {
         lv_obj_clear_flag(ui_lblAppMessage, LV_OBJ_FLAG_HIDDEN);
     }
 
-    if (ui_count > device.MUX.ITEM.COUNT) {
+    if (ui_count > theme.MUX.ITEM.COUNT) {
         lv_obj_t * last_item = lv_obj_get_child(ui_pnlContent, -1);
         lv_obj_set_height(last_item, lv_obj_get_height(last_item) + 50); // Don't bother asking...
     }

--- a/muxapp/main.c
+++ b/muxapp/main.c
@@ -191,6 +191,8 @@ void create_app_items() {
         lv_obj_set_style_text_line_space(ui_lblAppItem, 16, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_label_set_long_mode(ui_lblAppItem, LV_LABEL_LONG_WRAP);
 
+        lv_obj_set_style_radius(ui_lblAppItem, theme.LIST_DEFAULT.RADIUS, LV_PART_MAIN | LV_STATE_DEFAULT);
+
         lv_obj_t * ui_lblAppItemGlyph = lv_label_create(ui_pnlApp);
 
         if (strcasecmp(app_store, "Archive Manager") == 0) {

--- a/muxapp/main.c
+++ b/muxapp/main.c
@@ -147,8 +147,10 @@ void create_app_items() {
 
         lv_obj_set_style_border_width(ui_lblAppItem, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_obj_set_style_border_side(ui_lblAppItem, LV_BORDER_SIDE_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
-        lv_obj_set_style_bg_grad_color(ui_lblAppItem, lv_color_hex(theme.SYSTEM.BACKGROUND),
+        lv_obj_set_style_bg_grad_color(ui_lblAppItem, lv_color_hex(theme.LIST_DEFAULT.BACKGROUND_GRADIENT),
                                        LV_PART_MAIN | LV_STATE_DEFAULT);
+        lv_obj_set_style_bg_grad_color(ui_lblAppItem, lv_color_hex(theme.LIST_FOCUS.BACKGROUND_GRADIENT),
+                                       LV_PART_MAIN | LV_STATE_FOCUSED);
         lv_obj_set_style_bg_main_stop(ui_lblAppItem, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_obj_set_style_bg_grad_dir(ui_lblAppItem, LV_GRAD_DIR_HOR, LV_PART_MAIN | LV_STATE_DEFAULT);
 

--- a/muxarchive/main.c
+++ b/muxarchive/main.c
@@ -163,7 +163,7 @@ void create_archive_items() {
 
         lv_obj_t * ui_pnlArchive = lv_obj_create(ui_pnlContent);
         lv_obj_set_width(ui_pnlArchive, device.MUX.WIDTH);
-        lv_obj_set_height(ui_pnlArchive, device.MUX.ITEM.HEIGHT);
+        lv_obj_set_height(ui_pnlArchive, theme.MUX.ITEM.HEIGHT);
         lv_obj_set_scrollbar_mode(ui_pnlArchive, LV_SCROLLBAR_MODE_OFF);
         lv_obj_set_style_align(ui_pnlArchive, LV_ALIGN_CENTER, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_obj_set_style_bg_opa(ui_pnlArchive, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -179,7 +179,7 @@ void create_archive_items() {
         lv_label_set_text(ui_lblArchiveItem, archive_store);
 
         lv_obj_set_width(ui_lblArchiveItem, device.MUX.WIDTH);
-        lv_obj_set_height(ui_lblArchiveItem, device.MUX.ITEM.HEIGHT);
+        lv_obj_set_height(ui_lblArchiveItem, theme.MUX.ITEM.HEIGHT);
 
         lv_obj_set_style_border_width(ui_lblArchiveItem, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_obj_set_style_border_side(ui_lblArchiveItem, LV_BORDER_SIDE_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -232,7 +232,7 @@ void create_archive_items() {
         lv_label_set_text(ui_lblArchiveItemInstalled, is_installed);
 
         lv_obj_set_width(ui_lblArchiveItemInstalled, device.MUX.WIDTH);
-        lv_obj_set_height(ui_lblArchiveItemInstalled, device.MUX.ITEM.HEIGHT);
+        lv_obj_set_height(ui_lblArchiveItemInstalled, theme.MUX.ITEM.HEIGHT);
 
         lv_obj_set_style_border_width(ui_lblArchiveItemInstalled, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_obj_set_style_border_side(ui_lblArchiveItemInstalled, LV_BORDER_SIDE_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -267,7 +267,7 @@ void create_archive_items() {
         lv_label_set_text(ui_lblArchiveItemGlyph, "\uF1C6");
 
         lv_obj_set_width(ui_lblArchiveItemGlyph, device.MUX.WIDTH);
-        lv_obj_set_height(ui_lblArchiveItemGlyph, device.MUX.ITEM.HEIGHT);
+        lv_obj_set_height(ui_lblArchiveItemGlyph, theme.MUX.ITEM.HEIGHT);
 
         lv_obj_set_style_border_width(ui_lblArchiveItemGlyph, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
 
@@ -306,18 +306,18 @@ void create_archive_items() {
 
 void list_nav_prev(int steps) {
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index >= 1 && ui_count > device.MUX.ITEM.COUNT) {
+        if (current_item_index >= 1 && ui_count > theme.MUX.ITEM.COUNT) {
             current_item_index--;
             nav_prev(ui_group, 1);
             nav_prev(ui_group_glyph, 1);
             nav_prev(ui_group_installed, 1);
             nav_prev(ui_group_data, 1);
-            if (current_item_index > device.MUX.ITEM.PREV_LOW &&
-                current_item_index < (ui_count - device.MUX.ITEM.PREV_HIGH)) {
-                content_panel_y -= device.MUX.ITEM.PANEL;
+            if (current_item_index > theme.MUX.ITEM.PREV_LOW &&
+                current_item_index < (ui_count - theme.MUX.ITEM.PREV_HIGH)) {
+                content_panel_y -= theme.MUX.ITEM.PANEL;
                 lv_obj_scroll_to_y(ui_pnlContent, content_panel_y, LV_ANIM_OFF);
             }
-        } else if (current_item_index >= 0 && ui_count <= device.MUX.ITEM.COUNT) {
+        } else if (current_item_index >= 0 && ui_count <= theme.MUX.ITEM.COUNT) {
             if (current_item_index > 0) {
                 current_item_index--;
                 nav_prev(ui_group, 1);
@@ -334,20 +334,20 @@ void list_nav_prev(int steps) {
 
 void list_nav_next(int steps) {
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index < (ui_count - 1) && ui_count > device.MUX.ITEM.COUNT) {
+        if (current_item_index < (ui_count - 1) && ui_count > theme.MUX.ITEM.COUNT) {
             if (current_item_index < (ui_count - 1)) {
                 current_item_index++;
                 nav_next(ui_group, 1);
                 nav_next(ui_group_glyph, 1);
                 nav_next(ui_group_installed, 1);
                 nav_next(ui_group_data, 1);
-                if (current_item_index >= device.MUX.ITEM.NEXT_HIGH &&
-                    current_item_index < (ui_count - device.MUX.ITEM.NEXT_LOW)) {
-                    content_panel_y += device.MUX.ITEM.PANEL;
+                if (current_item_index >= theme.MUX.ITEM.NEXT_HIGH &&
+                    current_item_index < (ui_count - theme.MUX.ITEM.NEXT_LOW)) {
+                    content_panel_y += theme.MUX.ITEM.PANEL;
                     lv_obj_scroll_to_y(ui_pnlContent, content_panel_y, LV_ANIM_OFF);
                 }
             }
-        } else if (current_item_index < ui_count && ui_count <= device.MUX.ITEM.COUNT) {
+        } else if (current_item_index < ui_count && ui_count <= theme.MUX.ITEM.COUNT) {
             if (current_item_index < (ui_count - 1)) {
                 current_item_index++;
                 nav_next(ui_group, 1);
@@ -447,12 +447,12 @@ void *joystick_task() {
                                     safe_quit = 1;
                                 } else if (ev.code == device.RAW_INPUT.BUTTON.L1) {
                                     if (current_item_index >= 0 && current_item_index < ui_count) {
-                                        list_nav_prev(device.MUX.ITEM.COUNT);
+                                        list_nav_prev(theme.MUX.ITEM.COUNT);
                                         lv_task_handler();
                                     }
                                 } else if (ev.code == device.RAW_INPUT.BUTTON.R1) {
                                     if (current_item_index >= 0 && current_item_index < ui_count) {
-                                        list_nav_next(device.MUX.ITEM.COUNT);
+                                        list_nav_next(theme.MUX.ITEM.COUNT);
                                         lv_task_handler();
                                     }
                                 }
@@ -478,7 +478,7 @@ void *joystick_task() {
                                  ev.value <= ((device.INPUT.AXIS_MIN >> 2) * -1)) ||
                                 ev.value == -1) {
                                 if (current_item_index == 0) {
-                                    int y = (ui_count - device.MUX.ITEM.COUNT) * device.MUX.ITEM.PANEL;
+                                    int y = (ui_count - theme.MUX.ITEM.COUNT) * theme.MUX.ITEM.PANEL;
                                     lv_obj_scroll_to_y(ui_pnlContent, y, LV_ANIM_OFF);
                                     content_panel_y = y;
                                     current_item_index = ui_count - 1;
@@ -520,7 +520,7 @@ void *joystick_task() {
             }
         }
 
-        if (ui_count > device.MUX.ITEM.COUNT && (JOYUP_pressed || JOYDOWN_pressed)) {
+        if (ui_count > theme.MUX.ITEM.COUNT && (JOYUP_pressed || JOYDOWN_pressed)) {
             if (nav_hold > 2) {
                 if (nav_delay > 16) {
                     nav_delay -= 16;
@@ -891,7 +891,7 @@ int main(int argc, char *argv[]) {
         lv_obj_clear_flag(ui_lblArchiveMessage, LV_OBJ_FLAG_HIDDEN);
     }
 
-    if (ui_count > device.MUX.ITEM.COUNT) {
+    if (ui_count > theme.MUX.ITEM.COUNT) {
         lv_obj_t * last_item = lv_obj_get_child(ui_pnlContent, -1);
         lv_obj_set_height(last_item, lv_obj_get_height(last_item) + 50); // Don't bother asking...
     }

--- a/muxarchive/main.c
+++ b/muxarchive/main.c
@@ -183,8 +183,10 @@ void create_archive_items() {
 
         lv_obj_set_style_border_width(ui_lblArchiveItem, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_obj_set_style_border_side(ui_lblArchiveItem, LV_BORDER_SIDE_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
-        lv_obj_set_style_bg_grad_color(ui_lblArchiveItem, lv_color_hex(theme.SYSTEM.BACKGROUND),
+        lv_obj_set_style_bg_grad_color(ui_lblArchiveItem, lv_color_hex(theme.LIST_DEFAULT.BACKGROUND_GRADIENT),
                                        LV_PART_MAIN | LV_STATE_DEFAULT);
+        lv_obj_set_style_bg_grad_color(ui_lblArchiveItem, lv_color_hex(theme.LIST_FOCUS.BACKGROUND_GRADIENT),
+                                       LV_PART_MAIN | LV_STATE_FOCUSED);
         lv_obj_set_style_bg_main_stop(ui_lblArchiveItem, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_obj_set_style_bg_grad_dir(ui_lblArchiveItem, LV_GRAD_DIR_HOR, LV_PART_MAIN | LV_STATE_DEFAULT);
 

--- a/muxarchive/main.c
+++ b/muxarchive/main.c
@@ -227,6 +227,8 @@ void create_archive_items() {
         lv_obj_set_style_text_line_space(ui_lblArchiveItem, 16, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_label_set_long_mode(ui_lblArchiveItem, LV_LABEL_LONG_WRAP);
 
+        lv_obj_set_style_radius(ui_lblArchiveItem, theme.LIST_DEFAULT.RADIUS, LV_PART_MAIN | LV_STATE_DEFAULT);
+
         lv_obj_t * ui_lblArchiveItemInstalled = lv_label_create(ui_pnlArchive);
 
         lv_label_set_text(ui_lblArchiveItemInstalled, is_installed);
@@ -256,6 +258,8 @@ void create_archive_items() {
         lv_obj_set_style_text_line_space(ui_lblArchiveItemInstalled, 16, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_obj_set_style_text_align(ui_lblArchiveItemInstalled, LV_TEXT_ALIGN_RIGHT, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_label_set_long_mode(ui_lblArchiveItemInstalled, LV_LABEL_LONG_WRAP);
+
+        lv_obj_set_style_radius(ui_lblArchiveItemInstalled, theme.LIST_DEFAULT.RADIUS, LV_PART_MAIN | LV_STATE_DEFAULT);
 
         lv_obj_t * ui_lblArchiveItemData = lv_label_create(ui_pnlArchive);
         lv_label_set_text(ui_lblArchiveItemData, base_filename);

--- a/muxarchive/main.c
+++ b/muxarchive/main.c
@@ -833,6 +833,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrArchive);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxassign/main.c
+++ b/muxassign/main.c
@@ -218,8 +218,10 @@ void create_system_items() {
 
             lv_obj_set_style_border_width(ui_lblCoreItem, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
             lv_obj_set_style_border_side(ui_lblCoreItem, LV_BORDER_SIDE_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
-            lv_obj_set_style_bg_grad_color(ui_lblCoreItem, lv_color_hex(theme.SYSTEM.BACKGROUND),
+            lv_obj_set_style_bg_grad_color(ui_lblCoreItem, lv_color_hex(theme.LIST_DEFAULT.BACKGROUND_GRADIENT),
                                            LV_PART_MAIN | LV_STATE_DEFAULT);
+            lv_obj_set_style_bg_grad_color(ui_lblCoreItem, lv_color_hex(theme.LIST_FOCUS.BACKGROUND_GRADIENT),
+                                           LV_PART_MAIN | LV_STATE_FOCUSED);
             lv_obj_set_style_bg_main_stop(ui_lblCoreItem, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
             lv_obj_set_style_bg_grad_dir(ui_lblCoreItem, LV_GRAD_DIR_HOR, LV_PART_MAIN | LV_STATE_DEFAULT);
 
@@ -357,8 +359,11 @@ void create_core_items(const char *target) {
 
         lv_obj_set_style_border_width(ui_lblCoreItem, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_obj_set_style_border_side(ui_lblCoreItem, LV_BORDER_SIDE_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
-        lv_obj_set_style_bg_grad_color(ui_lblCoreItem, lv_color_hex(theme.SYSTEM.BACKGROUND),
+        lv_obj_set_style_bg_grad_color(ui_lblCoreItem, lv_color_hex(theme.LIST_DEFAULT.BACKGROUND_GRADIENT),
                                        LV_PART_MAIN | LV_STATE_DEFAULT);
+        lv_obj_set_style_bg_grad_color(ui_lblCoreItem, lv_color_hex(theme.LIST_FOCUS.BACKGROUND_GRADIENT),
+                                       LV_PART_MAIN | LV_STATE_FOCUSED);
+
         lv_obj_set_style_bg_main_stop(ui_lblCoreItem, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_obj_set_style_bg_grad_dir(ui_lblCoreItem, LV_GRAD_DIR_HOR, LV_PART_MAIN | LV_STATE_DEFAULT);
 

--- a/muxassign/main.c
+++ b/muxassign/main.c
@@ -1074,6 +1074,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrAssign);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxassign/main.c
+++ b/muxassign/main.c
@@ -262,6 +262,8 @@ void create_system_items() {
             lv_obj_set_style_text_line_space(ui_lblCoreItem, 16, LV_PART_MAIN | LV_STATE_DEFAULT);
             lv_label_set_long_mode(ui_lblCoreItem, LV_LABEL_LONG_WRAP);
 
+            lv_obj_set_style_radius(ui_lblCoreItem, theme.LIST_DEFAULT.RADIUS, LV_PART_MAIN | LV_STATE_DEFAULT);
+
             lv_obj_t * ui_lblCoreItemGlyph = lv_label_create(ui_pnlCore);
             lv_label_set_text(ui_lblCoreItemGlyph, "\uF233");
 

--- a/muxassign/main.c
+++ b/muxassign/main.c
@@ -198,7 +198,7 @@ void create_system_items() {
 
             lv_obj_t * ui_pnlCore = lv_obj_create(ui_pnlContent);
             lv_obj_set_width(ui_pnlCore, device.MUX.WIDTH);
-            lv_obj_set_height(ui_pnlCore, device.MUX.ITEM.HEIGHT);
+            lv_obj_set_height(ui_pnlCore, theme.MUX.ITEM.HEIGHT);
             lv_obj_set_scrollbar_mode(ui_pnlCore, LV_SCROLLBAR_MODE_OFF);
             lv_obj_set_style_align(ui_pnlCore, LV_ALIGN_CENTER, LV_PART_MAIN | LV_STATE_DEFAULT);
             lv_obj_set_style_bg_opa(ui_pnlCore, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -214,7 +214,7 @@ void create_system_items() {
             lv_label_set_text(ui_lblCoreItem, base_filename);
 
             lv_obj_set_width(ui_lblCoreItem, device.MUX.WIDTH);
-            lv_obj_set_height(ui_lblCoreItem, device.MUX.ITEM.HEIGHT);
+            lv_obj_set_height(ui_lblCoreItem, theme.MUX.ITEM.HEIGHT);
 
             lv_obj_set_style_border_width(ui_lblCoreItem, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
             lv_obj_set_style_border_side(ui_lblCoreItem, LV_BORDER_SIDE_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -266,7 +266,7 @@ void create_system_items() {
             lv_label_set_text(ui_lblCoreItemGlyph, "\uF233");
 
             lv_obj_set_width(ui_lblCoreItemGlyph, device.MUX.WIDTH);
-            lv_obj_set_height(ui_lblCoreItemGlyph, device.MUX.ITEM.HEIGHT);
+            lv_obj_set_height(ui_lblCoreItemGlyph, theme.MUX.ITEM.HEIGHT);
 
             lv_obj_set_style_border_width(ui_lblCoreItemGlyph, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
 
@@ -335,7 +335,7 @@ void create_core_items(const char *target) {
 
         lv_obj_t * ui_pnlCore = lv_obj_create(ui_pnlContent);
         lv_obj_set_width(ui_pnlCore, device.MUX.WIDTH);
-        lv_obj_set_height(ui_pnlCore, device.MUX.ITEM.HEIGHT);
+        lv_obj_set_height(ui_pnlCore, theme.MUX.ITEM.HEIGHT);
         lv_obj_set_scrollbar_mode(ui_pnlCore, LV_SCROLLBAR_MODE_OFF);
         lv_obj_set_style_align(ui_pnlCore, LV_ALIGN_CENTER, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_obj_set_style_bg_opa(ui_pnlCore, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -351,7 +351,7 @@ void create_core_items(const char *target) {
         lv_label_set_text(ui_lblCoreItem, core_headers[i]);
 
         lv_obj_set_width(ui_lblCoreItem, device.MUX.WIDTH);
-        lv_obj_set_height(ui_lblCoreItem, device.MUX.ITEM.HEIGHT);
+        lv_obj_set_height(ui_lblCoreItem, theme.MUX.ITEM.HEIGHT);
 
         lv_obj_set_style_border_width(ui_lblCoreItem, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_obj_set_style_border_side(ui_lblCoreItem, LV_BORDER_SIDE_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -406,7 +406,7 @@ void create_core_items(const char *target) {
         lv_label_set_text(ui_lblCoreItemGlyph, "\uF6D1");
 
         lv_obj_set_width(ui_lblCoreItemGlyph, device.MUX.WIDTH);
-        lv_obj_set_height(ui_lblCoreItemGlyph, device.MUX.ITEM.HEIGHT);
+        lv_obj_set_height(ui_lblCoreItemGlyph, theme.MUX.ITEM.HEIGHT);
 
         lv_obj_set_style_border_width(ui_lblCoreItemGlyph, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
 
@@ -445,16 +445,16 @@ void create_core_items(const char *target) {
 
 void list_nav_prev(int steps) {
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index >= 1 && ui_count > device.MUX.ITEM.COUNT) {
+        if (current_item_index >= 1 && ui_count > theme.MUX.ITEM.COUNT) {
             current_item_index--;
             nav_prev(ui_group, 1);
             nav_prev(ui_group_glyph, 1);
-            if (current_item_index > device.MUX.ITEM.PREV_LOW &&
-                current_item_index < (ui_count - device.MUX.ITEM.PREV_HIGH)) {
-                content_panel_y -= device.MUX.ITEM.PANEL;
+            if (current_item_index > theme.MUX.ITEM.PREV_LOW &&
+                current_item_index < (ui_count - theme.MUX.ITEM.PREV_HIGH)) {
+                content_panel_y -= theme.MUX.ITEM.PANEL;
                 lv_obj_scroll_to_y(ui_pnlContent, content_panel_y, LV_ANIM_OFF);
             }
-        } else if (current_item_index >= 0 && ui_count <= device.MUX.ITEM.COUNT) {
+        } else if (current_item_index >= 0 && ui_count <= theme.MUX.ITEM.COUNT) {
             if (current_item_index > 0) {
                 current_item_index--;
                 nav_prev(ui_group, 1);
@@ -469,18 +469,18 @@ void list_nav_prev(int steps) {
 
 void list_nav_next(int steps) {
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index < (ui_count - 1) && ui_count > device.MUX.ITEM.COUNT) {
+        if (current_item_index < (ui_count - 1) && ui_count > theme.MUX.ITEM.COUNT) {
             if (current_item_index < (ui_count - 1)) {
                 current_item_index++;
                 nav_next(ui_group, 1);
                 nav_next(ui_group_glyph, 1);
-                if (current_item_index >= device.MUX.ITEM.NEXT_HIGH &&
-                    current_item_index < (ui_count - device.MUX.ITEM.NEXT_LOW)) {
-                    content_panel_y += device.MUX.ITEM.PANEL;
+                if (current_item_index >= theme.MUX.ITEM.NEXT_HIGH &&
+                    current_item_index < (ui_count - theme.MUX.ITEM.NEXT_LOW)) {
+                    content_panel_y += theme.MUX.ITEM.PANEL;
                     lv_obj_scroll_to_y(ui_pnlContent, content_panel_y, LV_ANIM_OFF);
                 }
             }
-        } else if (current_item_index < ui_count && ui_count <= device.MUX.ITEM.COUNT) {
+        } else if (current_item_index < ui_count && ui_count <= theme.MUX.ITEM.COUNT) {
             if (current_item_index < (ui_count - 1)) {
                 current_item_index++;
                 nav_next(ui_group, 1);
@@ -596,12 +596,12 @@ void *joystick_task() {
                                     safe_quit = 1;
                                 } else if (ev.code == device.RAW_INPUT.BUTTON.L1) {
                                     if (current_item_index >= 0 && current_item_index < ui_count) {
-                                        list_nav_prev(device.MUX.ITEM.COUNT);
+                                        list_nav_prev(theme.MUX.ITEM.COUNT);
                                         lv_task_handler();
                                     }
                                 } else if (ev.code == device.RAW_INPUT.BUTTON.R1) {
                                     if (current_item_index >= 0 && current_item_index < ui_count) {
-                                        list_nav_next(device.MUX.ITEM.COUNT);
+                                        list_nav_next(theme.MUX.ITEM.COUNT);
                                         lv_task_handler();
                                     }
                                 }
@@ -627,7 +627,7 @@ void *joystick_task() {
                                  ev.value <= ((device.INPUT.AXIS_MIN >> 2) * -1)) ||
                                 ev.value == -1) {
                                 if (current_item_index == 0) {
-                                    int y = (ui_count - device.MUX.ITEM.COUNT) * device.MUX.ITEM.PANEL;
+                                    int y = (ui_count - theme.MUX.ITEM.COUNT) * theme.MUX.ITEM.PANEL;
                                     lv_obj_scroll_to_y(ui_pnlContent, y, LV_ANIM_OFF);
                                     content_panel_y = y;
                                     current_item_index = ui_count - 1;
@@ -665,7 +665,7 @@ void *joystick_task() {
             }
         }
 
-        if (ui_count > device.MUX.ITEM.COUNT && (JOYUP_pressed || JOYDOWN_pressed)) {
+        if (ui_count > theme.MUX.ITEM.COUNT && (JOYUP_pressed || JOYDOWN_pressed)) {
             if (nav_hold > 2) {
                 if (nav_delay > 16) {
                     nav_delay -= 16;
@@ -1137,7 +1137,7 @@ int main(int argc, char *argv[]) {
         lv_obj_clear_flag(ui_lblCoreMessage, LV_OBJ_FLAG_HIDDEN);
     }
 
-    if (ui_count > device.MUX.ITEM.COUNT) {
+    if (ui_count > theme.MUX.ITEM.COUNT) {
         lv_obj_t * last_item = lv_obj_get_child(ui_pnlContent, -1);
         lv_obj_set_height(last_item, lv_obj_get_height(last_item) + 50); // Don't bother asking...
     }

--- a/muxconfig/main.c
+++ b/muxconfig/main.c
@@ -539,6 +539,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrConfig);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxconfig/theme.c
+++ b/muxconfig/theme.c
@@ -284,6 +284,30 @@ void apply_theme() {
                                     LV_PART_MAIN | LV_STATE_FOCUSED);
     }
 
+    struct small gradient_start_default_elements[] = {
+            {ui_lblTweakGeneral, theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblTheme,        theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblNetwork,      theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblServices,     theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblRTC,          theme.LIST_DEFAULT.GRADIENT_START},
+    };
+    for (size_t i = 0; i < sizeof(gradient_start_default_elements) / sizeof(gradient_start_default_elements[0]); ++i) {
+        lv_obj_set_style_bg_main_stop(gradient_start_default_elements[i].e, gradient_start_default_elements[i].c,
+                                      LV_PART_MAIN | LV_STATE_DEFAULT);
+    }
+
+    struct small gradient_start_focus_elements[] = {
+            {ui_lblTweakGeneral, theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblTheme,        theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblNetwork,      theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblServices,     theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblRTC,          theme.LIST_FOCUS.GRADIENT_START},
+    };
+    for (size_t i = 0; i < sizeof(gradient_start_focus_elements) / sizeof(gradient_start_focus_elements[0]); ++i) {
+        lv_obj_set_style_bg_main_stop(gradient_start_focus_elements[i].e, gradient_start_focus_elements[i].c,
+                                      LV_PART_MAIN | LV_STATE_FOCUSED);
+    }
+
     struct small gradient_stop_default_elements[] = {
             {ui_lblTweakGeneral, theme.LIST_DEFAULT.GRADIENT_STOP},
             {ui_lblTheme,        theme.LIST_DEFAULT.GRADIENT_STOP},

--- a/muxconfig/theme.c
+++ b/muxconfig/theme.c
@@ -364,6 +364,11 @@ void apply_theme() {
             {ui_barProgressBrightness, theme.BAR.PROGRESS_RADIUS},
             {ui_pnlProgressVolume,     theme.BAR.PANEL_BORDER_RADIUS},
             {ui_barProgressVolume,     theme.BAR.PROGRESS_RADIUS},
+            {ui_lblTweakGeneral, theme.LIST_DEFAULT.RADIUS},
+            {ui_lblTheme,        theme.LIST_DEFAULT.RADIUS},
+            {ui_lblNetwork,      theme.LIST_DEFAULT.RADIUS},
+            {ui_lblServices,     theme.LIST_DEFAULT.RADIUS},
+            {ui_lblRTC,          theme.LIST_DEFAULT.RADIUS},
     };
     for (size_t i = 0; i < sizeof(radius_elements) / sizeof(radius_elements[0]); ++i) {
         lv_obj_set_style_radius(radius_elements[i].e, radius_elements[i].c,

--- a/muxconfig/theme.c
+++ b/muxconfig/theme.c
@@ -84,15 +84,27 @@ void apply_theme() {
     }
 
     struct big gradient_elements[] = {
-            {ui_lblTweakGeneral, theme.SYSTEM.BACKGROUND},
-            {ui_lblTheme,        theme.SYSTEM.BACKGROUND},
-            {ui_lblNetwork,      theme.SYSTEM.BACKGROUND},
-            {ui_lblServices,     theme.SYSTEM.BACKGROUND},
-            {ui_lblRTC,          theme.SYSTEM.BACKGROUND},
+            {ui_lblTweakGeneral, theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblTheme,        theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblNetwork,      theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblServices,     theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblRTC,          theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
     };
     for (size_t i = 0; i < sizeof(gradient_elements) / sizeof(gradient_elements[0]); ++i) {
         lv_obj_set_style_bg_grad_color(gradient_elements[i].e, lv_color_hex(gradient_elements[i].c),
                                        LV_PART_MAIN | LV_STATE_DEFAULT);
+    }
+
+    struct big gradient_focused_elements[] = {
+            {ui_lblTweakGeneral, theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblTheme,        theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblNetwork,      theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblServices,     theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblRTC,          theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+    };
+    for (size_t i = 0; i < sizeof(gradient_focused_elements) / sizeof(gradient_focused_elements[0]); ++i) {
+        lv_obj_set_style_bg_grad_color(gradient_focused_elements[i].e, lv_color_hex(gradient_focused_elements[i].c),
+                                       LV_PART_MAIN | LV_STATE_FOCUSED);
     }
 
     struct big indicator_elements[] = {

--- a/muxdevice/main.c
+++ b/muxdevice/main.c
@@ -582,6 +582,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrDevice);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxinfo/main.c
+++ b/muxinfo/main.c
@@ -517,6 +517,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrInfo);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxinfo/theme.c
+++ b/muxinfo/theme.c
@@ -82,14 +82,25 @@ void apply_theme() {
     }
 
     struct big gradient_elements[] = {
-            {ui_lblTracker, theme.SYSTEM.BACKGROUND},
-            {ui_lblTester,  theme.SYSTEM.BACKGROUND},
-            {ui_lblSystem,  theme.SYSTEM.BACKGROUND},
-            {ui_lblCredits, theme.SYSTEM.BACKGROUND},
+            {ui_lblTracker, theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblTester,  theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblSystem,  theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblCredits, theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
     };
     for (size_t i = 0; i < sizeof(gradient_elements) / sizeof(gradient_elements[0]); ++i) {
         lv_obj_set_style_bg_grad_color(gradient_elements[i].e, lv_color_hex(gradient_elements[i].c),
                                        LV_PART_MAIN | LV_STATE_DEFAULT);
+    }
+
+    struct big gradient_focused_elements[] = {
+            {ui_lblTracker, theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblTester,  theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblSystem,  theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblCredits, theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+    };
+    for (size_t i = 0; i < sizeof(gradient_focused_elements) / sizeof(gradient_focused_elements[0]); ++i) {
+        lv_obj_set_style_bg_grad_color(gradient_focused_elements[i].e, lv_color_hex(gradient_focused_elements[i].c),
+                                       LV_PART_MAIN | LV_STATE_FOCUSED);
     }
 
     struct big indicator_elements[] = {

--- a/muxinfo/theme.c
+++ b/muxinfo/theme.c
@@ -267,6 +267,28 @@ void apply_theme() {
                                     LV_PART_MAIN | LV_STATE_FOCUSED);
     }
 
+    struct small gradient_start_default_elements[] = {
+            {ui_lblTracker, theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblTester,  theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblSystem,  theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblCredits, theme.LIST_DEFAULT.GRADIENT_START},
+    };
+    for (size_t i = 0; i < sizeof(gradient_start_default_elements) / sizeof(gradient_start_default_elements[0]); ++i) {
+        lv_obj_set_style_bg_main_stop(gradient_start_default_elements[i].e, gradient_start_default_elements[i].c,
+                                      LV_PART_MAIN | LV_STATE_DEFAULT);
+    }
+
+    struct small gradient_start_focus_elements[] = {
+            {ui_lblTracker, theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblTester,  theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblSystem,  theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblCredits, theme.LIST_FOCUS.GRADIENT_START},
+    };
+    for (size_t i = 0; i < sizeof(gradient_start_focus_elements) / sizeof(gradient_start_focus_elements[0]); ++i) {
+        lv_obj_set_style_bg_main_stop(gradient_start_focus_elements[i].e, gradient_start_focus_elements[i].c,
+                                      LV_PART_MAIN | LV_STATE_FOCUSED);
+    }
+
     struct small gradient_stop_default_elements[] = {
             {ui_lblTracker, theme.LIST_DEFAULT.GRADIENT_STOP},
             {ui_lblTester,  theme.LIST_DEFAULT.GRADIENT_STOP},

--- a/muxinfo/theme.c
+++ b/muxinfo/theme.c
@@ -341,6 +341,10 @@ void apply_theme() {
             {ui_barProgressBrightness, theme.BAR.PROGRESS_RADIUS},
             {ui_pnlProgressVolume,     theme.BAR.PANEL_BORDER_RADIUS},
             {ui_barProgressVolume,     theme.BAR.PROGRESS_RADIUS},
+            {ui_lblTracker, theme.LIST_DEFAULT.RADIUS},
+            {ui_lblTester,  theme.LIST_DEFAULT.RADIUS},
+            {ui_lblSystem,  theme.LIST_DEFAULT.RADIUS},
+            {ui_lblCredits, theme.LIST_DEFAULT.RADIUS},
     };
     for (size_t i = 0; i < sizeof(radius_elements) / sizeof(radius_elements[0]); ++i) {
         lv_obj_set_style_radius(radius_elements[i].e, radius_elements[i].c,

--- a/muxlaunch/main.c
+++ b/muxlaunch/main.c
@@ -576,6 +576,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrLaunch);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxlaunch/theme.c
+++ b/muxlaunch/theme.c
@@ -349,6 +349,36 @@ void apply_theme() {
                                     LV_PART_MAIN | LV_STATE_FOCUSED);
     }
 
+    struct small gradient_start_default_elements[] = {
+            {ui_lblContent,    theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblFavourites, theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblHistory,    theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblApps,       theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblInfo,       theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblConfig,     theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblReboot,     theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblShutdown,   theme.LIST_DEFAULT.GRADIENT_START},
+    };
+    for (size_t i = 0; i < sizeof(gradient_start_default_elements) / sizeof(gradient_start_default_elements[0]); ++i) {
+        lv_obj_set_style_bg_main_stop(gradient_start_default_elements[i].e, gradient_start_default_elements[i].c,
+                                      LV_PART_MAIN | LV_STATE_DEFAULT);
+    }
+
+    struct small gradient_start_focus_elements[] = {
+            {ui_lblContent,    theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblFavourites, theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblHistory,    theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblApps,       theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblInfo,       theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblConfig,     theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblReboot,     theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblShutdown,   theme.LIST_FOCUS.GRADIENT_START},
+    };
+    for (size_t i = 0; i < sizeof(gradient_start_focus_elements) / sizeof(gradient_start_focus_elements[0]); ++i) {
+        lv_obj_set_style_bg_main_stop(gradient_start_focus_elements[i].e, gradient_start_focus_elements[i].c,
+                                      LV_PART_MAIN | LV_STATE_FOCUSED);
+    }
+
     struct small gradient_stop_default_elements[] = {
             {ui_lblContent,    theme.LIST_DEFAULT.GRADIENT_STOP},
             {ui_lblFavourites, theme.LIST_DEFAULT.GRADIENT_STOP},

--- a/muxlaunch/theme.c
+++ b/muxlaunch/theme.c
@@ -447,6 +447,14 @@ void apply_theme() {
             {ui_barProgressBrightness, theme.BAR.PROGRESS_RADIUS},
             {ui_pnlProgressVolume,     theme.BAR.PANEL_BORDER_RADIUS},
             {ui_barProgressVolume,     theme.BAR.PROGRESS_RADIUS},
+            {ui_lblContent,    theme.LIST_DEFAULT.RADIUS},
+            {ui_lblFavourites, theme.LIST_DEFAULT.RADIUS},
+            {ui_lblHistory,    theme.LIST_DEFAULT.RADIUS},
+            {ui_lblApps,       theme.LIST_DEFAULT.RADIUS},
+            {ui_lblInfo,       theme.LIST_DEFAULT.RADIUS},
+            {ui_lblConfig,     theme.LIST_DEFAULT.RADIUS},
+            {ui_lblReboot,     theme.LIST_DEFAULT.RADIUS},
+            {ui_lblShutdown,   theme.LIST_DEFAULT.RADIUS},
     };
     for (size_t i = 0; i < sizeof(radius_elements) / sizeof(radius_elements[0]); ++i) {
         lv_obj_set_style_radius(radius_elements[i].e, radius_elements[i].c,

--- a/muxlaunch/theme.c
+++ b/muxlaunch/theme.c
@@ -90,18 +90,33 @@ void apply_theme() {
     }
 
     struct big gradient_elements[] = {
-            {ui_lblContent,    theme.SYSTEM.BACKGROUND},
-            {ui_lblFavourites, theme.SYSTEM.BACKGROUND},
-            {ui_lblHistory,    theme.SYSTEM.BACKGROUND},
-            {ui_lblApps,       theme.SYSTEM.BACKGROUND},
-            {ui_lblInfo,       theme.SYSTEM.BACKGROUND},
-            {ui_lblConfig,     theme.SYSTEM.BACKGROUND},
-            {ui_lblReboot,     theme.SYSTEM.BACKGROUND},
-            {ui_lblShutdown,   theme.SYSTEM.BACKGROUND},
+            {ui_lblContent,    theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblFavourites, theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblHistory,    theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblApps,       theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblInfo,       theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblConfig,     theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblReboot,     theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblShutdown,   theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
     };
     for (size_t i = 0; i < sizeof(gradient_elements) / sizeof(gradient_elements[0]); ++i) {
         lv_obj_set_style_bg_grad_color(gradient_elements[i].e, lv_color_hex(gradient_elements[i].c),
                                        LV_PART_MAIN | LV_STATE_DEFAULT);
+    }
+
+    struct big gradient_focused_elements[] = {
+            {ui_lblContent,    theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblFavourites, theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblHistory,    theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblApps,       theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblInfo,       theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblConfig,     theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblReboot,     theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblShutdown,   theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+    };
+    for (size_t i = 0; i < sizeof(gradient_focused_elements) / sizeof(gradient_focused_elements[0]); ++i) {
+        lv_obj_set_style_bg_grad_color(gradient_focused_elements[i].e, lv_color_hex(gradient_focused_elements[i].c),
+                                       LV_PART_MAIN | LV_STATE_FOCUSED);
     }
 
     struct big indicator_elements[] = {

--- a/muxnetprofile/main.c
+++ b/muxnetprofile/main.c
@@ -147,7 +147,7 @@ void create_profile_items() {
 
             lv_obj_t * ui_pnlNetProfile = lv_obj_create(ui_pnlContent);
             lv_obj_set_width(ui_pnlNetProfile, device.MUX.WIDTH);
-            lv_obj_set_height(ui_pnlNetProfile, device.MUX.ITEM.HEIGHT);
+            lv_obj_set_height(ui_pnlNetProfile, theme.MUX.ITEM.HEIGHT);
             lv_obj_set_scrollbar_mode(ui_pnlNetProfile, LV_SCROLLBAR_MODE_OFF);
             lv_obj_set_style_align(ui_pnlNetProfile, LV_ALIGN_CENTER, LV_PART_MAIN | LV_STATE_DEFAULT);
             lv_obj_set_style_bg_opa(ui_pnlNetProfile, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -163,7 +163,7 @@ void create_profile_items() {
             lv_label_set_text(ui_lblNetProfileItem, base_filename);
 
             lv_obj_set_width(ui_lblNetProfileItem, device.MUX.WIDTH);
-            lv_obj_set_height(ui_lblNetProfileItem, device.MUX.ITEM.HEIGHT);
+            lv_obj_set_height(ui_lblNetProfileItem, theme.MUX.ITEM.HEIGHT);
 
             lv_obj_set_style_border_width(ui_lblNetProfileItem, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
             lv_obj_set_style_border_side(ui_lblNetProfileItem, LV_BORDER_SIDE_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -219,7 +219,7 @@ void create_profile_items() {
             lv_label_set_text(ui_lblNetProfileItemGlyph, "\uF53F");
 
             lv_obj_set_width(ui_lblNetProfileItemGlyph, device.MUX.WIDTH);
-            lv_obj_set_height(ui_lblNetProfileItemGlyph, device.MUX.ITEM.HEIGHT);
+            lv_obj_set_height(ui_lblNetProfileItemGlyph, theme.MUX.ITEM.HEIGHT);
 
             lv_obj_set_style_border_width(ui_lblNetProfileItemGlyph, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
 
@@ -263,16 +263,16 @@ void create_profile_items() {
 
 void list_nav_prev(int steps) {
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index >= 1 && ui_count > device.MUX.ITEM.COUNT) {
+        if (current_item_index >= 1 && ui_count > theme.MUX.ITEM.COUNT) {
             current_item_index--;
             nav_prev(ui_group, 1);
             nav_prev(ui_group_glyph, 1);
-            if (current_item_index > device.MUX.ITEM.PREV_LOW &&
-                current_item_index < (ui_count - device.MUX.ITEM.PREV_HIGH)) {
-                content_panel_y -= device.MUX.ITEM.PANEL;
+            if (current_item_index > theme.MUX.ITEM.PREV_LOW &&
+                current_item_index < (ui_count - theme.MUX.ITEM.PREV_HIGH)) {
+                content_panel_y -= theme.MUX.ITEM.PANEL;
                 lv_obj_scroll_to_y(ui_pnlContent, content_panel_y, LV_ANIM_OFF);
             }
-        } else if (current_item_index >= 0 && ui_count <= device.MUX.ITEM.COUNT) {
+        } else if (current_item_index >= 0 && ui_count <= theme.MUX.ITEM.COUNT) {
             if (current_item_index > 0) {
                 current_item_index--;
                 nav_prev(ui_group, 1);
@@ -287,18 +287,18 @@ void list_nav_prev(int steps) {
 
 void list_nav_next(int steps) {
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index < (ui_count - 1) && ui_count > device.MUX.ITEM.COUNT) {
+        if (current_item_index < (ui_count - 1) && ui_count > theme.MUX.ITEM.COUNT) {
             if (current_item_index < (ui_count - 1)) {
                 current_item_index++;
                 nav_next(ui_group, 1);
                 nav_next(ui_group_glyph, 1);
-                if (current_item_index >= device.MUX.ITEM.NEXT_HIGH &&
-                    current_item_index < (ui_count - device.MUX.ITEM.NEXT_LOW)) {
-                    content_panel_y += device.MUX.ITEM.PANEL;
+                if (current_item_index >= theme.MUX.ITEM.NEXT_HIGH &&
+                    current_item_index < (ui_count - theme.MUX.ITEM.NEXT_LOW)) {
+                    content_panel_y += theme.MUX.ITEM.PANEL;
                     lv_obj_scroll_to_y(ui_pnlContent, content_panel_y, LV_ANIM_OFF);
                 }
             }
-        } else if (current_item_index < ui_count && ui_count <= device.MUX.ITEM.COUNT) {
+        } else if (current_item_index < ui_count && ui_count <= theme.MUX.ITEM.COUNT) {
             if (current_item_index < (ui_count - 1)) {
                 current_item_index++;
                 nav_next(ui_group, 1);
@@ -377,12 +377,12 @@ void *joystick_task() {
                                     safe_quit = 1;
                                 } else if (ev.code == device.RAW_INPUT.BUTTON.L1) {
                                     if (current_item_index >= 0 && current_item_index < ui_count) {
-                                        list_nav_prev(device.MUX.ITEM.COUNT);
+                                        list_nav_prev(theme.MUX.ITEM.COUNT);
                                         lv_task_handler();
                                     }
                                 } else if (ev.code == device.RAW_INPUT.BUTTON.R1) {
                                     if (current_item_index >= 0 && current_item_index < ui_count) {
-                                        list_nav_next(device.MUX.ITEM.COUNT);
+                                        list_nav_next(theme.MUX.ITEM.COUNT);
                                         lv_task_handler();
                                     }
                                 }
@@ -408,7 +408,7 @@ void *joystick_task() {
                                  ev.value <= ((device.INPUT.AXIS_MIN >> 2) * -1)) ||
                                 ev.value == -1) {
                                 if (current_item_index == 0) {
-                                    int y = (ui_count - device.MUX.ITEM.COUNT) * device.MUX.ITEM.PANEL;
+                                    int y = (ui_count - theme.MUX.ITEM.COUNT) * theme.MUX.ITEM.PANEL;
                                     lv_obj_scroll_to_y(ui_pnlContent, y, LV_ANIM_OFF);
                                     content_panel_y = y;
                                     current_item_index = ui_count - 1;
@@ -446,7 +446,7 @@ void *joystick_task() {
             }
         }
 
-        if (ui_count > device.MUX.ITEM.COUNT && (JOYUP_pressed || JOYDOWN_pressed)) {
+        if (ui_count > theme.MUX.ITEM.COUNT && (JOYUP_pressed || JOYDOWN_pressed)) {
             if (nav_hold > 2) {
                 if (nav_delay > 16) {
                     nav_delay -= 16;
@@ -802,7 +802,7 @@ int main(int argc, char *argv[]) {
 
     create_profile_items();
 
-    if (ui_count > device.MUX.ITEM.COUNT) {
+    if (ui_count > theme.MUX.ITEM.COUNT) {
         lv_obj_t * last_item = lv_obj_get_child(ui_pnlContent, -1);
         lv_obj_set_height(last_item, lv_obj_get_height(last_item) + 50); // Don't bother asking...
     }

--- a/muxnetprofile/main.c
+++ b/muxnetprofile/main.c
@@ -167,8 +167,10 @@ void create_profile_items() {
 
             lv_obj_set_style_border_width(ui_lblNetProfileItem, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
             lv_obj_set_style_border_side(ui_lblNetProfileItem, LV_BORDER_SIDE_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
-            lv_obj_set_style_bg_grad_color(ui_lblNetProfileItem, lv_color_hex(theme.SYSTEM.BACKGROUND),
+            lv_obj_set_style_bg_grad_color(ui_lblNetProfileItem, lv_color_hex(theme.LIST_DEFAULT.BACKGROUND_GRADIENT),
                                            LV_PART_MAIN | LV_STATE_DEFAULT);
+            lv_obj_set_style_bg_grad_color(ui_lblNetProfileItem, lv_color_hex(theme.LIST_FOCUS.BACKGROUND_GRADIENT),
+                                           LV_PART_MAIN | LV_STATE_FOCUSED);
             lv_obj_set_style_bg_main_stop(ui_lblNetProfileItem, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
             lv_obj_set_style_bg_grad_dir(ui_lblNetProfileItem, LV_GRAD_DIR_HOR, LV_PART_MAIN | LV_STATE_DEFAULT);
 

--- a/muxnetprofile/main.c
+++ b/muxnetprofile/main.c
@@ -215,6 +215,8 @@ void create_profile_items() {
             lv_obj_set_style_text_line_space(ui_lblNetProfileItem, 16, LV_PART_MAIN | LV_STATE_DEFAULT);
             lv_label_set_long_mode(ui_lblNetProfileItem, LV_LABEL_LONG_WRAP);
 
+            lv_obj_set_style_radius(ui_lblNetProfileItem, theme.LIST_DEFAULT.RADIUS, LV_PART_MAIN | LV_STATE_DEFAULT);
+
             lv_obj_t * ui_lblNetProfileItemGlyph = lv_label_create(ui_pnlNetProfile);
             lv_label_set_text(ui_lblNetProfileItemGlyph, "\uF53F");
 

--- a/muxnetprofile/main.c
+++ b/muxnetprofile/main.c
@@ -751,6 +751,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrNetProfile);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxnetscan/main.c
+++ b/muxnetscan/main.c
@@ -176,6 +176,8 @@ void create_network_items() {
         lv_obj_set_style_text_line_space(ui_lblNetScanItem, 16, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_label_set_long_mode(ui_lblNetScanItem, LV_LABEL_LONG_WRAP);
 
+        lv_obj_set_style_radius(ui_lblNetScanItem, theme.LIST_DEFAULT.RADIUS, LV_PART_MAIN | LV_STATE_DEFAULT);
+
         lv_obj_t * ui_lblNetScanGlyph = lv_label_create(ui_pnlNetScan);
         lv_label_set_text(ui_lblNetScanGlyph, "\uF0AC");
 

--- a/muxnetscan/main.c
+++ b/muxnetscan/main.c
@@ -132,8 +132,10 @@ void create_network_items() {
 
         lv_obj_set_style_border_width(ui_lblNetScanItem, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_obj_set_style_border_side(ui_lblNetScanItem, LV_BORDER_SIDE_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
-        lv_obj_set_style_bg_grad_color(ui_lblNetScanItem, lv_color_hex(theme.SYSTEM.BACKGROUND),
+        lv_obj_set_style_bg_grad_color(ui_lblNetScanItem, lv_color_hex(theme.LIST_DEFAULT.BACKGROUND_GRADIENT),
                                        LV_PART_MAIN | LV_STATE_DEFAULT);
+        lv_obj_set_style_bg_grad_color(ui_lblNetScanItem, lv_color_hex(theme.LIST_FOCUS.BACKGROUND_GRADIENT),
+                                       LV_PART_MAIN | LV_STATE_FOCUSED);
         lv_obj_set_style_bg_main_stop(ui_lblNetScanItem, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_obj_set_style_bg_grad_dir(ui_lblNetScanItem, LV_GRAD_DIR_HOR, LV_PART_MAIN | LV_STATE_DEFAULT);
 

--- a/muxnetscan/main.c
+++ b/muxnetscan/main.c
@@ -705,6 +705,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrNetScan);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxnetscan/main.c
+++ b/muxnetscan/main.c
@@ -112,7 +112,7 @@ void create_network_items() {
 
         lv_obj_t * ui_pnlNetScan = lv_obj_create(ui_pnlContent);
         lv_obj_set_width(ui_pnlNetScan, device.MUX.WIDTH);
-        lv_obj_set_height(ui_pnlNetScan, device.MUX.ITEM.HEIGHT);
+        lv_obj_set_height(ui_pnlNetScan, theme.MUX.ITEM.HEIGHT);
         lv_obj_set_scrollbar_mode(ui_pnlNetScan, LV_SCROLLBAR_MODE_OFF);
         lv_obj_set_style_align(ui_pnlNetScan, LV_ALIGN_CENTER, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_obj_set_style_bg_opa(ui_pnlNetScan, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -128,7 +128,7 @@ void create_network_items() {
         lv_label_set_text(ui_lblNetScanItem, str_nonew(ssid));
 
         lv_obj_set_width(ui_lblNetScanItem, device.MUX.WIDTH);
-        lv_obj_set_height(ui_lblNetScanItem, device.MUX.ITEM.HEIGHT);
+        lv_obj_set_height(ui_lblNetScanItem, theme.MUX.ITEM.HEIGHT);
 
         lv_obj_set_style_border_width(ui_lblNetScanItem, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_obj_set_style_border_side(ui_lblNetScanItem, LV_BORDER_SIDE_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -180,7 +180,7 @@ void create_network_items() {
         lv_label_set_text(ui_lblNetScanGlyph, "\uF0AC");
 
         lv_obj_set_width(ui_lblNetScanGlyph, device.MUX.WIDTH);
-        lv_obj_set_height(ui_lblNetScanGlyph, device.MUX.ITEM.HEIGHT);
+        lv_obj_set_height(ui_lblNetScanGlyph, theme.MUX.ITEM.HEIGHT);
 
         lv_obj_set_style_border_width(ui_lblNetScanGlyph, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
 
@@ -214,16 +214,16 @@ void create_network_items() {
 
 void list_nav_prev(int steps) {
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index >= 1 && ui_count > device.MUX.ITEM.COUNT) {
+        if (current_item_index >= 1 && ui_count > theme.MUX.ITEM.COUNT) {
             current_item_index--;
             nav_prev(ui_group, 1);
             nav_prev(ui_group_glyph, 1);
-            if (current_item_index > device.MUX.ITEM.PREV_LOW &&
-                current_item_index < (ui_count - device.MUX.ITEM.PREV_HIGH)) {
-                content_panel_y -= device.MUX.ITEM.PANEL;
+            if (current_item_index > theme.MUX.ITEM.PREV_LOW &&
+                current_item_index < (ui_count - theme.MUX.ITEM.PREV_HIGH)) {
+                content_panel_y -= theme.MUX.ITEM.PANEL;
                 lv_obj_scroll_to_y(ui_pnlContent, content_panel_y, LV_ANIM_OFF);
             }
-        } else if (current_item_index >= 0 && ui_count <= device.MUX.ITEM.COUNT) {
+        } else if (current_item_index >= 0 && ui_count <= theme.MUX.ITEM.COUNT) {
             if (current_item_index > 0) {
                 current_item_index--;
                 nav_prev(ui_group, 1);
@@ -238,18 +238,18 @@ void list_nav_prev(int steps) {
 
 void list_nav_next(int steps) {
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index < (ui_count - 1) && ui_count > device.MUX.ITEM.COUNT) {
+        if (current_item_index < (ui_count - 1) && ui_count > theme.MUX.ITEM.COUNT) {
             if (current_item_index < (ui_count - 1)) {
                 current_item_index++;
                 nav_next(ui_group, 1);
                 nav_next(ui_group_glyph, 1);
-                if (current_item_index >= device.MUX.ITEM.NEXT_HIGH &&
-                    current_item_index < (ui_count - device.MUX.ITEM.NEXT_LOW)) {
-                    content_panel_y += device.MUX.ITEM.PANEL;
+                if (current_item_index >= theme.MUX.ITEM.NEXT_HIGH &&
+                    current_item_index < (ui_count - theme.MUX.ITEM.NEXT_LOW)) {
+                    content_panel_y += theme.MUX.ITEM.PANEL;
                     lv_obj_scroll_to_y(ui_pnlContent, content_panel_y, LV_ANIM_OFF);
                 }
             }
-        } else if (current_item_index < ui_count && ui_count <= device.MUX.ITEM.COUNT) {
+        } else if (current_item_index < ui_count && ui_count <= theme.MUX.ITEM.COUNT) {
             if (current_item_index < (ui_count - 1)) {
                 current_item_index++;
                 nav_next(ui_group, 1);
@@ -332,12 +332,12 @@ void *joystick_task() {
                                     safe_quit = 1;
                                 } else if (ev.code == device.RAW_INPUT.BUTTON.L1) {
                                     if (current_item_index >= 0 && current_item_index < ui_count) {
-                                        list_nav_prev(device.MUX.ITEM.COUNT);
+                                        list_nav_prev(theme.MUX.ITEM.COUNT);
                                         lv_task_handler();
                                     }
                                 } else if (ev.code == device.RAW_INPUT.BUTTON.R1) {
                                     if (current_item_index >= 0 && current_item_index < ui_count) {
-                                        list_nav_next(device.MUX.ITEM.COUNT);
+                                        list_nav_next(theme.MUX.ITEM.COUNT);
                                         lv_task_handler();
                                     }
                                 }
@@ -363,7 +363,7 @@ void *joystick_task() {
                                  ev.value <= ((device.INPUT.AXIS_MIN >> 2) * -1)) ||
                                 ev.value == -1) {
                                 if (current_item_index == 0) {
-                                    int y = (ui_count - device.MUX.ITEM.COUNT) * device.MUX.ITEM.PANEL;
+                                    int y = (ui_count - theme.MUX.ITEM.COUNT) * theme.MUX.ITEM.PANEL;
                                     lv_obj_scroll_to_y(ui_pnlContent, y, LV_ANIM_OFF);
                                     content_panel_y = y;
                                     current_item_index = ui_count - 1;
@@ -401,7 +401,7 @@ void *joystick_task() {
             }
         }
 
-        if (ui_count > device.MUX.ITEM.COUNT && (JOYUP_pressed || JOYDOWN_pressed)) {
+        if (ui_count > theme.MUX.ITEM.COUNT && (JOYUP_pressed || JOYDOWN_pressed)) {
             if (nav_hold > 2) {
                 if (nav_delay > 16) {
                     nav_delay -= 16;
@@ -756,7 +756,7 @@ int main(int argc, char *argv[]) {
 
     create_network_items();
 
-    if (ui_count > device.MUX.ITEM.COUNT) {
+    if (ui_count > theme.MUX.ITEM.COUNT) {
         lv_obj_t * last_item = lv_obj_get_child(ui_pnlContent, -1);
         lv_obj_set_height(last_item, lv_obj_get_height(last_item) + 50); // Don't bother asking...
     }

--- a/muxnetwork/main.c
+++ b/muxnetwork/main.c
@@ -1828,6 +1828,8 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrNetwork);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlHighlight);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxnetwork/theme.c
+++ b/muxnetwork/theme.c
@@ -548,6 +548,16 @@ void apply_theme() {
             {ui_barProgressBrightness, theme.BAR.PROGRESS_RADIUS},
             {ui_pnlProgressVolume,     theme.BAR.PANEL_BORDER_RADIUS},
             {ui_barProgressVolume,     theme.BAR.PROGRESS_RADIUS},
+            {ui_lblEnable,     theme.LIST_DEFAULT.RADIUS},
+            {ui_lblIdentifier, theme.LIST_DEFAULT.RADIUS},
+            {ui_lblPassword,   theme.LIST_DEFAULT.RADIUS},
+            {ui_lblType,       theme.LIST_DEFAULT.RADIUS},
+            {ui_lblAddress,    theme.LIST_DEFAULT.RADIUS},
+            {ui_lblSubnet,     theme.LIST_DEFAULT.RADIUS},
+            {ui_lblGateway,    theme.LIST_DEFAULT.RADIUS},
+            {ui_lblDNS,        theme.LIST_DEFAULT.RADIUS},
+            {ui_lblStatus,     theme.LIST_DEFAULT.RADIUS},
+            {ui_lblConnect,    theme.LIST_DEFAULT.RADIUS},
     };
     for (size_t i = 0; i < sizeof(radius_elements) / sizeof(radius_elements[0]); ++i) {
         lv_obj_set_style_radius(radius_elements[i].e, radius_elements[i].c,

--- a/muxnetwork/theme.c
+++ b/muxnetwork/theme.c
@@ -437,6 +437,40 @@ void apply_theme() {
                                     LV_PART_MAIN | LV_STATE_FOCUSED);
     }
 
+    struct small gradient_start_default_elements[] = {
+            {ui_lblEnable,     theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblIdentifier, theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblPassword,   theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblType,       theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblAddress,    theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblSubnet,     theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblGateway,    theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblDNS,        theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblStatus,     theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblConnect,    theme.LIST_DEFAULT.GRADIENT_START},
+    };
+    for (size_t i = 0; i < sizeof(gradient_start_default_elements) / sizeof(gradient_start_default_elements[0]); ++i) {
+        lv_obj_set_style_bg_main_stop(gradient_start_default_elements[i].e, gradient_start_default_elements[i].c,
+                                      LV_PART_MAIN | LV_STATE_DEFAULT);
+    }
+
+    struct small gradient_start_focus_elements[] = {
+            {ui_lblEnable,     theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblIdentifier, theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblPassword,   theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblType,       theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblAddress,    theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblSubnet,     theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblGateway,    theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblDNS,        theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblStatus,     theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblConnect,    theme.LIST_FOCUS.GRADIENT_START},
+    };
+    for (size_t i = 0; i < sizeof(gradient_start_focus_elements) / sizeof(gradient_start_focus_elements[0]); ++i) {
+        lv_obj_set_style_bg_main_stop(gradient_start_focus_elements[i].e, gradient_start_focus_elements[i].c,
+                                      LV_PART_MAIN | LV_STATE_FOCUSED);
+    }
+
     struct small gradient_stop_default_elements[] = {
             {ui_lblEnable,     theme.LIST_DEFAULT.GRADIENT_STOP},
             {ui_lblIdentifier, theme.LIST_DEFAULT.GRADIENT_STOP},

--- a/muxnetwork/theme.c
+++ b/muxnetwork/theme.c
@@ -95,20 +95,37 @@ void apply_theme() {
     }
 
     struct big gradient_elements[] = {
-            {ui_lblEnable,     theme.SYSTEM.BACKGROUND},
-            {ui_lblIdentifier, theme.SYSTEM.BACKGROUND},
-            {ui_lblPassword,   theme.SYSTEM.BACKGROUND},
-            {ui_lblType,       theme.SYSTEM.BACKGROUND},
-            {ui_lblAddress,    theme.SYSTEM.BACKGROUND},
-            {ui_lblSubnet,     theme.SYSTEM.BACKGROUND},
-            {ui_lblGateway,    theme.SYSTEM.BACKGROUND},
-            {ui_lblDNS,        theme.SYSTEM.BACKGROUND},
-            {ui_lblStatus,     theme.SYSTEM.BACKGROUND},
-            {ui_lblConnect,    theme.SYSTEM.BACKGROUND},
+            {ui_lblEnable,     theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblIdentifier, theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblPassword,   theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblType,       theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblAddress,    theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblSubnet,     theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblGateway,    theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblDNS,        theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblStatus,     theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblConnect,    theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
     };
     for (size_t i = 0; i < sizeof(gradient_elements) / sizeof(gradient_elements[0]); ++i) {
         lv_obj_set_style_bg_grad_color(gradient_elements[i].e, lv_color_hex(gradient_elements[i].c),
                                        LV_PART_MAIN | LV_STATE_DEFAULT);
+    }
+
+    struct big gradient_focused_elements[] = {
+            {ui_lblEnable,     theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblIdentifier, theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblPassword,   theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblType,       theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblAddress,    theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblSubnet,     theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblGateway,    theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblDNS,        theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblStatus,     theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblConnect,    theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+    };
+    for (size_t i = 0; i < sizeof(gradient_focused_elements) / sizeof(gradient_focused_elements[0]); ++i) {
+        lv_obj_set_style_bg_grad_color(gradient_focused_elements[i].e, lv_color_hex(gradient_focused_elements[i].c),
+                                       LV_PART_MAIN | LV_STATE_FOCUSED);
     }
 
     struct big indicator_elements[] = {

--- a/muxplore/main.c
+++ b/muxplore/main.c
@@ -454,7 +454,7 @@ void add_directory_and_file_names(const char *base_dir, char ***dir_names, int *
 void gen_label(int item_type, char *item_glyph, char *item_text, int glyph_pad) {
     lv_obj_t * ui_pnlExplore = lv_obj_create(ui_pnlContent);
     lv_obj_set_width(ui_pnlExplore, device.MUX.WIDTH);
-    lv_obj_set_height(ui_pnlExplore, device.MUX.ITEM.HEIGHT);
+    lv_obj_set_height(ui_pnlExplore, theme.MUX.ITEM.HEIGHT);
     lv_obj_set_scrollbar_mode(ui_pnlExplore, LV_SCROLLBAR_MODE_OFF);
     lv_obj_set_style_align(ui_pnlExplore, LV_ALIGN_CENTER, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_bg_opa(ui_pnlExplore, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -473,13 +473,17 @@ void gen_label(int item_type, char *item_glyph, char *item_text, int glyph_pad) 
     }
     lv_label_set_text(ui_lblExploreItem, item_text);
 
-    lv_obj_set_width(ui_lblExploreItem, device.MUX.WIDTH);
-    lv_obj_set_height(ui_lblExploreItem, device.MUX.ITEM.HEIGHT);
+    lv_obj_set_width(ui_lblExploreItem, theme.MISC.CONTENT.WIDTH);
+    lv_obj_set_height(ui_lblExploreItem, theme.MUX.ITEM.HEIGHT);
 
     lv_obj_set_style_border_width(ui_lblExploreItem, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_border_side(ui_lblExploreItem, LV_BORDER_SIDE_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
-    lv_obj_set_style_bg_grad_color(ui_lblExploreItem, lv_color_hex(theme.SYSTEM.BACKGROUND),
+    uint32_t DEFAULT_BACKGROUND_GRADIENT = (theme.LIST_DEFAULT.GRADIENT_START == 255) ? theme.LIST_DEFAULT.BACKGROUND : theme.SYSTEM.BACKGROUND;
+    lv_obj_set_style_bg_grad_color(ui_lblExploreItem, lv_color_hex(DEFAULT_BACKGROUND_GRADIENT),
                                    LV_PART_MAIN | LV_STATE_DEFAULT);
+    uint32_t FOCUS_BACKGROUND_GRADIENT = (theme.LIST_FOCUS.GRADIENT_START == 255) ? theme.LIST_FOCUS.BACKGROUND : theme.SYSTEM.BACKGROUND;
+    lv_obj_set_style_bg_grad_color(ui_lblExploreItem, lv_color_hex(FOCUS_BACKGROUND_GRADIENT),
+                                   LV_PART_MAIN | LV_STATE_FOCUSED);     
     lv_obj_set_style_bg_main_stop(ui_lblExploreItem, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_bg_grad_dir(ui_lblExploreItem, LV_GRAD_DIR_HOR, LV_PART_MAIN | LV_STATE_DEFAULT);
 
@@ -516,11 +520,13 @@ void gen_label(int item_type, char *item_glyph, char *item_text, int glyph_pad) 
     lv_obj_set_style_text_line_space(ui_lblExploreItem, 16, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_label_set_long_mode(ui_lblExploreItem, LV_LABEL_LONG_WRAP);
 
+    lv_obj_set_style_radius(ui_lblExploreItem, theme.LIST_DEFAULT.RADIUS, LV_PART_MAIN | LV_STATE_DEFAULT);
+
     lv_obj_t * ui_lblExploreItemGlyph = lv_label_create(ui_pnlExplore);
     lv_label_set_text(ui_lblExploreItemGlyph, item_glyph);
 
     lv_obj_set_width(ui_lblExploreItemGlyph, device.MUX.WIDTH);
-    lv_obj_set_height(ui_lblExploreItemGlyph, device.MUX.ITEM.HEIGHT);
+    lv_obj_set_height(ui_lblExploreItemGlyph, theme.MUX.ITEM.HEIGHT);
 
     lv_obj_set_style_border_width(ui_lblExploreItemGlyph, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
 
@@ -1021,16 +1027,16 @@ int load_cached_content(const char *content_name, char *cache_type, int add_favo
 
 void list_nav_prev(int steps) {
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index >= 1 && ui_count > device.MUX.ITEM.COUNT) {
+        if (current_item_index >= 1 && ui_count > theme.MUX.ITEM.COUNT) {
             current_item_index--;
             nav_prev(ui_group, 1);
             nav_prev(ui_group_glyph, 1);
-            if (current_item_index > device.MUX.ITEM.PREV_LOW &&
-                current_item_index < (ui_count - device.MUX.ITEM.PREV_HIGH)) {
-                content_panel_y -= device.MUX.ITEM.PANEL;
+            if (current_item_index > theme.MUX.ITEM.PREV_LOW &&
+                current_item_index < (ui_count - theme.MUX.ITEM.PREV_HIGH)) {
+                content_panel_y -= theme.MUX.ITEM.PANEL;
                 lv_obj_scroll_to_y(ui_pnlContent, content_panel_y, LV_ANIM_OFF);
             }
-        } else if (current_item_index >= 0 && ui_count <= device.MUX.ITEM.COUNT) {
+        } else if (current_item_index >= 0 && ui_count <= theme.MUX.ITEM.COUNT) {
             if (current_item_index > 0) {
                 current_item_index--;
                 nav_prev(ui_group, 1);
@@ -1045,18 +1051,18 @@ void list_nav_prev(int steps) {
 
 void list_nav_next(int steps) {
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index < (ui_count - 1) && ui_count > device.MUX.ITEM.COUNT) {
+        if (current_item_index < (ui_count - 1) && ui_count > theme.MUX.ITEM.COUNT) {
             if (current_item_index < (ui_count - 1)) {
                 current_item_index++;
                 nav_next(ui_group, 1);
                 nav_next(ui_group_glyph, 1);
-                if (current_item_index >= device.MUX.ITEM.NEXT_HIGH &&
-                    current_item_index < (ui_count - device.MUX.ITEM.NEXT_LOW)) {
-                    content_panel_y += device.MUX.ITEM.PANEL;
+                if (current_item_index >= theme.MUX.ITEM.NEXT_HIGH &&
+                    current_item_index < (ui_count - theme.MUX.ITEM.NEXT_LOW)) {
+                    content_panel_y += theme.MUX.ITEM.PANEL;
                     lv_obj_scroll_to_y(ui_pnlContent, content_panel_y, LV_ANIM_OFF);
                 }
             }
-        } else if (current_item_index < ui_count && ui_count <= device.MUX.ITEM.COUNT) {
+        } else if (current_item_index < ui_count && ui_count <= theme.MUX.ITEM.COUNT) {
             if (current_item_index < (ui_count - 1)) {
                 current_item_index++;
                 nav_next(ui_group, 1);
@@ -1464,12 +1470,12 @@ void *joystick_task() {
                                     }
                                 } else if (ev.code == device.RAW_INPUT.BUTTON.L1) {
                                     if (current_item_index != 0 && current_item_index < ui_count) {
-                                        list_nav_prev(device.MUX.ITEM.COUNT);
+                                        list_nav_prev(theme.MUX.ITEM.COUNT);
                                         lv_task_handler();
                                     }
                                 } else if (ev.code == device.RAW_INPUT.BUTTON.R1) {
                                     if (current_item_index >= 0 && current_item_index != ui_count - 1) {
-                                        list_nav_next(device.MUX.ITEM.COUNT);
+                                        list_nav_next(theme.MUX.ITEM.COUNT);
                                         lv_task_handler();
                                     }
                                 }
@@ -1514,7 +1520,7 @@ void *joystick_task() {
                                  ev.value <= ((device.INPUT.AXIS_MIN >> 2) * -1)) ||
                                 ev.value == -1) {
                                 if (current_item_index == 0) {
-                                    int y = (ui_count - device.MUX.ITEM.COUNT) * device.MUX.ITEM.PANEL;
+                                    int y = (ui_count - theme.MUX.ITEM.COUNT) * theme.MUX.ITEM.PANEL;
                                     lv_obj_scroll_to_y(ui_pnlContent, y, LV_ANIM_OFF);
                                     content_panel_y = y;
                                     current_item_index = ui_count - 1;
@@ -1555,7 +1561,7 @@ void *joystick_task() {
             }
         }
 
-        if (ui_count > device.MUX.ITEM.COUNT && (JOYUP_pressed || JOYDOWN_pressed)) {
+        if (ui_count > theme.MUX.ITEM.COUNT && (JOYUP_pressed || JOYDOWN_pressed)) {
             if (nav_hold > 2) {
                 if (nav_delay > 16) {
                     nav_delay -= 16;
@@ -2180,7 +2186,7 @@ int main(int argc, char *argv[]) {
 
     pthread_join(gen_item_thread, NULL);
     if (ui_count > 0) {
-        if (ui_count > device.MUX.ITEM.COUNT) {
+        if (ui_count > theme.MUX.ITEM.COUNT) {
             lv_obj_t * last_item = lv_obj_get_child(ui_pnlContent, -1);
             lv_obj_set_height(last_item, lv_obj_get_height(last_item) + 50); // Don't bother asking...
         }

--- a/muxplore/main.c
+++ b/muxplore/main.c
@@ -478,11 +478,9 @@ void gen_label(int item_type, char *item_glyph, char *item_text, int glyph_pad) 
 
     lv_obj_set_style_border_width(ui_lblExploreItem, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_border_side(ui_lblExploreItem, LV_BORDER_SIDE_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
-    uint32_t DEFAULT_BACKGROUND_GRADIENT = (theme.LIST_DEFAULT.GRADIENT_START == 255) ? theme.LIST_DEFAULT.BACKGROUND : theme.SYSTEM.BACKGROUND;
-    lv_obj_set_style_bg_grad_color(ui_lblExploreItem, lv_color_hex(DEFAULT_BACKGROUND_GRADIENT),
+    lv_obj_set_style_bg_grad_color(ui_lblExploreItem, lv_color_hex(theme.LIST_DEFAULT.BACKGROUND_GRADIENT),
                                    LV_PART_MAIN | LV_STATE_DEFAULT);
-    uint32_t FOCUS_BACKGROUND_GRADIENT = (theme.LIST_FOCUS.GRADIENT_START == 255) ? theme.LIST_FOCUS.BACKGROUND : theme.SYSTEM.BACKGROUND;
-    lv_obj_set_style_bg_grad_color(ui_lblExploreItem, lv_color_hex(FOCUS_BACKGROUND_GRADIENT),
+    lv_obj_set_style_bg_grad_color(ui_lblExploreItem, lv_color_hex(theme.LIST_FOCUS.BACKGROUND_GRADIENT),
                                    LV_PART_MAIN | LV_STATE_FOCUSED);     
     lv_obj_set_style_bg_main_stop(ui_lblExploreItem, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_bg_grad_dir(ui_lblExploreItem, LV_GRAD_DIR_HOR, LV_PART_MAIN | LV_STATE_DEFAULT);

--- a/muxplore/main.c
+++ b/muxplore/main.c
@@ -1781,6 +1781,7 @@ void init_elements() {
 
 void init_fonts() {
     load_font_text(mux_prog, ui_scrExplore);
+    load_font_section(mux_prog, FONT_PANEL_FOLDER, ui_pnlContent);
 }
 
 void glyph_task() {

--- a/muxplore/theme.c
+++ b/muxplore/theme.c
@@ -353,6 +353,9 @@ void apply_theme() {
                                   LV_PART_MAIN | LV_STATE_DEFAULT);
     }
 
+    lv_obj_set_height(ui_pnlContent, theme.MISC.CONTENT.HEIGHT);
+    lv_obj_set_y(ui_pnlContent, 44 + theme.MISC.CONTENT.PADDING_TOP);
+
     struct small datetime_pad_left_element[] = {
             {ui_lblDatetime, theme.DATETIME.PADDING_LEFT},
     };

--- a/muxplore/theme.c
+++ b/muxplore/theme.c
@@ -353,14 +353,6 @@ void apply_theme() {
                                   LV_PART_MAIN | LV_STATE_DEFAULT);
     }
 
-    struct small content_pad_right_element[] = {
-            {ui_pnlContent, theme.MISC.CONTENT.WIDTH},
-    };
-    for (size_t i = 0; i < sizeof(content_pad_right_element) / sizeof(content_pad_right_element[0]); ++i) {
-        lv_obj_set_style_width(content_pad_right_element[i].e, content_pad_right_element[i].c,
-                               LV_PART_MAIN | LV_STATE_DEFAULT);
-    }
-
     struct small datetime_pad_left_element[] = {
             {ui_lblDatetime, theme.DATETIME.PADDING_LEFT},
     };

--- a/muxplore/ui/ui_scrExplore.c
+++ b/muxplore/ui/ui_scrExplore.c
@@ -45,9 +45,9 @@ void ui_scrExplore_screen_init(void)
     lv_obj_set_height(ui_pnlContent, 392);
     lv_obj_set_x(ui_pnlContent, 0);
     lv_obj_set_y(ui_pnlContent, 44);
-    lv_obj_set_align(ui_pnlContent, LV_ALIGN_TOP_MID);
+    lv_obj_set_align(ui_pnlContent, LV_ALIGN_TOP_LEFT);
     lv_obj_set_flex_flow(ui_pnlContent, LV_FLEX_FLOW_ROW_WRAP);
-    lv_obj_set_flex_align(ui_pnlContent, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_START);
+    lv_obj_set_flex_align(ui_pnlContent, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
     lv_obj_clear_flag(ui_pnlContent, LV_OBJ_FLAG_SCROLL_ELASTIC | LV_OBJ_FLAG_SCROLL_CHAIN);      /// Flags
     lv_obj_set_scrollbar_mode(ui_pnlContent, LV_SCROLLBAR_MODE_ON);
     lv_obj_set_scroll_dir(ui_pnlContent, LV_DIR_VER);

--- a/muxrtc/main.c
+++ b/muxrtc/main.c
@@ -901,6 +901,8 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrRTC);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlHighlight);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxrtc/theme.c
+++ b/muxrtc/theme.c
@@ -88,17 +88,31 @@ void apply_theme() {
     }
 
     struct big gradient_elements[] = {
-            {ui_lblYear,     theme.SYSTEM.BACKGROUND},
-            {ui_lblMonth,    theme.SYSTEM.BACKGROUND},
-            {ui_lblDay,      theme.SYSTEM.BACKGROUND},
-            {ui_lblHour,     theme.SYSTEM.BACKGROUND},
-            {ui_lblMinute,   theme.SYSTEM.BACKGROUND},
-            {ui_lblNotation, theme.SYSTEM.BACKGROUND},
-            {ui_lblTimezone, theme.SYSTEM.BACKGROUND},
+            {ui_lblYear,     theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblMonth,    theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblDay,      theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblHour,     theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblMinute,   theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblNotation, theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblTimezone, theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
     };
     for (size_t i = 0; i < sizeof(gradient_elements) / sizeof(gradient_elements[0]); ++i) {
         lv_obj_set_style_bg_grad_color(gradient_elements[i].e, lv_color_hex(gradient_elements[i].c),
                                        LV_PART_MAIN | LV_STATE_DEFAULT);
+    }
+
+    struct big gradient_focused_elements[] = {
+            {ui_lblYear,     theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblMonth,    theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblDay,      theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblHour,     theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblMinute,   theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblNotation, theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblTimezone, theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+    };
+    for (size_t i = 0; i < sizeof(gradient_focused_elements) / sizeof(gradient_focused_elements[0]); ++i) {
+        lv_obj_set_style_bg_grad_color(gradient_focused_elements[i].e, lv_color_hex(gradient_focused_elements[i].c),
+                                       LV_PART_MAIN | LV_STATE_FOCUSED);
     }
 
     struct big indicator_elements[] = {

--- a/muxrtc/theme.c
+++ b/muxrtc/theme.c
@@ -430,6 +430,13 @@ void apply_theme() {
             {ui_barProgressBrightness, theme.BAR.PROGRESS_RADIUS},
             {ui_pnlProgressVolume,     theme.BAR.PANEL_BORDER_RADIUS},
             {ui_barProgressVolume,     theme.BAR.PROGRESS_RADIUS},
+            {ui_lblYear,     theme.LIST_DEFAULT.RADIUS},
+            {ui_lblMonth,    theme.LIST_DEFAULT.RADIUS},
+            {ui_lblDay,      theme.LIST_DEFAULT.RADIUS},
+            {ui_lblHour,     theme.LIST_DEFAULT.RADIUS},
+            {ui_lblMinute,   theme.LIST_DEFAULT.RADIUS},
+            {ui_lblNotation, theme.LIST_DEFAULT.RADIUS},
+            {ui_lblTimezone, theme.LIST_DEFAULT.RADIUS},
     };
     for (size_t i = 0; i < sizeof(radius_elements) / sizeof(radius_elements[0]); ++i) {
         lv_obj_set_style_radius(radius_elements[i].e, radius_elements[i].c,

--- a/muxrtc/theme.c
+++ b/muxrtc/theme.c
@@ -338,6 +338,34 @@ void apply_theme() {
                                     LV_PART_MAIN | LV_STATE_FOCUSED);
     }
 
+    struct small gradient_start_default_elements[] = {
+            {ui_lblYear,     theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblMonth,    theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblDay,      theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblHour,     theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblMinute,   theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblNotation, theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblTimezone, theme.LIST_DEFAULT.GRADIENT_START},
+    };
+    for (size_t i = 0; i < sizeof(gradient_start_default_elements) / sizeof(gradient_start_default_elements[0]); ++i) {
+        lv_obj_set_style_bg_main_stop(gradient_start_default_elements[i].e, gradient_start_default_elements[i].c,
+                                      LV_PART_MAIN | LV_STATE_DEFAULT);
+    }
+
+    struct small gradient_start_focus_elements[] = {
+            {ui_lblYear,     theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblMonth,    theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblDay,      theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblHour,     theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblMinute,   theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblNotation, theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblTimezone, theme.LIST_FOCUS.GRADIENT_START},
+    };
+    for (size_t i = 0; i < sizeof(gradient_start_focus_elements) / sizeof(gradient_start_focus_elements[0]); ++i) {
+        lv_obj_set_style_bg_main_stop(gradient_start_focus_elements[i].e, gradient_start_focus_elements[i].c,
+                                      LV_PART_MAIN | LV_STATE_FOCUSED);
+    }
+
     struct small gradient_stop_default_elements[] = {
             {ui_lblYear,     theme.LIST_DEFAULT.GRADIENT_STOP},
             {ui_lblMonth,    theme.LIST_DEFAULT.GRADIENT_STOP},

--- a/muxstorage/main.c
+++ b/muxstorage/main.c
@@ -772,6 +772,8 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrStorage);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlHighlight);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxstorage/theme.c
+++ b/muxstorage/theme.c
@@ -90,18 +90,33 @@ void apply_theme() {
     }
 
     struct big gradient_elements[] = {
-            {ui_lblBIOS,       theme.SYSTEM.BACKGROUND},
-            {ui_lblConfig,     theme.SYSTEM.BACKGROUND},
-            {ui_lblCatalogue,  theme.SYSTEM.BACKGROUND},
-            {ui_lblFav,        theme.SYSTEM.BACKGROUND},
-            {ui_lblMusic,      theme.SYSTEM.BACKGROUND},
-            {ui_lblSave,       theme.SYSTEM.BACKGROUND},
-            {ui_lblScreenshot, theme.SYSTEM.BACKGROUND},
-            {ui_lblTheme,      theme.SYSTEM.BACKGROUND},
+            {ui_lblBIOS,       theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblConfig,     theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblCatalogue,  theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblFav,        theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblMusic,      theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblSave,       theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblScreenshot, theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblTheme,      theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
     };
     for (size_t i = 0; i < sizeof(gradient_elements) / sizeof(gradient_elements[0]); ++i) {
         lv_obj_set_style_bg_grad_color(gradient_elements[i].e, lv_color_hex(gradient_elements[i].c),
                                        LV_PART_MAIN | LV_STATE_DEFAULT);
+    }
+
+    struct big gradient_focused_elements[] = {
+            {ui_lblBIOS,       theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblConfig,     theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblCatalogue,  theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblFav,        theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblMusic,      theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblSave,       theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblScreenshot, theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblTheme,      theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+    };
+    for (size_t i = 0; i < sizeof(gradient_focused_elements) / sizeof(gradient_focused_elements[0]); ++i) {
+        lv_obj_set_style_bg_grad_color(gradient_focused_elements[i].e, lv_color_hex(gradient_focused_elements[i].c),
+                                       LV_PART_MAIN | LV_STATE_FOCUSED);
     }
 
     struct big indicator_elements[] = {

--- a/muxstorage/theme.c
+++ b/muxstorage/theme.c
@@ -455,6 +455,14 @@ void apply_theme() {
             {ui_barProgressBrightness, theme.BAR.PROGRESS_RADIUS},
             {ui_pnlProgressVolume,     theme.BAR.PANEL_BORDER_RADIUS},
             {ui_barProgressVolume,     theme.BAR.PROGRESS_RADIUS},
+            {ui_lblBIOS,       theme.LIST_DEFAULT.RADIUS},
+            {ui_lblConfig,     theme.LIST_DEFAULT.RADIUS},
+            {ui_lblCatalogue,  theme.LIST_DEFAULT.RADIUS},
+            {ui_lblFav,        theme.LIST_DEFAULT.RADIUS},
+            {ui_lblMusic,      theme.LIST_DEFAULT.RADIUS},
+            {ui_lblSave,       theme.LIST_DEFAULT.RADIUS},
+            {ui_lblScreenshot, theme.LIST_DEFAULT.RADIUS},
+            {ui_lblTheme,      theme.LIST_DEFAULT.RADIUS},
     };
     for (size_t i = 0; i < sizeof(radius_elements) / sizeof(radius_elements[0]); ++i) {
         lv_obj_set_style_radius(radius_elements[i].e, radius_elements[i].c,

--- a/muxsysinfo/main.c
+++ b/muxsysinfo/main.c
@@ -635,6 +635,8 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrSysInfo);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlHighlight);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxsysinfo/theme.c
+++ b/muxsysinfo/theme.c
@@ -96,21 +96,39 @@ void apply_theme() {
     }
 
     struct big gradient_elements[] = {
-            {ui_lblVersion,    theme.SYSTEM.BACKGROUND},
-            {ui_lblKernel,     theme.SYSTEM.BACKGROUND},
-            {ui_lblUptime,     theme.SYSTEM.BACKGROUND},
-            {ui_lblCPU,        theme.SYSTEM.BACKGROUND},
-            {ui_lblSpeed,      theme.SYSTEM.BACKGROUND},
-            {ui_lblGovernor,   theme.SYSTEM.BACKGROUND},
-            {ui_lblMemory,     theme.SYSTEM.BACKGROUND},
-            {ui_lblTemp,       theme.SYSTEM.BACKGROUND},
-            {ui_lblServices,   theme.SYSTEM.BACKGROUND},
-            {ui_lblBatteryCap, theme.SYSTEM.BACKGROUND},
-            {ui_lblVoltage,    theme.SYSTEM.BACKGROUND},
+            {ui_lblVersion,    theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblKernel,     theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblUptime,     theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblCPU,        theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblSpeed,      theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblGovernor,   theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblMemory,     theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblTemp,       theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblServices,   theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblBatteryCap, theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblVoltage,    theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
     };
     for (size_t i = 0; i < sizeof(gradient_elements) / sizeof(gradient_elements[0]); ++i) {
         lv_obj_set_style_bg_grad_color(gradient_elements[i].e, lv_color_hex(gradient_elements[i].c),
                                        LV_PART_MAIN | LV_STATE_DEFAULT);
+    }
+
+    struct big gradient_focused_elements[] = {
+            {ui_lblVersion,    theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblKernel,     theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblUptime,     theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblCPU,        theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblSpeed,      theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblGovernor,   theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblMemory,     theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblTemp,       theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblServices,   theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblBatteryCap, theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblVoltage,    theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+    };
+    for (size_t i = 0; i < sizeof(gradient_focused_elements) / sizeof(gradient_focused_elements[0]); ++i) {
+        lv_obj_set_style_bg_grad_color(gradient_focused_elements[i].e, lv_color_hex(gradient_focused_elements[i].c),
+                                       LV_PART_MAIN | LV_STATE_FOCUSED);
     }
 
     struct big indicator_elements[] = {

--- a/muxsysinfo/theme.c
+++ b/muxsysinfo/theme.c
@@ -530,6 +530,17 @@ void apply_theme() {
             {ui_barProgressBrightness, theme.BAR.PROGRESS_RADIUS},
             {ui_pnlProgressVolume,     theme.BAR.PANEL_BORDER_RADIUS},
             {ui_barProgressVolume,     theme.BAR.PROGRESS_RADIUS},
+            {ui_lblVersion,    theme.LIST_DEFAULT.RADIUS},
+            {ui_lblKernel,     theme.LIST_DEFAULT.RADIUS},
+            {ui_lblUptime,     theme.LIST_DEFAULT.RADIUS},
+            {ui_lblCPU,        theme.LIST_DEFAULT.RADIUS},
+            {ui_lblSpeed,      theme.LIST_DEFAULT.RADIUS},
+            {ui_lblGovernor,   theme.LIST_DEFAULT.RADIUS},
+            {ui_lblMemory,     theme.LIST_DEFAULT.RADIUS},
+            {ui_lblTemp,       theme.LIST_DEFAULT.RADIUS},
+            {ui_lblServices,   theme.LIST_DEFAULT.RADIUS},
+            {ui_lblBatteryCap, theme.LIST_DEFAULT.RADIUS},
+            {ui_lblVoltage,    theme.LIST_DEFAULT.RADIUS},
     };
     for (size_t i = 0; i < sizeof(radius_elements) / sizeof(radius_elements[0]); ++i) {
         lv_obj_set_style_radius(radius_elements[i].e, radius_elements[i].c,

--- a/muxsysinfo/theme.c
+++ b/muxsysinfo/theme.c
@@ -414,6 +414,42 @@ void apply_theme() {
                                     LV_PART_MAIN | LV_STATE_FOCUSED);
     }
 
+    struct small gradient_start_default_elements[] = {
+            {ui_lblVersion,    theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblKernel,     theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblUptime,     theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblCPU,        theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblSpeed,      theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblGovernor,   theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblMemory,     theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblTemp,       theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblServices,   theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblBatteryCap, theme.LIST_DEFAULT.GRADIENT_START},
+            {ui_lblVoltage,    theme.LIST_DEFAULT.GRADIENT_START},
+    };
+    for (size_t i = 0; i < sizeof(gradient_start_default_elements) / sizeof(gradient_start_default_elements[0]); ++i) {
+        lv_obj_set_style_bg_main_stop(gradient_start_default_elements[i].e, gradient_start_default_elements[i].c,
+                                      LV_PART_MAIN | LV_STATE_DEFAULT);
+    }
+
+    struct small gradient_start_focus_elements[] = {
+            {ui_lblVersion,    theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblKernel,     theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblUptime,     theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblCPU,        theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblSpeed,      theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblGovernor,   theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblMemory,     theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblTemp,       theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblServices,   theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblBatteryCap, theme.LIST_FOCUS.GRADIENT_START},
+            {ui_lblVoltage,    theme.LIST_FOCUS.GRADIENT_START},
+    };
+    for (size_t i = 0; i < sizeof(gradient_start_focus_elements) / sizeof(gradient_start_focus_elements[0]); ++i) {
+        lv_obj_set_style_bg_main_stop(gradient_start_focus_elements[i].e, gradient_start_focus_elements[i].c,
+                                      LV_PART_MAIN | LV_STATE_FOCUSED);
+    }
+
     struct small gradient_stop_default_elements[] = {
             {ui_lblVersion,    theme.LIST_DEFAULT.GRADIENT_STOP},
             {ui_lblKernel,     theme.LIST_DEFAULT.GRADIENT_STOP},

--- a/muxtask/main.c
+++ b/muxtask/main.c
@@ -191,6 +191,8 @@ void create_task_items() {
         lv_obj_set_style_text_line_space(ui_lblTaskItem, 16, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_label_set_long_mode(ui_lblTaskItem, LV_LABEL_LONG_WRAP);
 
+        lv_obj_set_style_radius(ui_lblTaskItem, theme.LIST_DEFAULT.RADIUS, LV_PART_MAIN | LV_STATE_DEFAULT);
+
         lv_obj_t * ui_lblTaskItemGlyph = lv_label_create(ui_pnlTask);
         lv_label_set_text(ui_lblTaskItemGlyph, "\uF56E");
 

--- a/muxtask/main.c
+++ b/muxtask/main.c
@@ -127,7 +127,7 @@ void create_task_items() {
 
         lv_obj_t * ui_pnlTask = lv_obj_create(ui_pnlContent);
         lv_obj_set_width(ui_pnlTask, device.MUX.WIDTH);
-        lv_obj_set_height(ui_pnlTask, device.MUX.ITEM.HEIGHT);
+        lv_obj_set_height(ui_pnlTask, theme.MUX.ITEM.HEIGHT);
         lv_obj_set_scrollbar_mode(ui_pnlTask, LV_SCROLLBAR_MODE_OFF);
         lv_obj_set_style_align(ui_pnlTask, LV_ALIGN_CENTER, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_obj_set_style_bg_opa(ui_pnlTask, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -143,7 +143,7 @@ void create_task_items() {
         lv_label_set_text(ui_lblTaskItem, task_store);
 
         lv_obj_set_width(ui_lblTaskItem, device.MUX.WIDTH);
-        lv_obj_set_height(ui_lblTaskItem, device.MUX.ITEM.HEIGHT);
+        lv_obj_set_height(ui_lblTaskItem, theme.MUX.ITEM.HEIGHT);
 
         lv_obj_set_style_border_width(ui_lblTaskItem, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_obj_set_style_border_side(ui_lblTaskItem, LV_BORDER_SIDE_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -195,7 +195,7 @@ void create_task_items() {
         lv_label_set_text(ui_lblTaskItemGlyph, "\uF56E");
 
         lv_obj_set_width(ui_lblTaskItemGlyph, device.MUX.WIDTH);
-        lv_obj_set_height(ui_lblTaskItemGlyph, device.MUX.ITEM.HEIGHT);
+        lv_obj_set_height(ui_lblTaskItemGlyph, theme.MUX.ITEM.HEIGHT);
 
         lv_obj_set_style_border_width(ui_lblTaskItemGlyph, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
 
@@ -232,16 +232,16 @@ void create_task_items() {
 
 void list_nav_prev(int steps) {
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index >= 1 && ui_count > device.MUX.ITEM.COUNT) {
+        if (current_item_index >= 1 && ui_count > theme.MUX.ITEM.COUNT) {
             current_item_index--;
             nav_prev(ui_group, 1);
             nav_prev(ui_group_glyph, 1);
-            if (current_item_index > device.MUX.ITEM.PREV_LOW &&
-                current_item_index < (ui_count - device.MUX.ITEM.PREV_HIGH)) {
-                content_panel_y -= device.MUX.ITEM.PANEL;
+            if (current_item_index > theme.MUX.ITEM.PREV_LOW &&
+                current_item_index < (ui_count - theme.MUX.ITEM.PREV_HIGH)) {
+                content_panel_y -= theme.MUX.ITEM.PANEL;
                 lv_obj_scroll_to_y(ui_pnlContent, content_panel_y, LV_ANIM_OFF);
             }
-        } else if (current_item_index >= 0 && ui_count <= device.MUX.ITEM.COUNT) {
+        } else if (current_item_index >= 0 && ui_count <= theme.MUX.ITEM.COUNT) {
             if (current_item_index > 0) {
                 current_item_index--;
                 nav_prev(ui_group, 1);
@@ -256,18 +256,18 @@ void list_nav_prev(int steps) {
 
 void list_nav_next(int steps) {
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index < (ui_count - 1) && ui_count > device.MUX.ITEM.COUNT) {
+        if (current_item_index < (ui_count - 1) && ui_count > theme.MUX.ITEM.COUNT) {
             if (current_item_index < (ui_count - 1)) {
                 current_item_index++;
                 nav_next(ui_group, 1);
                 nav_next(ui_group_glyph, 1);
-                if (current_item_index >= device.MUX.ITEM.NEXT_HIGH &&
-                    current_item_index < (ui_count - device.MUX.ITEM.NEXT_LOW)) {
-                    content_panel_y += device.MUX.ITEM.PANEL;
+                if (current_item_index >= theme.MUX.ITEM.NEXT_HIGH &&
+                    current_item_index < (ui_count - theme.MUX.ITEM.NEXT_LOW)) {
+                    content_panel_y += theme.MUX.ITEM.PANEL;
                     lv_obj_scroll_to_y(ui_pnlContent, content_panel_y, LV_ANIM_OFF);
                 }
             }
-        } else if (current_item_index < ui_count && ui_count <= device.MUX.ITEM.COUNT) {
+        } else if (current_item_index < ui_count && ui_count <= theme.MUX.ITEM.COUNT) {
             if (current_item_index < (ui_count - 1)) {
                 current_item_index++;
                 nav_next(ui_group, 1);
@@ -365,12 +365,12 @@ void *joystick_task() {
                                     safe_quit = 1;
                                 } else if (ev.code == device.RAW_INPUT.BUTTON.L1) {
                                     if (current_item_index >= 0 && current_item_index < ui_count) {
-                                        list_nav_prev(device.MUX.ITEM.COUNT);
+                                        list_nav_prev(theme.MUX.ITEM.COUNT);
                                         lv_task_handler();
                                     }
                                 } else if (ev.code == device.RAW_INPUT.BUTTON.R1) {
                                     if (current_item_index >= 0 && current_item_index < ui_count) {
-                                        list_nav_next(device.MUX.ITEM.COUNT);
+                                        list_nav_next(theme.MUX.ITEM.COUNT);
                                         lv_task_handler();
                                     }
                                 }
@@ -396,7 +396,7 @@ void *joystick_task() {
                                  ev.value <= ((device.INPUT.AXIS_MIN >> 2) * -1)) ||
                                 ev.value == -1) {
                                 if (current_item_index == 0) {
-                                    int y = (ui_count - device.MUX.ITEM.COUNT) * device.MUX.ITEM.PANEL;
+                                    int y = (ui_count - theme.MUX.ITEM.COUNT) * theme.MUX.ITEM.PANEL;
                                     lv_obj_scroll_to_y(ui_pnlContent, y, LV_ANIM_OFF);
                                     content_panel_y = y;
                                     current_item_index = ui_count - 1;
@@ -434,7 +434,7 @@ void *joystick_task() {
             }
         }
 
-        if (ui_count > device.MUX.ITEM.COUNT && (JOYUP_pressed || JOYDOWN_pressed)) {
+        if (ui_count > theme.MUX.ITEM.COUNT && (JOYUP_pressed || JOYDOWN_pressed)) {
             if (nav_hold > 2) {
                 if (nav_delay > 16) {
                     nav_delay -= 16;
@@ -806,7 +806,7 @@ int main(int argc, char *argv[]) {
         lv_obj_clear_flag(ui_lblTaskMessage, LV_OBJ_FLAG_HIDDEN);
     }
 
-    if (ui_count > device.MUX.ITEM.COUNT) {
+    if (ui_count > theme.MUX.ITEM.COUNT) {
         lv_obj_t * last_item = lv_obj_get_child(ui_pnlContent, -1);
         lv_obj_set_height(last_item, lv_obj_get_height(last_item) + 50); // Don't bother asking...
     }

--- a/muxtask/main.c
+++ b/muxtask/main.c
@@ -748,6 +748,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrTask);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxtask/main.c
+++ b/muxtask/main.c
@@ -147,8 +147,10 @@ void create_task_items() {
 
         lv_obj_set_style_border_width(ui_lblTaskItem, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_obj_set_style_border_side(ui_lblTaskItem, LV_BORDER_SIDE_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
-        lv_obj_set_style_bg_grad_color(ui_lblTaskItem, lv_color_hex(theme.SYSTEM.BACKGROUND),
+        lv_obj_set_style_bg_grad_color(ui_lblTaskItem, lv_color_hex(theme.LIST_DEFAULT.BACKGROUND_GRADIENT),
                                        LV_PART_MAIN | LV_STATE_DEFAULT);
+        lv_obj_set_style_bg_grad_color(ui_lblTaskItem, lv_color_hex(theme.LIST_FOCUS.BACKGROUND_GRADIENT),
+                                       LV_PART_MAIN | LV_STATE_FOCUSED);
         lv_obj_set_style_bg_main_stop(ui_lblTaskItem, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_obj_set_style_bg_grad_dir(ui_lblTaskItem, LV_GRAD_DIR_HOR, LV_PART_MAIN | LV_STATE_DEFAULT);
 

--- a/muxtheme/main.c
+++ b/muxtheme/main.c
@@ -143,7 +143,7 @@ void create_theme_items() {
 
             lv_obj_t * ui_pnlTheme = lv_obj_create(ui_pnlContent);
             lv_obj_set_width(ui_pnlTheme, device.MUX.WIDTH);
-            lv_obj_set_height(ui_pnlTheme, device.MUX.ITEM.HEIGHT);
+            lv_obj_set_height(ui_pnlTheme, theme.MUX.ITEM.HEIGHT);
             lv_obj_set_scrollbar_mode(ui_pnlTheme, LV_SCROLLBAR_MODE_OFF);
             lv_obj_set_style_align(ui_pnlTheme, LV_ALIGN_CENTER, LV_PART_MAIN | LV_STATE_DEFAULT);
             lv_obj_set_style_bg_opa(ui_pnlTheme, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -159,7 +159,7 @@ void create_theme_items() {
             lv_label_set_text(ui_lblThemeItem, base_filename);
 
             lv_obj_set_width(ui_lblThemeItem, device.MUX.WIDTH);
-            lv_obj_set_height(ui_lblThemeItem, device.MUX.ITEM.HEIGHT);
+            lv_obj_set_height(ui_lblThemeItem, theme.MUX.ITEM.HEIGHT);
 
             lv_obj_set_style_border_width(ui_lblThemeItem, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
             lv_obj_set_style_border_side(ui_lblThemeItem, LV_BORDER_SIDE_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -212,7 +212,7 @@ void create_theme_items() {
             lv_label_set_text(ui_lblThemeItemGlyph, "\uF53F");
 
             lv_obj_set_width(ui_lblThemeItemGlyph, device.MUX.WIDTH);
-            lv_obj_set_height(ui_lblThemeItemGlyph, device.MUX.ITEM.HEIGHT);
+            lv_obj_set_height(ui_lblThemeItemGlyph, theme.MUX.ITEM.HEIGHT);
 
             lv_obj_set_style_border_width(ui_lblThemeItemGlyph, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
 
@@ -252,16 +252,16 @@ void create_theme_items() {
 
 void list_nav_prev(int steps) {
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index >= 1 && ui_count > device.MUX.ITEM.COUNT) {
+        if (current_item_index >= 1 && ui_count > theme.MUX.ITEM.COUNT) {
             current_item_index--;
             nav_prev(ui_group, 1);
             nav_prev(ui_group_glyph, 1);
-            if (current_item_index > device.MUX.ITEM.PREV_LOW &&
-                current_item_index < (ui_count - device.MUX.ITEM.PREV_HIGH)) {
-                content_panel_y -= device.MUX.ITEM.PANEL;
+            if (current_item_index > theme.MUX.ITEM.PREV_LOW &&
+                current_item_index < (ui_count - theme.MUX.ITEM.PREV_HIGH)) {
+                content_panel_y -= theme.MUX.ITEM.PANEL;
                 lv_obj_scroll_to_y(ui_pnlContent, content_panel_y, LV_ANIM_OFF);
             }
-        } else if (current_item_index >= 0 && ui_count <= device.MUX.ITEM.COUNT) {
+        } else if (current_item_index >= 0 && ui_count <= theme.MUX.ITEM.COUNT) {
             if (current_item_index > 0) {
                 current_item_index--;
                 nav_prev(ui_group, 1);
@@ -277,18 +277,18 @@ void list_nav_prev(int steps) {
 
 void list_nav_next(int steps) {
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index < (ui_count - 1) && ui_count > device.MUX.ITEM.COUNT) {
+        if (current_item_index < (ui_count - 1) && ui_count > theme.MUX.ITEM.COUNT) {
             if (current_item_index < (ui_count - 1)) {
                 current_item_index++;
                 nav_next(ui_group, 1);
                 nav_next(ui_group_glyph, 1);
-                if (current_item_index >= device.MUX.ITEM.NEXT_HIGH &&
-                    current_item_index < (ui_count - device.MUX.ITEM.NEXT_LOW)) {
-                    content_panel_y += device.MUX.ITEM.PANEL;
+                if (current_item_index >= theme.MUX.ITEM.NEXT_HIGH &&
+                    current_item_index < (ui_count - theme.MUX.ITEM.NEXT_LOW)) {
+                    content_panel_y += theme.MUX.ITEM.PANEL;
                     lv_obj_scroll_to_y(ui_pnlContent, content_panel_y, LV_ANIM_OFF);
                 }
             }
-        } else if (current_item_index < ui_count && ui_count <= device.MUX.ITEM.COUNT) {
+        } else if (current_item_index < ui_count && ui_count <= theme.MUX.ITEM.COUNT) {
             if (current_item_index < (ui_count - 1)) {
                 current_item_index++;
                 nav_next(ui_group, 1);
@@ -384,12 +384,12 @@ void *joystick_task() {
                                     safe_quit = 1;
                                 } else if (ev.code == device.RAW_INPUT.BUTTON.L1) {
                                     if (current_item_index >= 0 && current_item_index < ui_count) {
-                                        list_nav_prev(device.MUX.ITEM.COUNT);
+                                        list_nav_prev(theme.MUX.ITEM.COUNT);
                                         lv_task_handler();
                                     }
                                 } else if (ev.code == device.RAW_INPUT.BUTTON.R1) {
                                     if (current_item_index >= 0 && current_item_index < ui_count) {
-                                        list_nav_next(device.MUX.ITEM.COUNT);
+                                        list_nav_next(theme.MUX.ITEM.COUNT);
                                         lv_task_handler();
                                     }
                                 }
@@ -415,7 +415,7 @@ void *joystick_task() {
                                  ev.value <= ((device.INPUT.AXIS_MIN >> 2) * -1)) ||
                                 ev.value == -1) {
                                 if (current_item_index == 0) {
-                                    int y = (ui_count - device.MUX.ITEM.COUNT) * device.MUX.ITEM.PANEL;
+                                    int y = (ui_count - theme.MUX.ITEM.COUNT) * theme.MUX.ITEM.PANEL;
                                     lv_obj_scroll_to_y(ui_pnlContent, y, LV_ANIM_OFF);
                                     content_panel_y = y;
                                     current_item_index = ui_count - 1;
@@ -455,7 +455,7 @@ void *joystick_task() {
             }
         }
 
-        if (ui_count > device.MUX.ITEM.COUNT && (JOYUP_pressed || JOYDOWN_pressed)) {
+        if (ui_count > theme.MUX.ITEM.COUNT && (JOYUP_pressed || JOYDOWN_pressed)) {
             if (nav_hold > 2) {
                 if (nav_delay > 16) {
                     nav_delay -= 16;
@@ -818,7 +818,7 @@ int main(int argc, char *argv[]) {
         lv_obj_clear_flag(ui_lblThemeMessage, LV_OBJ_FLAG_HIDDEN);
     }
 
-    if (ui_count > device.MUX.ITEM.COUNT) {
+    if (ui_count > theme.MUX.ITEM.COUNT) {
         lv_obj_t * last_item = lv_obj_get_child(ui_pnlContent, -1);
         lv_obj_set_height(last_item, lv_obj_get_height(last_item) + 50); // Don't bother asking...
     }

--- a/muxtheme/main.c
+++ b/muxtheme/main.c
@@ -163,8 +163,10 @@ void create_theme_items() {
 
             lv_obj_set_style_border_width(ui_lblThemeItem, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
             lv_obj_set_style_border_side(ui_lblThemeItem, LV_BORDER_SIDE_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
-            lv_obj_set_style_bg_grad_color(ui_lblThemeItem, lv_color_hex(theme.SYSTEM.BACKGROUND),
+            lv_obj_set_style_bg_grad_color(ui_lblThemeItem, lv_color_hex(theme.LIST_DEFAULT.BACKGROUND_GRADIENT),
                                            LV_PART_MAIN | LV_STATE_DEFAULT);
+            lv_obj_set_style_bg_grad_color(ui_lblThemeItem, lv_color_hex(theme.LIST_FOCUS.BACKGROUND_GRADIENT),
+                                           LV_PART_MAIN | LV_STATE_FOCUSED);
             lv_obj_set_style_bg_main_stop(ui_lblThemeItem, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
             lv_obj_set_style_bg_grad_dir(ui_lblThemeItem, LV_GRAD_DIR_HOR, LV_PART_MAIN | LV_STATE_DEFAULT);
 

--- a/muxtheme/main.c
+++ b/muxtheme/main.c
@@ -760,6 +760,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrTheme);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxtheme/main.c
+++ b/muxtheme/main.c
@@ -208,6 +208,8 @@ void create_theme_items() {
             lv_obj_set_style_text_line_space(ui_lblThemeItem, 16, LV_PART_MAIN | LV_STATE_DEFAULT);
             lv_label_set_long_mode(ui_lblThemeItem, LV_LABEL_LONG_WRAP);
 
+            lv_obj_set_style_radius(ui_lblThemeItem, theme.LIST_DEFAULT.RADIUS, LV_PART_MAIN | LV_STATE_DEFAULT);
+
             lv_obj_t * ui_lblThemeItemGlyph = lv_label_create(ui_pnlTheme);
             lv_label_set_text(ui_lblThemeItemGlyph, "\uF53F");
 

--- a/muxtimezone/main.c
+++ b/muxtimezone/main.c
@@ -684,6 +684,7 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrTimezone);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxtimezone/main.c
+++ b/muxtimezone/main.c
@@ -103,8 +103,10 @@ void create_timezone_items() {
 
         lv_obj_set_style_border_width(ui_lblTimezoneItem, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_obj_set_style_border_side(ui_lblTimezoneItem, LV_BORDER_SIDE_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
-        lv_obj_set_style_bg_grad_color(ui_lblTimezoneItem, lv_color_hex(theme.SYSTEM.BACKGROUND),
+        lv_obj_set_style_bg_grad_color(ui_lblTimezoneItem, lv_color_hex(theme.LIST_DEFAULT.BACKGROUND_GRADIENT),
                                        LV_PART_MAIN | LV_STATE_DEFAULT);
+        lv_obj_set_style_bg_grad_color(ui_lblTimezoneItem, lv_color_hex(theme.LIST_FOCUS.BACKGROUND_GRADIENT),
+                                       LV_PART_MAIN | LV_STATE_FOCUSED);
         lv_obj_set_style_bg_main_stop(ui_lblTimezoneItem, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_obj_set_style_bg_grad_dir(ui_lblTimezoneItem, LV_GRAD_DIR_HOR, LV_PART_MAIN | LV_STATE_DEFAULT);
 

--- a/muxtimezone/main.c
+++ b/muxtimezone/main.c
@@ -147,6 +147,8 @@ void create_timezone_items() {
         lv_obj_set_style_text_line_space(ui_lblTimezoneItem, 16, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_label_set_long_mode(ui_lblTimezoneItem, LV_LABEL_LONG_WRAP);
 
+        lv_obj_set_style_radius(ui_lblTimezoneItem, theme.LIST_DEFAULT.RADIUS, LV_PART_MAIN | LV_STATE_DEFAULT);
+
         lv_obj_t * ui_lblTimezoneGlyph = lv_label_create(ui_pnlTimezone);
         lv_label_set_text(ui_lblTimezoneGlyph, "\uF0AC");
 

--- a/muxtimezone/main.c
+++ b/muxtimezone/main.c
@@ -83,7 +83,7 @@ void create_timezone_items() {
 
         lv_obj_t * ui_pnlTimezone = lv_obj_create(ui_pnlContent);
         lv_obj_set_width(ui_pnlTimezone, device.MUX.WIDTH);
-        lv_obj_set_height(ui_pnlTimezone, device.MUX.ITEM.HEIGHT);
+        lv_obj_set_height(ui_pnlTimezone, theme.MUX.ITEM.HEIGHT);
         lv_obj_set_scrollbar_mode(ui_pnlTimezone, LV_SCROLLBAR_MODE_OFF);
         lv_obj_set_style_align(ui_pnlTimezone, LV_ALIGN_CENTER, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_obj_set_style_bg_opa(ui_pnlTimezone, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -99,7 +99,7 @@ void create_timezone_items() {
         lv_label_set_text(ui_lblTimezoneItem, base_key);
 
         lv_obj_set_width(ui_lblTimezoneItem, device.MUX.WIDTH);
-        lv_obj_set_height(ui_lblTimezoneItem, device.MUX.ITEM.HEIGHT);
+        lv_obj_set_height(ui_lblTimezoneItem, theme.MUX.ITEM.HEIGHT);
 
         lv_obj_set_style_border_width(ui_lblTimezoneItem, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
         lv_obj_set_style_border_side(ui_lblTimezoneItem, LV_BORDER_SIDE_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -151,7 +151,7 @@ void create_timezone_items() {
         lv_label_set_text(ui_lblTimezoneGlyph, "\uF0AC");
 
         lv_obj_set_width(ui_lblTimezoneGlyph, device.MUX.WIDTH);
-        lv_obj_set_height(ui_lblTimezoneGlyph, device.MUX.ITEM.HEIGHT);
+        lv_obj_set_height(ui_lblTimezoneGlyph, theme.MUX.ITEM.HEIGHT);
 
         lv_obj_set_style_border_width(ui_lblTimezoneGlyph, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
 
@@ -183,16 +183,16 @@ void create_timezone_items() {
 
 void list_nav_prev(int steps) {
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index >= 1 && ui_count > device.MUX.ITEM.COUNT) {
+        if (current_item_index >= 1 && ui_count > theme.MUX.ITEM.COUNT) {
             current_item_index--;
             nav_prev(ui_group, 1);
             nav_prev(ui_group_glyph, 1);
-            if (current_item_index > device.MUX.ITEM.PREV_LOW &&
-                current_item_index < (ui_count - device.MUX.ITEM.PREV_HIGH)) {
-                content_panel_y -= device.MUX.ITEM.PANEL;
+            if (current_item_index > theme.MUX.ITEM.PREV_LOW &&
+                current_item_index < (ui_count - theme.MUX.ITEM.PREV_HIGH)) {
+                content_panel_y -= theme.MUX.ITEM.PANEL;
                 lv_obj_scroll_to_y(ui_pnlContent, content_panel_y, LV_ANIM_OFF);
             }
-        } else if (current_item_index >= 0 && ui_count <= device.MUX.ITEM.COUNT) {
+        } else if (current_item_index >= 0 && ui_count <= theme.MUX.ITEM.COUNT) {
             if (current_item_index > 0) {
                 current_item_index--;
                 nav_prev(ui_group, 1);
@@ -207,18 +207,18 @@ void list_nav_prev(int steps) {
 
 void list_nav_next(int steps) {
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index < (ui_count - 1) && ui_count > device.MUX.ITEM.COUNT) {
+        if (current_item_index < (ui_count - 1) && ui_count > theme.MUX.ITEM.COUNT) {
             if (current_item_index < (ui_count - 1)) {
                 current_item_index++;
                 nav_next(ui_group, 1);
                 nav_next(ui_group_glyph, 1);
-                if (current_item_index >= device.MUX.ITEM.NEXT_HIGH &&
-                    current_item_index < (ui_count - device.MUX.ITEM.NEXT_LOW)) {
-                    content_panel_y += device.MUX.ITEM.PANEL;
+                if (current_item_index >= theme.MUX.ITEM.NEXT_HIGH &&
+                    current_item_index < (ui_count - theme.MUX.ITEM.NEXT_LOW)) {
+                    content_panel_y += theme.MUX.ITEM.PANEL;
                     lv_obj_scroll_to_y(ui_pnlContent, content_panel_y, LV_ANIM_OFF);
                 }
             }
-        } else if (current_item_index < ui_count && ui_count <= device.MUX.ITEM.COUNT) {
+        } else if (current_item_index < ui_count && ui_count <= theme.MUX.ITEM.COUNT) {
             if (current_item_index < (ui_count - 1)) {
                 current_item_index++;
                 nav_next(ui_group, 1);
@@ -306,12 +306,12 @@ void *joystick_task() {
                                     safe_quit = 1;
                                 } else if (ev.code == device.RAW_INPUT.BUTTON.L1) {
                                     if (current_item_index >= 0 && current_item_index < ui_count) {
-                                        list_nav_prev(device.MUX.ITEM.COUNT);
+                                        list_nav_prev(theme.MUX.ITEM.COUNT);
                                         lv_task_handler();
                                     }
                                 } else if (ev.code == device.RAW_INPUT.BUTTON.R1) {
                                     if (current_item_index >= 0 && current_item_index < ui_count) {
-                                        list_nav_next(device.MUX.ITEM.COUNT);
+                                        list_nav_next(theme.MUX.ITEM.COUNT);
                                         lv_task_handler();
                                     }
                                 }
@@ -337,7 +337,7 @@ void *joystick_task() {
                                  ev.value <= ((device.INPUT.AXIS_MIN >> 2) * -1)) ||
                                 ev.value == -1) {
                                 if (current_item_index == 0) {
-                                    int y = (ui_count - device.MUX.ITEM.COUNT) * device.MUX.ITEM.PANEL;
+                                    int y = (ui_count - theme.MUX.ITEM.COUNT) * theme.MUX.ITEM.PANEL;
                                     lv_obj_scroll_to_y(ui_pnlContent, y, LV_ANIM_OFF);
                                     content_panel_y = y;
                                     current_item_index = ui_count - 1;
@@ -375,7 +375,7 @@ void *joystick_task() {
             }
         }
 
-        if (ui_count > device.MUX.ITEM.COUNT && (JOYUP_pressed || JOYDOWN_pressed)) {
+        if (ui_count > theme.MUX.ITEM.COUNT && (JOYUP_pressed || JOYDOWN_pressed)) {
             if (nav_hold > 2) {
                 if (nav_delay > 16) {
                     nav_delay -= 16;
@@ -739,7 +739,7 @@ int main(int argc, char *argv[]) {
         lv_obj_clear_flag(ui_lblTimezoneMessage, LV_OBJ_FLAG_HIDDEN);
     }
 
-    if (ui_count > device.MUX.ITEM.COUNT) {
+    if (ui_count > theme.MUX.ITEM.COUNT) {
         lv_obj_t * last_item = lv_obj_get_child(ui_pnlContent, -1);
         lv_obj_set_height(last_item, lv_obj_get_height(last_item) + 50); // Don't bother asking...
     }

--- a/muxtweakadv/main.c
+++ b/muxtweakadv/main.c
@@ -962,6 +962,8 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrTweakAdvanced);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlHighlight);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxtweakadv/theme.c
+++ b/muxtweakadv/theme.c
@@ -98,22 +98,41 @@ void apply_theme() {
     }
 
     struct big gradient_elements[] = {
-            {ui_lblSwap,       theme.SYSTEM.BACKGROUND},
-            {ui_lblThermal,    theme.SYSTEM.BACKGROUND},
-            {ui_lblFont,       theme.SYSTEM.BACKGROUND},
-            {ui_lblVolume,     theme.SYSTEM.BACKGROUND},
-            {ui_lblBrightness, theme.SYSTEM.BACKGROUND},
-            {ui_lblOffset,     theme.SYSTEM.BACKGROUND},
-            {ui_lblPasscode,   theme.SYSTEM.BACKGROUND},
-            {ui_lblLED,        theme.SYSTEM.BACKGROUND},
-            {ui_lblTheme,      theme.SYSTEM.BACKGROUND},
-            {ui_lblRetroWait,  theme.SYSTEM.BACKGROUND},
-            {ui_lblAndroid,    theme.SYSTEM.BACKGROUND},
-            {ui_lblState,      theme.SYSTEM.BACKGROUND},
+            {ui_lblSwap,       theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblThermal,    theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblFont,       theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblVolume,     theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblBrightness, theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblOffset,     theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblPasscode,   theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblLED,        theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblTheme,      theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblRetroWait,  theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblAndroid,    theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblState,      theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
     };
     for (size_t i = 0; i < sizeof(gradient_elements) / sizeof(gradient_elements[0]); ++i) {
         lv_obj_set_style_bg_grad_color(gradient_elements[i].e, lv_color_hex(gradient_elements[i].c),
                                        LV_PART_MAIN | LV_STATE_DEFAULT);
+    }
+
+    struct big gradient_focused_elements[] = {
+            {ui_lblSwap,       theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblThermal,    theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblFont,       theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblVolume,     theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblBrightness, theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblOffset,     theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblPasscode,   theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblLED,        theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblTheme,      theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblRetroWait,  theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblAndroid,    theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblState,      theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+    };
+    for (size_t i = 0; i < sizeof(gradient_focused_elements) / sizeof(gradient_focused_elements[0]); ++i) {
+        lv_obj_set_style_bg_grad_color(gradient_focused_elements[i].e, lv_color_hex(gradient_focused_elements[i].c),
+                                       LV_PART_MAIN | LV_STATE_FOCUSED);
     }
 
     struct big indicator_elements[] = {

--- a/muxtweakadv/theme.c
+++ b/muxtweakadv/theme.c
@@ -555,6 +555,18 @@ void apply_theme() {
             {ui_barProgressBrightness, theme.BAR.PROGRESS_RADIUS},
             {ui_pnlProgressVolume,     theme.BAR.PANEL_BORDER_RADIUS},
             {ui_barProgressVolume,     theme.BAR.PROGRESS_RADIUS},
+            {ui_lblSwap,       theme.LIST_DEFAULT.RADIUS},
+            {ui_lblThermal,    theme.LIST_DEFAULT.RADIUS},
+            {ui_lblFont,       theme.LIST_DEFAULT.RADIUS},
+            {ui_lblVolume,     theme.LIST_DEFAULT.RADIUS},
+            {ui_lblBrightness, theme.LIST_DEFAULT.RADIUS},
+            {ui_lblOffset,     theme.LIST_DEFAULT.RADIUS},
+            {ui_lblPasscode,   theme.LIST_DEFAULT.RADIUS},
+            {ui_lblLED,        theme.LIST_DEFAULT.RADIUS},
+            {ui_lblTheme,      theme.LIST_DEFAULT.RADIUS},
+            {ui_lblRetroWait,  theme.LIST_DEFAULT.RADIUS},
+            {ui_lblAndroid,    theme.LIST_DEFAULT.RADIUS},
+            {ui_lblState,      theme.LIST_DEFAULT.RADIUS},
     };
     for (size_t i = 0; i < sizeof(radius_elements) / sizeof(radius_elements[0]); ++i) {
         lv_obj_set_style_radius(radius_elements[i].e, radius_elements[i].c,

--- a/muxtweakgen/main.c
+++ b/muxtweakgen/main.c
@@ -1178,6 +1178,8 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrTweakGeneral);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlHighlight);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxtweakgen/theme.c
+++ b/muxtweakgen/theme.c
@@ -95,20 +95,37 @@ void apply_theme() {
     }
 
     struct big gradient_elements[] = {
-            {ui_lblHidden,     theme.SYSTEM.BACKGROUND},
-            {ui_lblBGM,        theme.SYSTEM.BACKGROUND},
-            {ui_lblStartup,    theme.SYSTEM.BACKGROUND},
-            {ui_lblColour,     theme.SYSTEM.BACKGROUND},
-            {ui_lblBrightness, theme.SYSTEM.BACKGROUND},
-            {ui_lblHDMI,       theme.SYSTEM.BACKGROUND},
-            {ui_lblShutdown,   theme.SYSTEM.BACKGROUND},
-            {ui_lblInterface,  theme.SYSTEM.BACKGROUND},
-            {ui_lblStorage,    theme.SYSTEM.BACKGROUND},
-            {ui_lblAdvanced,   theme.SYSTEM.BACKGROUND},
+            {ui_lblHidden,     theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblBGM,        theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblStartup,    theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblColour,     theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblBrightness, theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblHDMI,       theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblShutdown,   theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblInterface,  theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblStorage,    theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblAdvanced,   theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
     };
     for (size_t i = 0; i < sizeof(gradient_elements) / sizeof(gradient_elements[0]); ++i) {
         lv_obj_set_style_bg_grad_color(gradient_elements[i].e, lv_color_hex(gradient_elements[i].c),
                                        LV_PART_MAIN | LV_STATE_DEFAULT);
+    }
+
+    struct big gradient_focused_elements[] = {
+            {ui_lblHidden,     theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblBGM,        theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblStartup,    theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblColour,     theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblBrightness, theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblHDMI,       theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblShutdown,   theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblInterface,  theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblStorage,    theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblAdvanced,   theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+    };
+    for (size_t i = 0; i < sizeof(gradient_focused_elements) / sizeof(gradient_focused_elements[0]); ++i) {
+        lv_obj_set_style_bg_grad_color(gradient_focused_elements[i].e, lv_color_hex(gradient_focused_elements[i].c),
+                                       LV_PART_MAIN | LV_STATE_FOCUSED);
     }
 
     struct big indicator_elements[] = {

--- a/muxtweakgen/theme.c
+++ b/muxtweakgen/theme.c
@@ -494,6 +494,16 @@ void apply_theme() {
             {ui_barProgressBrightness, theme.BAR.PROGRESS_RADIUS},
             {ui_pnlProgressVolume,     theme.BAR.PANEL_BORDER_RADIUS},
             {ui_barProgressVolume,     theme.BAR.PROGRESS_RADIUS},
+            {ui_lblHidden,     theme.LIST_DEFAULT.RADIUS},
+            {ui_lblBGM,        theme.LIST_DEFAULT.RADIUS},
+            {ui_lblStartup,    theme.LIST_DEFAULT.RADIUS},
+            {ui_lblColour,     theme.LIST_DEFAULT.RADIUS},
+            {ui_lblBrightness, theme.LIST_DEFAULT.RADIUS},
+            {ui_lblHDMI,       theme.LIST_DEFAULT.RADIUS},
+            {ui_lblShutdown,   theme.LIST_DEFAULT.RADIUS},
+            {ui_lblInterface,  theme.LIST_DEFAULT.RADIUS},
+            {ui_lblStorage,    theme.LIST_DEFAULT.RADIUS},
+            {ui_lblAdvanced,   theme.LIST_DEFAULT.RADIUS},
     };
     for (size_t i = 0; i < sizeof(radius_elements) / sizeof(radius_elements[0]); ++i) {
         lv_obj_set_style_radius(radius_elements[i].e, radius_elements[i].c,

--- a/muxvisual/main.c
+++ b/muxvisual/main.c
@@ -764,6 +764,8 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrVisual);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlHighlight);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxvisual/theme.c
+++ b/muxvisual/theme.c
@@ -430,6 +430,13 @@ void apply_theme() {
             {ui_barProgressBrightness, theme.BAR.PROGRESS_RADIUS},
             {ui_pnlProgressVolume,     theme.BAR.PANEL_BORDER_RADIUS},
             {ui_barProgressVolume,     theme.BAR.PROGRESS_RADIUS},
+            {ui_lblBattery,   theme.LIST_DEFAULT.RADIUS},
+            {ui_lblNetwork,   theme.LIST_DEFAULT.RADIUS},
+            {ui_lblBluetooth, theme.LIST_DEFAULT.RADIUS},
+            {ui_lblClock,     theme.LIST_DEFAULT.RADIUS},
+            {ui_lblBoxArt,    theme.LIST_DEFAULT.RADIUS},
+            {ui_lblName,      theme.LIST_DEFAULT.RADIUS},
+            {ui_lblDash,      theme.LIST_DEFAULT.RADIUS},
     };
     for (size_t i = 0; i < sizeof(radius_elements) / sizeof(radius_elements[0]); ++i) {
         lv_obj_set_style_radius(radius_elements[i].e, radius_elements[i].c,

--- a/muxvisual/theme.c
+++ b/muxvisual/theme.c
@@ -88,17 +88,31 @@ void apply_theme() {
     }
 
     struct big gradient_elements[] = {
-            {ui_lblBattery,   theme.SYSTEM.BACKGROUND},
-            {ui_lblNetwork,   theme.SYSTEM.BACKGROUND},
-            {ui_lblBluetooth, theme.SYSTEM.BACKGROUND},
-            {ui_lblClock,     theme.SYSTEM.BACKGROUND},
-            {ui_lblBoxArt,    theme.SYSTEM.BACKGROUND},
-            {ui_lblName,      theme.SYSTEM.BACKGROUND},
-            {ui_lblDash,      theme.SYSTEM.BACKGROUND},
+            {ui_lblBattery,   theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblNetwork,   theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblBluetooth, theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblClock,     theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblBoxArt,    theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblName,      theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblDash,      theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
     };
     for (size_t i = 0; i < sizeof(gradient_elements) / sizeof(gradient_elements[0]); ++i) {
         lv_obj_set_style_bg_grad_color(gradient_elements[i].e, lv_color_hex(gradient_elements[i].c),
                                        LV_PART_MAIN | LV_STATE_DEFAULT);
+    }
+
+    struct big gradient_focused_elements[] = {
+            {ui_lblBattery,   theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblNetwork,   theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblBluetooth, theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblClock,     theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblBoxArt,    theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblName,      theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblDash,      theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+    };
+    for (size_t i = 0; i < sizeof(gradient_focused_elements) / sizeof(gradient_focused_elements[0]); ++i) {
+        lv_obj_set_style_bg_grad_color(gradient_focused_elements[i].e, lv_color_hex(gradient_focused_elements[i].c),
+                                       LV_PART_MAIN | LV_STATE_FOCUSED);
     }
 
     struct big indicator_elements[] = {

--- a/muxwebserv/main.c
+++ b/muxwebserv/main.c
@@ -700,6 +700,8 @@ int main(int argc, char *argv[]) {
     }
 
     load_font_text(basename(argv[0]), ui_scrWebServices);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
+    load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlHighlight);
 
     if (config.SETTINGS.GENERAL.SOUND == 2) {
         nav_sound = 1;

--- a/muxwebserv/theme.c
+++ b/muxwebserv/theme.c
@@ -380,6 +380,11 @@ void apply_theme() {
             {ui_barProgressBrightness, theme.BAR.PROGRESS_RADIUS},
             {ui_pnlProgressVolume,     theme.BAR.PANEL_BORDER_RADIUS},
             {ui_barProgressVolume,     theme.BAR.PROGRESS_RADIUS},
+            {ui_lblShell,     theme.LIST_DEFAULT.RADIUS},
+            {ui_lblBrowser,   theme.LIST_DEFAULT.RADIUS},
+            {ui_lblTerminal,  theme.LIST_DEFAULT.RADIUS},
+            {ui_lblSyncthing, theme.LIST_DEFAULT.RADIUS},
+            {ui_lblNTP,       theme.LIST_DEFAULT.RADIUS},
     };
     for (size_t i = 0; i < sizeof(radius_elements) / sizeof(radius_elements[0]); ++i) {
         lv_obj_set_style_radius(radius_elements[i].e, radius_elements[i].c,

--- a/muxwebserv/theme.c
+++ b/muxwebserv/theme.c
@@ -84,15 +84,27 @@ void apply_theme() {
     }
 
     struct big gradient_elements[] = {
-            {ui_lblShell,     theme.SYSTEM.BACKGROUND},
-            {ui_lblBrowser,   theme.SYSTEM.BACKGROUND},
-            {ui_lblTerminal,  theme.SYSTEM.BACKGROUND},
-            {ui_lblSyncthing, theme.SYSTEM.BACKGROUND},
-            {ui_lblNTP,       theme.SYSTEM.BACKGROUND},
+            {ui_lblShell,     theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblBrowser,   theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblTerminal,  theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblSyncthing, theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
+            {ui_lblNTP,       theme.LIST_DEFAULT.BACKGROUND_GRADIENT},
     };
     for (size_t i = 0; i < sizeof(gradient_elements) / sizeof(gradient_elements[0]); ++i) {
         lv_obj_set_style_bg_grad_color(gradient_elements[i].e, lv_color_hex(gradient_elements[i].c),
                                        LV_PART_MAIN | LV_STATE_DEFAULT);
+    }
+
+    struct big gradient_focused_elements[] = {
+            {ui_lblShell,     theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblBrowser,   theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblTerminal,  theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblSyncthing, theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+            {ui_lblNTP,       theme.LIST_FOCUS.BACKGROUND_GRADIENT},
+    };
+    for (size_t i = 0; i < sizeof(gradient_focused_elements) / sizeof(gradient_focused_elements[0]); ++i) {
+        lv_obj_set_style_bg_grad_color(gradient_focused_elements[i].e, lv_color_hex(gradient_focused_elements[i].c),
+                                       LV_PART_MAIN | LV_STATE_FOCUSED);
     }
 
     struct big indicator_elements[] = {


### PR DESCRIPTION
Ran into some merge conflicts and decided to merge my PR's into one pull request
* Added ability to set font used for panel content
* Update to pull item settings from theme first before falling back to device config
* Added new theme settings
  * misc -> CONTENT_ITEM_COUNT (minimum value 5 macimum value 13)
  * misc -> CONTENT_PADDING_TOP
  * misc -> CONTENT_HEIGHT (minimum value 100 maximum value device screen height)
  * list -> LIST_DEFAULT_RADIUS
* Item Count and Item Height will be used to automatically 
  * theme->MUX.ITEM.PANEL
  * theme->MUX.ITEM.HEIGHT
  * theme->MUX.ITEM.PREV_LOW
  * theme->MUX.ITEM.PREV_HIGH
  * theme->MUX.ITEM.NEXT_LOW
  * theme->MUX.ITEM.NEXT_HIGH
* Fixed issue where changing width of panel content would force it to align center.  Now content can be resized and aligned with MISC.CONTENT.PADDING_LEFT
