### PR TITLE
added support for auto loading custom font

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -1229,6 +1229,18 @@ void load_font_text(const char *program, lv_obj_t *screen) {
                                            LV_PART_MAIN | LV_STATE_DEFAULT);
             }
         }
+    } else {
+        char theme_font_language[MAX_BUFFER_SIZE];
+        snprintf(theme_font_language, sizeof(theme_font_language), "%s/language/%s.bin",
+                STORAGE_PATH, config.SETTINGS.GENERAL.LANGUAGE);
+
+        if (file_exist(theme_font_language)) {
+            char theme_font_language_fs[MAX_BUFFER_SIZE];
+            snprintf(theme_font_language_fs, sizeof(theme_font_language_fs),
+                        "M:%s/language/%s.bin", STORAGE_PATH, config.SETTINGS.GENERAL.LANGUAGE);
+            lv_obj_set_style_text_font(screen, lv_font_load(theme_font_language_fs),
+                                        LV_PART_MAIN | LV_STATE_DEFAULT);
+        }        
     }
 }
 


### PR DESCRIPTION
If Interface Font Type is set to 'Noto Sans' system will check to see if a bin file exists in the language folder matching the selected language name and use that for the font