### PR TITLE
Horizontal Navigation with 3 item first row, 5 item second row

### DIFF
--- a/muxlaunch/main.c
+++ b/muxlaunch/main.c
@@ -310,20 +310,69 @@ void *joystick_task() {
                                 }
                             }
                         }
+                        // Horizontal Navigation with 2 rows of 4 items
                         if (theme.MISC.NAVIGATION_TYPE == 2 && (ev.code == NAV_DPAD_HOR || ev.code == NAV_ANLG_HOR)) {
                             if ((ev.value >= ((device.INPUT.AXIS_MAX >> 2) * -1) &&
                                  ev.value <= ((device.INPUT.AXIS_MIN >> 2) * -1)) ||
                                 ev.value == -1) {
                                 play_sound("navigate", nav_sound, 0);
-                                nav_prev(ui_group, 4);
-                                nav_prev(ui_group_glyph, 4);
+                                if (current_item_index > 3) {
+                                    nav_prev(ui_group, 4);
+                                    nav_prev(ui_group_glyph, 4);
+                                }
                                 nav_moved = 1;
                             } else if ((ev.value >= (device.INPUT.AXIS_MIN >> 2) &&
                                         ev.value <= (device.INPUT.AXIS_MAX >> 2)) ||
                                        ev.value == 1) {
                                 play_sound("navigate", nav_sound, 0);
-                                nav_next(ui_group, 4);
-                                nav_next(ui_group_glyph, 4);
+                                if (current_item_index < 4) {
+                                    nav_next(ui_group, 4);
+                                    nav_next(ui_group_glyph, 4);
+                                }
+                                nav_moved = 1;
+                            }
+                        }
+                        // Horizontal Navigation with 3 item first row, 5 item second row
+                        if (theme.MISC.NAVIGATION_TYPE == 3 && (ev.code == NAV_DPAD_HOR || ev.code == NAV_ANLG_HOR)) {
+                            if ((ev.value >= ((device.INPUT.AXIS_MAX >> 2) * -1) &&
+                                 ev.value <= ((device.INPUT.AXIS_MIN >> 2) * -1)) ||
+                                ev.value == -1) {
+                                    switch (current_item_index) {
+                                        case 3:
+                                        case 4:
+                                            nav_prev(ui_group, 3);
+                                            nav_prev(ui_group_glyph, 3);
+                                            break;
+                                        case 5:
+                                            nav_prev(ui_group, 4);
+                                            nav_prev(ui_group_glyph, 4);
+                                            break;
+                                        case 6:
+                                        case 7:
+                                            nav_prev(ui_group, 5);
+                                            nav_prev(ui_group_glyph, 5);
+                                            break;
+                                    }
+                                play_sound("navigate", nav_sound, 0);
+                                nav_moved = 1;
+                            } else if ((ev.value >= (device.INPUT.AXIS_MIN >> 2) &&
+                                        ev.value <= (device.INPUT.AXIS_MAX >> 2)) ||
+                                ev.value == 1) {
+                                    switch (current_item_index) {
+                                        case 0:
+                                            nav_next(ui_group, 3);
+                                            nav_next(ui_group_glyph, 3);
+                                            break;
+                                        case 1:
+                                            nav_next(ui_group, 4);
+                                            nav_next(ui_group_glyph, 4);
+                                            break;
+                                        case 2:
+                                            nav_next(ui_group, 5);
+                                            nav_next(ui_group_glyph, 5);
+                                            break;
+                                    }
+                                play_sound("navigate", nav_sound, 0);
                                 nav_moved = 1;
                             }
                         }
@@ -611,6 +660,7 @@ int main(int argc, char *argv[]) {
     switch (theme.MISC.NAVIGATION_TYPE) {
         case 1:
         case 2:
+        case 3:
             NAV_DPAD_HOR = device.RAW_INPUT.DPAD.DOWN;
             NAV_ANLG_HOR = device.RAW_INPUT.ANALOG.LEFT.DOWN;
             NAV_DPAD_VER = device.RAW_INPUT.DPAD.RIGHT;


### PR DESCRIPTION
New NAVIGATION_TYPE == 3 which, once again, is primarily horizontal scrolling, but this one is designed around a two row layout with 3 items in the first row, and 5 items in the second row. Useful for these themes:
![image](https://github.com/user-attachments/assets/795f625a-3078-45ea-b4d8-73b005f6ed15)
![68747470733a2f2f692e696d6775722e636f6d2f674b77366362302e676966](https://github.com/user-attachments/assets/4352ee1d-7a61-4f3f-a5eb-10a015b31d69)
![68747470733a2f2f692e696d6775722e636f6d2f7a584f386f64552e676966](https://github.com/user-attachments/assets/890967f9-257a-4c53-a54d-3e0caa59903b)
![image](https://github.com/user-attachments/assets/e700b739-88c5-48e4-93f3-60139b63be01)

Also, upgraded the two rows of 4 mode to only jump down if on the first row and only jump up if on the second row.