### PR TITLE
muOS Frontend - Theme Image List Settings

### DIFF
--- a/muxplore/theme.c
+++ b/muxplore/theme.c
@@ -177,7 +177,7 @@ void apply_theme() {
             {ui_pnlHelpMessage,        theme.HELP.RADIUS},
             {ui_pnlHelpPreview,        theme.HELP.RADIUS},
             {ui_imgBox,                theme.IMAGE_LIST.RADIUS},
-            {ui_imgHelpPreviewImage,   theme.IMAGE_LIST.RADIUS},
+            {ui_imgHelpPreviewImage,   theme.IMAGE_PREVIEW.RADIUS},
             {ui_pnlMessage,            theme.MESSAGE.RADIUS},
             {ui_pnlProgressBrightness, theme.BAR.PANEL_BORDER_RADIUS},
             {ui_barProgressBrightness, theme.BAR.PROGRESS_RADIUS},

--- a/muxplore/ui/ui_scrExplore.c
+++ b/muxplore/ui/ui_scrExplore.c
@@ -110,6 +110,7 @@ void ui_scrExplore_screen_init(void)
     lv_obj_set_align(ui_imgBox, LV_ALIGN_TOP_RIGHT);
     lv_obj_add_flag(ui_imgBox, LV_OBJ_FLAG_ADV_HITTEST);     /// Flags
     lv_obj_clear_flag(ui_imgBox, LV_OBJ_FLAG_SCROLLABLE);      /// Flags
+    lv_obj_set_style_clip_corner(ui_imgBox, true, LV_PART_MAIN | LV_STATE_DEFAULT);
 
     ui_pnlHeader = lv_obj_create(ui_scrExplore);
     lv_obj_set_width(ui_pnlHeader, 640);


### PR DESCRIPTION
* Fixed issue with image preview using wrong setting for radius.
* Fixed issue with Image_list_radius only applying the radius to the background and not the image itself