### PR TITLE
Change scroll acceleration in most of the muX apps to a more Hall-friendly implementation

### DIFF
--- a/muxapp/main.c
+++ b/muxapp/main.c
@@ -243,12 +243,19 @@ void joystick_task() {
     int epoll_fd;
     struct epoll_event event, events[device.DEVICE.EVENT];
 
-    int JOYUP_pressed = 0;
-    int JOYDOWN_pressed = 0;
+    enum {
+        JOY_NONE,
+        JOY_UP,
+        JOY_DOWN,
+    } joy_pressed = JOY_NONE;
+
+    // Delay (millis) before scrolling again on D-pad/joystick hold. Zero indicates no active hold.
+    uint32_t joy_hold_delay = 0;
+    // System clock (millis) when D-pad/joystick hold started. Reset each time we scroll the list.
+    uint32_t joy_hold_tick = 0;
+
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
-
-    int nav_hold = 0;
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -348,56 +355,22 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
+                            joy_pressed = JOY_NONE;
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
+                        if ((ev.code == NAV_DPAD_VER && ev.value == -1) ||
+                                (ev.code == NAV_ANLG_VER && ev.value <= -(int)device.INPUT.AXIS)) {
+                            joy_pressed = JOY_UP;
+                        } else if ((ev.code == NAV_DPAD_VER && ev.value == 1) ||
+                                (ev.code == NAV_ANLG_VER && ev.value >= (int)device.INPUT.AXIS)) {
+                            joy_pressed = JOY_DOWN;
+                        } else if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
+                            joy_pressed = JOY_NONE;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
-                        if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
-                                if (current_item_index == 0) {
-                                    current_item_index = ui_count - 1;
-                                    nav_prev(ui_group, 1);
-                                    nav_prev(ui_group_glyph, 1);
-                                    nav_prev(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                    nav_moved = 1;
-                                } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
-                                    list_nav_prev(1);
-                                }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
-                                if (current_item_index == ui_count - 1) {
-                                    current_item_index = 0;
-                                    nav_next(ui_group, 1);
-                                    nav_next(ui_group_glyph, 1);
-                                    nav_next(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                    nav_moved = 1;
-                                } else if (current_item_index < ui_count - 1) {
-                                    JOYDOWN_pressed = (ev.value != 0);
-                                    list_nav_next(1);
-                                }
-                            } else {
-                                JOYUP_pressed = 0;
-                                JOYDOWN_pressed = 0;
-                            }
-                        }
+                        break;
                     default:
                         break;
                 }
@@ -405,18 +378,51 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
+        bool joy_scrolled = false;
+        if (joy_pressed == JOY_UP) {
+            if (current_item_index == 0) {
+                // Stop scroll acceleration at top of list.
+                if (!joy_hold_delay) {
+                    current_item_index = ui_count - 1;
+                    nav_prev(ui_group, 1);
+                    nav_prev(ui_group_glyph, 1);
+                    nav_prev(ui_group_panel, 1);
+                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                                           current_item_index, ui_pnlContent);
+                    nav_moved = 1;
+                    joy_scrolled = true;
                 }
-                if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
-                    list_nav_next(1);
-                }
+            } else if (mux_tick() - joy_hold_tick >= joy_hold_delay) {
+                list_nav_prev(1);
+                joy_scrolled = true;
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
+        } else if (joy_pressed == JOY_DOWN) {
+            if (current_item_index == ui_count - 1) {
+                // Stop scroll acceleration at bottom of list.
+                if (!joy_hold_delay) {
+                    current_item_index = 0;
+                    nav_next(ui_group, 1);
+                    nav_next(ui_group_glyph, 1);
+                    nav_next(ui_group_panel, 1);
+                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                                           current_item_index, ui_pnlContent);
+                    nav_moved = 1;
+                    joy_scrolled = true;
+                }
+            } else if (mux_tick() - joy_hold_tick >= joy_hold_delay) {
+                list_nav_next(1);
+                joy_scrolled = true;
+            }
+        }
+
+        if (joy_pressed == JOY_NONE) {
+            joy_hold_delay = 0;
+        } else if (joy_scrolled) {
+            // Skip an extra delay interval before starting scroll acceleration on initial hold.
+            joy_hold_delay = !joy_hold_delay ?
+                2 * config.SETTINGS.ADVANCED.ACCELERATE :
+                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_tick = mux_tick();
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxapp/main.c
+++ b/muxapp/main.c
@@ -378,6 +378,7 @@ void joystick_task() {
             refresh_screen();
         }
 
+        // Handle vertical scrolling.
         bool joy_scrolled = false;
         if (joy_pressed == JOY_UP) {
             if (current_item_index == 0) {
@@ -415,13 +416,12 @@ void joystick_task() {
             }
         }
 
+        // Handle scroll acceleration.
         if (joy_pressed == JOY_NONE) {
             joy_hold_delay = 0;
         } else if (joy_scrolled) {
             // Skip an extra delay interval before starting scroll acceleration on initial hold.
-            joy_hold_delay = !joy_hold_delay ?
-                2 * config.SETTINGS.ADVANCED.ACCELERATE :
-                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_delay = (!joy_hold_delay ? 2 : 1) * config.SETTINGS.ADVANCED.ACCELERATE;
             joy_hold_tick = mux_tick();
         }
 

--- a/muxarchive/main.c
+++ b/muxarchive/main.c
@@ -377,6 +377,7 @@ void joystick_task() {
             refresh_screen();
         }
 
+        // Handle vertical scrolling.
         bool joy_scrolled = false;
         if (joy_pressed == JOY_UP) {
             if (current_item_index == 0) {
@@ -416,13 +417,12 @@ void joystick_task() {
             }
         }
 
+        // Handle scroll acceleration.
         if (joy_pressed == JOY_NONE) {
             joy_hold_delay = 0;
         } else if (joy_scrolled) {
             // Skip an extra delay interval before starting scroll acceleration on initial hold.
-            joy_hold_delay = !joy_hold_delay ?
-                2 * config.SETTINGS.ADVANCED.ACCELERATE :
-                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_delay = (!joy_hold_delay ? 2 : 1) * config.SETTINGS.ADVANCED.ACCELERATE;
             joy_hold_tick = mux_tick();
         }
 

--- a/muxarchive/main.c
+++ b/muxarchive/main.c
@@ -238,12 +238,19 @@ void joystick_task() {
     int epoll_fd;
     struct epoll_event event, events[device.DEVICE.EVENT];
 
-    int JOYUP_pressed = 0;
-    int JOYDOWN_pressed = 0;
+    enum {
+        JOY_NONE,
+        JOY_UP,
+        JOY_DOWN,
+    } joy_pressed = JOY_NONE;
+
+    // Delay (millis) before scrolling again on D-pad/joystick hold. Zero indicates no active hold.
+    uint32_t joy_hold_delay = 0;
+    // System clock (millis) when D-pad/joystick hold started. Reset each time we scroll the list.
+    uint32_t joy_hold_tick = 0;
+
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
-
-    int nav_hold = 0;
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -347,58 +354,22 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
+                            joy_pressed = JOY_NONE;
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
+                        if ((ev.code == NAV_DPAD_VER && ev.value == -1) ||
+                                (ev.code == NAV_ANLG_VER && ev.value <= -(int)device.INPUT.AXIS)) {
+                            joy_pressed = JOY_UP;
+                        } else if ((ev.code == NAV_DPAD_VER && ev.value == 1) ||
+                                (ev.code == NAV_ANLG_VER && ev.value >= (int)device.INPUT.AXIS)) {
+                            joy_pressed = JOY_DOWN;
+                        } else if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
+                            joy_pressed = JOY_NONE;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
-                        if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
-                                if (current_item_index == 0) {
-                                    current_item_index = ui_count - 1;
-                                    nav_prev(ui_group, 1);
-                                    nav_prev(ui_group_glyph, 1);
-                                    nav_prev(ui_group_panel, 1);
-                                    nav_prev(ui_group_installed, 1);
-                                    nav_prev(ui_group_data, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
-                                    list_nav_prev(1);
-                                }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
-                                if (current_item_index == ui_count - 1) {
-                                    current_item_index = 0;
-                                    nav_next(ui_group, 1);
-                                    nav_next(ui_group_glyph, 1);
-                                    nav_next(ui_group_panel, 1);
-                                    nav_next(ui_group_installed, 1);
-                                    nav_next(ui_group_data, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                } else if (current_item_index < ui_count) {
-                                    JOYDOWN_pressed = (ev.value != 0);
-                                    list_nav_next(1);
-                                }
-                            } else {
-                                JOYUP_pressed = 0;
-                                JOYDOWN_pressed = 0;
-                            }
-                        }
+                        break;
                     default:
                         break;
                 }
@@ -406,18 +377,53 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
+        bool joy_scrolled = false;
+        if (joy_pressed == JOY_UP) {
+            if (current_item_index == 0) {
+                // Stop scroll acceleration at top of list.
+                if (!joy_hold_delay) {
+                    current_item_index = ui_count - 1;
+                    nav_prev(ui_group, 1);
+                    nav_prev(ui_group_glyph, 1);
+                    nav_prev(ui_group_panel, 1);
+                    nav_prev(ui_group_installed, 1);
+                    nav_prev(ui_group_data, 1);
+                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                                           current_item_index, ui_pnlContent);
+                    joy_scrolled = true;
                 }
-                if (JOYDOWN_pressed && current_item_index < ui_count) {
-                    list_nav_next(1);
-                }
+            } else if (mux_tick() - joy_hold_tick >= joy_hold_delay) {
+                list_nav_prev(1);
+                joy_scrolled = true;
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
+        } else if (joy_pressed == JOY_DOWN) {
+            if (current_item_index == ui_count - 1) {
+                // Stop scroll acceleration at bottom of list.
+                if (!joy_hold_delay) {
+                    current_item_index = 0;
+                    nav_next(ui_group, 1);
+                    nav_next(ui_group_glyph, 1);
+                    nav_next(ui_group_panel, 1);
+                    nav_next(ui_group_installed, 1);
+                    nav_next(ui_group_data, 1);
+                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                                           current_item_index, ui_pnlContent);
+                    joy_scrolled = true;
+                }
+            } else if (mux_tick() - joy_hold_tick >= joy_hold_delay) {
+                list_nav_next(1);
+                joy_scrolled = true;
+            }
+        }
+
+        if (joy_pressed == JOY_NONE) {
+            joy_hold_delay = 0;
+        } else if (joy_scrolled) {
+            // Skip an extra delay interval before starting scroll acceleration on initial hold.
+            joy_hold_delay = !joy_hold_delay ?
+                2 * config.SETTINGS.ADVANCED.ACCELERATE :
+                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_tick = mux_tick();
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxassign/main.c
+++ b/muxassign/main.c
@@ -677,6 +677,7 @@ void joystick_task() {
             refresh_screen();
         }
 
+        // Handle vertical scrolling.
         bool joy_scrolled = false;
         if (joy_pressed == JOY_UP) {
             if (current_item_index == 0) {
@@ -712,13 +713,12 @@ void joystick_task() {
             }
         }
 
+        // Handle scroll acceleration.
         if (joy_pressed == JOY_NONE) {
             joy_hold_delay = 0;
         } else if (joy_scrolled) {
             // Skip an extra delay interval before starting scroll acceleration on initial hold.
-            joy_hold_delay = !joy_hold_delay ?
-                2 * config.SETTINGS.ADVANCED.ACCELERATE :
-                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_delay = (!joy_hold_delay ? 2 : 1) * config.SETTINGS.ADVANCED.ACCELERATE;
             joy_hold_tick = mux_tick();
         }
 

--- a/muxassign/main.c
+++ b/muxassign/main.c
@@ -456,12 +456,19 @@ void joystick_task() {
     int epoll_fd;
     struct epoll_event event, events[device.DEVICE.EVENT];
 
-    int JOYUP_pressed = 0;
-    int JOYDOWN_pressed = 0;
+    enum {
+        JOY_NONE,
+        JOY_UP,
+        JOY_DOWN,
+    } joy_pressed = JOY_NONE;
+
+    // Delay (millis) before scrolling again on D-pad/joystick hold. Zero indicates no active hold.
+    uint32_t joy_hold_delay = 0;
+    // System clock (millis) when D-pad/joystick hold started. Reset each time we scroll the list.
+    uint32_t joy_hold_tick = 0;
+
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
-
-    int nav_hold = 0;
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -647,54 +654,22 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
+                            joy_pressed = JOY_NONE;
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
+                        if ((ev.code == NAV_DPAD_VER && ev.value == -1) ||
+                                (ev.code == NAV_ANLG_VER && ev.value <= -(int)device.INPUT.AXIS)) {
+                            joy_pressed = JOY_UP;
+                        } else if ((ev.code == NAV_DPAD_VER && ev.value == 1) ||
+                                (ev.code == NAV_ANLG_VER && ev.value >= (int)device.INPUT.AXIS)) {
+                            joy_pressed = JOY_DOWN;
+                        } else if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
+                            joy_pressed = JOY_NONE;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
-                        if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
-                                if (current_item_index == 0) {
-                                    current_item_index = ui_count - 1;
-                                    nav_prev(ui_group, 1);
-                                    nav_prev(ui_group_glyph, 1);
-                                    nav_prev(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
-                                    list_nav_prev(1);
-                                }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
-                                if (current_item_index == ui_count - 1) {
-                                    current_item_index = 0;
-                                    nav_next(ui_group, 1);
-                                    nav_next(ui_group_glyph, 1);
-                                    nav_next(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                } else if (current_item_index < ui_count) {
-                                    JOYDOWN_pressed = (ev.value != 0);
-                                    list_nav_next(1);
-                                }
-                            } else {
-                                JOYUP_pressed = 0;
-                                JOYDOWN_pressed = 0;
-                            }
-                        }
+                        break;
                     default:
                         break;
                 }
@@ -702,18 +677,49 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
+        bool joy_scrolled = false;
+        if (joy_pressed == JOY_UP) {
+            if (current_item_index == 0) {
+                // Stop scroll acceleration at top of list.
+                if (!joy_hold_delay) {
+                    current_item_index = ui_count - 1;
+                    nav_prev(ui_group, 1);
+                    nav_prev(ui_group_glyph, 1);
+                    nav_prev(ui_group_panel, 1);
+                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                                           current_item_index, ui_pnlContent);
+                    joy_scrolled = true;
                 }
-                if (JOYDOWN_pressed && current_item_index < ui_count) {
-                    list_nav_next(1);
-                }
+            } else if (mux_tick() - joy_hold_tick >= joy_hold_delay) {
+                list_nav_prev(1);
+                joy_scrolled = true;
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
+        } else if (joy_pressed == JOY_DOWN) {
+            if (current_item_index == ui_count - 1) {
+                // Stop scroll acceleration at bottom of list.
+                if (!joy_hold_delay) {
+                    current_item_index = 0;
+                    nav_next(ui_group, 1);
+                    nav_next(ui_group_glyph, 1);
+                    nav_next(ui_group_panel, 1);
+                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                                           current_item_index, ui_pnlContent);
+                    joy_scrolled = true;
+                }
+            } else if (mux_tick() - joy_hold_tick >= joy_hold_delay) {
+                list_nav_next(1);
+                joy_scrolled = true;
+            }
+        }
+
+        if (joy_pressed == JOY_NONE) {
+            joy_hold_delay = 0;
+        } else if (joy_scrolled) {
+            // Skip an extra delay interval before starting scroll acceleration on initial hold.
+            joy_hold_delay = !joy_hold_delay ?
+                2 * config.SETTINGS.ADVANCED.ACCELERATE :
+                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_tick = mux_tick();
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxconfig/main.c
+++ b/muxconfig/main.c
@@ -187,12 +187,19 @@ void joystick_task() {
     int epoll_fd;
     struct epoll_event event, events[device.DEVICE.EVENT];
 
-    int JOYUP_pressed = 0;
-    int JOYDOWN_pressed = 0;
+    enum {
+        JOY_NONE,
+        JOY_UP,
+        JOY_DOWN,
+    } joy_pressed = JOY_NONE;
+
+    // Delay (millis) before scrolling again on D-pad/joystick hold. Zero indicates no active hold.
+    uint32_t joy_hold_delay = 0;
+    // System clock (millis) when D-pad/joystick hold started. Reset each time we scroll the list.
+    uint32_t joy_hold_tick = 0;
+
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
-
-    int nav_hold = 0;
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -285,58 +292,22 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
+                            joy_pressed = JOY_NONE;
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
+                        if ((ev.code == NAV_DPAD_VER && ev.value == -1) ||
+                                (ev.code == NAV_ANLG_VER && ev.value <= -(int)device.INPUT.AXIS)) {
+                            joy_pressed = JOY_UP;
+                        } else if ((ev.code == NAV_DPAD_VER && ev.value == 1) ||
+                                (ev.code == NAV_ANLG_VER && ev.value >= (int)device.INPUT.AXIS)) {
+                            joy_pressed = JOY_DOWN;
+                        } else if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
+                            joy_pressed = JOY_NONE;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
-                        if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
-                                if (current_item_index == 0) {
-                                    current_item_index = ui_count - 1;
-                                    nav_prev(ui_group, 1);
-                                    nav_prev(ui_group_glyph, 1);
-                                    nav_prev(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                    nav_moved = 1;
-                                } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
-                                    list_nav_prev(1);
-                                    nav_moved = 1;
-                                }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
-                                if (current_item_index == ui_count - 1) {
-                                    current_item_index = 0;
-                                    nav_next(ui_group, 1);
-                                    nav_next(ui_group_glyph, 1);
-                                    nav_next(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                    nav_moved = 1;
-                                } else if (current_item_index < ui_count - 1) {
-                                    JOYDOWN_pressed = (ev.value != 0);
-                                    list_nav_next(1);
-                                    nav_moved = 1;
-                                }
-                            } else {
-                                JOYUP_pressed = 0;
-                                JOYDOWN_pressed = 0;
-                            }
-                        }
+                        break;
                     default:
                         break;
                 }
@@ -344,18 +315,51 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
+        bool joy_scrolled = false;
+        if (joy_pressed == JOY_UP) {
+            if (current_item_index == 0) {
+                // Stop scroll acceleration at top of list.
+                if (!joy_hold_delay) {
+                    current_item_index = ui_count - 1;
+                    nav_prev(ui_group, 1);
+                    nav_prev(ui_group_glyph, 1);
+                    nav_prev(ui_group_panel, 1);
+                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                                           current_item_index, ui_pnlContent);
+                    nav_moved = 1;
+                    joy_scrolled = true;
                 }
-                if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
-                    list_nav_next(1);
-                }
+            } else if (mux_tick() - joy_hold_tick >= joy_hold_delay) {
+                list_nav_prev(1);
+                joy_scrolled = true;
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
+        } else if (joy_pressed == JOY_DOWN) {
+            if (current_item_index == ui_count - 1) {
+                // Stop scroll acceleration at bottom of list.
+                if (!joy_hold_delay) {
+                    current_item_index = 0;
+                    nav_next(ui_group, 1);
+                    nav_next(ui_group_glyph, 1);
+                    nav_next(ui_group_panel, 1);
+                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                                           current_item_index, ui_pnlContent);
+                    nav_moved = 1;
+                    joy_scrolled = true;
+                }
+            } else if (mux_tick() - joy_hold_tick >= joy_hold_delay) {
+                list_nav_next(1);
+                joy_scrolled = true;
+            }
+        }
+
+        if (joy_pressed == JOY_NONE) {
+            joy_hold_delay = 0;
+        } else if (joy_scrolled) {
+            // Skip an extra delay interval before starting scroll acceleration on initial hold.
+            joy_hold_delay = !joy_hold_delay ?
+                2 * config.SETTINGS.ADVANCED.ACCELERATE :
+                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_tick = mux_tick();
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxconfig/main.c
+++ b/muxconfig/main.c
@@ -315,6 +315,7 @@ void joystick_task() {
             refresh_screen();
         }
 
+        // Handle vertical scrolling.
         bool joy_scrolled = false;
         if (joy_pressed == JOY_UP) {
             if (current_item_index == 0) {
@@ -352,13 +353,12 @@ void joystick_task() {
             }
         }
 
+        // Handle scroll acceleration.
         if (joy_pressed == JOY_NONE) {
             joy_hold_delay = 0;
         } else if (joy_scrolled) {
             // Skip an extra delay interval before starting scroll acceleration on initial hold.
-            joy_hold_delay = !joy_hold_delay ?
-                2 * config.SETTINGS.ADVANCED.ACCELERATE :
-                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_delay = (!joy_hold_delay ? 2 : 1) * config.SETTINGS.ADVANCED.ACCELERATE;
             joy_hold_tick = mux_tick();
         }
 

--- a/muxgov/main.c
+++ b/muxgov/main.c
@@ -514,6 +514,7 @@ void joystick_task() {
             refresh_screen();
         }
 
+        // Handle vertical scrolling.
         bool joy_scrolled = false;
         if (joy_pressed == JOY_UP) {
             if (current_item_index == 0) {
@@ -549,13 +550,12 @@ void joystick_task() {
             }
         }
 
+        // Handle scroll acceleration.
         if (joy_pressed == JOY_NONE) {
             joy_hold_delay = 0;
         } else if (joy_scrolled) {
             // Skip an extra delay interval before starting scroll acceleration on initial hold.
-            joy_hold_delay = !joy_hold_delay ?
-                2 * config.SETTINGS.ADVANCED.ACCELERATE :
-                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_delay = (!joy_hold_delay ? 2 : 1) * config.SETTINGS.ADVANCED.ACCELERATE;
             joy_hold_tick = mux_tick();
         }
 

--- a/muxgov/main.c
+++ b/muxgov/main.c
@@ -368,12 +368,19 @@ void joystick_task() {
     int epoll_fd;
     struct epoll_event event, events[device.DEVICE.EVENT];
 
-    int JOYUP_pressed = 0;
-    int JOYDOWN_pressed = 0;
+    enum {
+        JOY_NONE,
+        JOY_UP,
+        JOY_DOWN,
+    } joy_pressed = JOY_NONE;
+
+    // Delay (millis) before scrolling again on D-pad/joystick hold. Zero indicates no active hold.
+    uint32_t joy_hold_delay = 0;
+    // System clock (millis) when D-pad/joystick hold started. Reset each time we scroll the list.
+    uint32_t joy_hold_tick = 0;
+
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
-
-    int nav_hold = 0;
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -484,54 +491,22 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
+                            joy_pressed = JOY_NONE;
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
+                        if ((ev.code == NAV_DPAD_VER && ev.value == -1) ||
+                                (ev.code == NAV_ANLG_VER && ev.value <= -(int)device.INPUT.AXIS)) {
+                            joy_pressed = JOY_UP;
+                        } else if ((ev.code == NAV_DPAD_VER && ev.value == 1) ||
+                                (ev.code == NAV_ANLG_VER && ev.value >= (int)device.INPUT.AXIS)) {
+                            joy_pressed = JOY_DOWN;
+                        } else if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
+                            joy_pressed = JOY_NONE;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
-                        if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
-                                if (current_item_index == 0) {
-                                    current_item_index = ui_count - 1;
-                                    nav_prev(ui_group, 1);
-                                    nav_prev(ui_group_glyph, 1);
-                                    nav_prev(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
-                                    list_nav_prev(1);
-                                }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
-                                if (current_item_index == ui_count - 1) {
-                                    current_item_index = 0;
-                                    nav_next(ui_group, 1);
-                                    nav_next(ui_group_glyph, 1);
-                                    nav_next(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                } else if (current_item_index < ui_count) {
-                                    JOYDOWN_pressed = (ev.value != 0);
-                                    list_nav_next(1);
-                                }
-                            } else {
-                                JOYUP_pressed = 0;
-                                JOYDOWN_pressed = 0;
-                            }
-                        }
+                        break;
                     default:
                         break;
                 }
@@ -539,18 +514,49 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
+        bool joy_scrolled = false;
+        if (joy_pressed == JOY_UP) {
+            if (current_item_index == 0) {
+                // Stop scroll acceleration at top of list.
+                if (!joy_hold_delay) {
+                    current_item_index = ui_count - 1;
+                    nav_prev(ui_group, 1);
+                    nav_prev(ui_group_glyph, 1);
+                    nav_prev(ui_group_panel, 1);
+                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                                           current_item_index, ui_pnlContent);
+                    joy_scrolled = true;
                 }
-                if (JOYDOWN_pressed && current_item_index < ui_count) {
-                    list_nav_next(1);
-                }
+            } else if (mux_tick() - joy_hold_tick >= joy_hold_delay) {
+                list_nav_prev(1);
+                joy_scrolled = true;
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
+        } else if (joy_pressed == JOY_DOWN) {
+            if (current_item_index == ui_count - 1) {
+                // Stop scroll acceleration at bottom of list.
+                if (!joy_hold_delay) {
+                    current_item_index = 0;
+                    nav_next(ui_group, 1);
+                    nav_next(ui_group_glyph, 1);
+                    nav_next(ui_group_panel, 1);
+                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                                           current_item_index, ui_pnlContent);
+                    joy_scrolled = true;
+                }
+            } else if (mux_tick() - joy_hold_tick >= joy_hold_delay) {
+                list_nav_next(1);
+                joy_scrolled = true;
+            }
+        }
+
+        if (joy_pressed == JOY_NONE) {
+            joy_hold_delay = 0;
+        } else if (joy_scrolled) {
+            // Skip an extra delay interval before starting scroll acceleration on initial hold.
+            joy_hold_delay = !joy_hold_delay ?
+                2 * config.SETTINGS.ADVANCED.ACCELERATE :
+                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_tick = mux_tick();
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxinfo/main.c
+++ b/muxinfo/main.c
@@ -291,6 +291,7 @@ void joystick_task() {
             refresh_screen();
         }
 
+        // Handle vertical scrolling.
         bool joy_scrolled = false;
         if (joy_pressed == JOY_UP) {
             if (current_item_index == 0) {
@@ -328,13 +329,12 @@ void joystick_task() {
             }
         }
 
+        // Handle scroll acceleration.
         if (joy_pressed == JOY_NONE) {
             joy_hold_delay = 0;
         } else if (joy_scrolled) {
             // Skip an extra delay interval before starting scroll acceleration on initial hold.
-            joy_hold_delay = !joy_hold_delay ?
-                2 * config.SETTINGS.ADVANCED.ACCELERATE :
-                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_delay = (!joy_hold_delay ? 2 : 1) * config.SETTINGS.ADVANCED.ACCELERATE;
             joy_hold_tick = mux_tick();
         }
 

--- a/muxlanguage/main.c
+++ b/muxlanguage/main.c
@@ -166,12 +166,19 @@ void joystick_task() {
     int epoll_fd;
     struct epoll_event event, events[device.DEVICE.EVENT];
 
-    int JOYUP_pressed = 0;
-    int JOYDOWN_pressed = 0;
+    enum {
+        JOY_NONE,
+        JOY_UP,
+        JOY_DOWN,
+    } joy_pressed = JOY_NONE;
+
+    // Delay (millis) before scrolling again on D-pad/joystick hold. Zero indicates no active hold.
+    uint32_t joy_hold_delay = 0;
+    // System clock (millis) when D-pad/joystick hold started. Reset each time we scroll the list.
+    uint32_t joy_hold_tick = 0;
+
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
-
-    int nav_hold = 0;
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -265,54 +272,22 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
+                            joy_pressed = JOY_NONE;
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
+                        if ((ev.code == NAV_DPAD_VER && ev.value == -1) ||
+                                (ev.code == NAV_ANLG_VER && ev.value <= -(int)device.INPUT.AXIS)) {
+                            joy_pressed = JOY_UP;
+                        } else if ((ev.code == NAV_DPAD_VER && ev.value == 1) ||
+                                (ev.code == NAV_ANLG_VER && ev.value >= (int)device.INPUT.AXIS)) {
+                            joy_pressed = JOY_DOWN;
+                        } else if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
+                            joy_pressed = JOY_NONE;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
-                        if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
-                                if (current_item_index == 0) {
-                                    current_item_index = ui_count - 1;
-                                    nav_prev(ui_group, 1);
-                                    nav_prev(ui_group_glyph, 1);
-                                    nav_prev(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
-                                    list_nav_prev(1);
-                                }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
-                                if (current_item_index == ui_count - 1) {
-                                    current_item_index = 0;
-                                    nav_next(ui_group, 1);
-                                    nav_next(ui_group_glyph, 1);
-                                    nav_next(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                } else if (current_item_index < ui_count) {
-                                    JOYDOWN_pressed = (ev.value != 0);
-                                    list_nav_next(1);
-                                }
-                            } else {
-                                JOYUP_pressed = 0;
-                                JOYDOWN_pressed = 0;
-                            }
-                        }
+                        break;
                     default:
                         break;
                 }
@@ -320,18 +295,49 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
+        bool joy_scrolled = false;
+        if (joy_pressed == JOY_UP) {
+            if (current_item_index == 0) {
+                // Stop scroll acceleration at top of list.
+                if (!joy_hold_delay) {
+                    current_item_index = ui_count - 1;
+                    nav_prev(ui_group, 1);
+                    nav_prev(ui_group_glyph, 1);
+                    nav_prev(ui_group_panel, 1);
+                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                                           current_item_index, ui_pnlContent);
+                    joy_scrolled = true;
                 }
-                if (JOYDOWN_pressed && current_item_index < ui_count) {
-                    list_nav_next(1);
-                }
+            } else if (mux_tick() - joy_hold_tick >= joy_hold_delay) {
+                list_nav_prev(1);
+                joy_scrolled = true;
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
+        } else if (joy_pressed == JOY_DOWN) {
+            if (current_item_index == ui_count - 1) {
+                // Stop scroll acceleration at bottom of list.
+                if (!joy_hold_delay) {
+                    current_item_index = 0;
+                    nav_next(ui_group, 1);
+                    nav_next(ui_group_glyph, 1);
+                    nav_next(ui_group_panel, 1);
+                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                                           current_item_index, ui_pnlContent);
+                    joy_scrolled = true;
+                }
+            } else if (mux_tick() - joy_hold_tick >= joy_hold_delay) {
+                list_nav_next(1);
+                joy_scrolled = true;
+            }
+        }
+
+        if (joy_pressed == JOY_NONE) {
+            joy_hold_delay = 0;
+        } else if (joy_scrolled) {
+            // Skip an extra delay interval before starting scroll acceleration on initial hold.
+            joy_hold_delay = !joy_hold_delay ?
+                2 * config.SETTINGS.ADVANCED.ACCELERATE :
+                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_tick = mux_tick();
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) && !config.BOOT.FACTORY_RESET) {

--- a/muxlanguage/main.c
+++ b/muxlanguage/main.c
@@ -295,6 +295,7 @@ void joystick_task() {
             refresh_screen();
         }
 
+        // Handle vertical scrolling.
         bool joy_scrolled = false;
         if (joy_pressed == JOY_UP) {
             if (current_item_index == 0) {
@@ -330,13 +331,12 @@ void joystick_task() {
             }
         }
 
+        // Handle scroll acceleration.
         if (joy_pressed == JOY_NONE) {
             joy_hold_delay = 0;
         } else if (joy_scrolled) {
             // Skip an extra delay interval before starting scroll acceleration on initial hold.
-            joy_hold_delay = !joy_hold_delay ?
-                2 * config.SETTINGS.ADVANCED.ACCELERATE :
-                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_delay = (!joy_hold_delay ? 2 : 1) * config.SETTINGS.ADVANCED.ACCELERATE;
             joy_hold_tick = mux_tick();
         }
 

--- a/muxnetprofile/main.c
+++ b/muxnetprofile/main.c
@@ -333,12 +333,19 @@ void joystick_task() {
     int epoll_fd;
     struct epoll_event event, events[device.DEVICE.EVENT];
 
-    int JOYUP_pressed = 0;
-    int JOYDOWN_pressed = 0;
+    enum {
+        JOY_NONE,
+        JOY_UP,
+        JOY_DOWN,
+    } joy_pressed = JOY_NONE;
+
+    // Delay (millis) before scrolling again on D-pad/joystick hold. Zero indicates no active hold.
+    uint32_t joy_hold_delay = 0;
+    // System clock (millis) when D-pad/joystick hold started. Reset each time we scroll the list.
+    uint32_t joy_hold_tick = 0;
+
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
-
-    int nav_hold = 0;
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -441,54 +448,22 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
+                            joy_pressed = JOY_NONE;
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
+                        if ((ev.code == NAV_DPAD_VER && ev.value == -1) ||
+                                (ev.code == NAV_ANLG_VER && ev.value <= -(int)device.INPUT.AXIS)) {
+                            joy_pressed = JOY_UP;
+                        } else if ((ev.code == NAV_DPAD_VER && ev.value == 1) ||
+                                (ev.code == NAV_ANLG_VER && ev.value >= (int)device.INPUT.AXIS)) {
+                            joy_pressed = JOY_DOWN;
+                        } else if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
+                            joy_pressed = JOY_NONE;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
-                        if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
-                                if (current_item_index == 0) {
-                                    current_item_index = ui_count - 1;
-                                    nav_prev(ui_group, 1);
-                                    nav_prev(ui_group_glyph, 1);
-                                    nav_prev(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
-                                    list_nav_prev(1);
-                                }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
-                                if (current_item_index == ui_count - 1) {
-                                    current_item_index = 0;
-                                    nav_next(ui_group, 1);
-                                    nav_next(ui_group_glyph, 1);
-                                    nav_next(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                } else if (current_item_index < ui_count) {
-                                    JOYDOWN_pressed = (ev.value != 0);
-                                    list_nav_next(1);
-                                }
-                            } else {
-                                JOYUP_pressed = 0;
-                                JOYDOWN_pressed = 0;
-                            }
-                        }
+                        break;
                     default:
                         break;
                 }
@@ -496,18 +471,49 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
+        bool joy_scrolled = false;
+        if (joy_pressed == JOY_UP) {
+            if (current_item_index == 0) {
+                // Stop scroll acceleration at top of list.
+                if (!joy_hold_delay) {
+                    current_item_index = ui_count - 1;
+                    nav_prev(ui_group, 1);
+                    nav_prev(ui_group_glyph, 1);
+                    nav_prev(ui_group_panel, 1);
+                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                                           current_item_index, ui_pnlContent);
+                    joy_scrolled = true;
                 }
-                if (JOYDOWN_pressed && current_item_index < ui_count) {
-                    list_nav_next(1);
-                }
+            } else if (mux_tick() - joy_hold_tick >= joy_hold_delay) {
+                list_nav_prev(1);
+                joy_scrolled = true;
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
+        } else if (joy_pressed == JOY_DOWN) {
+            if (current_item_index == ui_count - 1) {
+                // Stop scroll acceleration at bottom of list.
+                if (!joy_hold_delay) {
+                    current_item_index = 0;
+                    nav_next(ui_group, 1);
+                    nav_next(ui_group_glyph, 1);
+                    nav_next(ui_group_panel, 1);
+                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                                           current_item_index, ui_pnlContent);
+                    joy_scrolled = true;
+                }
+            } else if (mux_tick() - joy_hold_tick >= joy_hold_delay) {
+                list_nav_next(1);
+                joy_scrolled = true;
+            }
+        }
+
+        if (joy_pressed == JOY_NONE) {
+            joy_hold_delay = 0;
+        } else if (joy_scrolled) {
+            // Skip an extra delay interval before starting scroll acceleration on initial hold.
+            joy_hold_delay = !joy_hold_delay ?
+                2 * config.SETTINGS.ADVANCED.ACCELERATE :
+                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_tick = mux_tick();
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxnetprofile/main.c
+++ b/muxnetprofile/main.c
@@ -471,6 +471,7 @@ void joystick_task() {
             refresh_screen();
         }
 
+        // Handle vertical scrolling.
         bool joy_scrolled = false;
         if (joy_pressed == JOY_UP) {
             if (current_item_index == 0) {
@@ -506,13 +507,12 @@ void joystick_task() {
             }
         }
 
+        // Handle scroll acceleration.
         if (joy_pressed == JOY_NONE) {
             joy_hold_delay = 0;
         } else if (joy_scrolled) {
             // Skip an extra delay interval before starting scroll acceleration on initial hold.
-            joy_hold_delay = !joy_hold_delay ?
-                2 * config.SETTINGS.ADVANCED.ACCELERATE :
-                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_delay = (!joy_hold_delay ? 2 : 1) * config.SETTINGS.ADVANCED.ACCELERATE;
             joy_hold_tick = mux_tick();
         }
 

--- a/muxnetscan/main.c
+++ b/muxnetscan/main.c
@@ -286,6 +286,7 @@ void joystick_task() {
             refresh_screen();
         }
 
+        // Handle vertical scrolling.
         bool joy_scrolled = false;
         if (joy_pressed == JOY_UP) {
             if (current_item_index == 0) {
@@ -321,13 +322,12 @@ void joystick_task() {
             }
         }
 
+        // Handle scroll acceleration.
         if (joy_pressed == JOY_NONE) {
             joy_hold_delay = 0;
         } else if (joy_scrolled) {
             // Skip an extra delay interval before starting scroll acceleration on initial hold.
-            joy_hold_delay = !joy_hold_delay ?
-                2 * config.SETTINGS.ADVANCED.ACCELERATE :
-                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_delay = (!joy_hold_delay ? 2 : 1) * config.SETTINGS.ADVANCED.ACCELERATE;
             joy_hold_tick = mux_tick();
         }
 

--- a/muxnetscan/main.c
+++ b/muxnetscan/main.c
@@ -154,12 +154,19 @@ void joystick_task() {
     int epoll_fd;
     struct epoll_event event, events[device.DEVICE.EVENT];
 
-    int JOYUP_pressed = 0;
-    int JOYDOWN_pressed = 0;
+    enum {
+        JOY_NONE,
+        JOY_UP,
+        JOY_DOWN,
+    } joy_pressed = JOY_NONE;
+
+    // Delay (millis) before scrolling again on D-pad/joystick hold. Zero indicates no active hold.
+    uint32_t joy_hold_delay = 0;
+    // System clock (millis) when D-pad/joystick hold started. Reset each time we scroll the list.
+    uint32_t joy_hold_tick = 0;
+
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
-
-    int nav_hold = 0;
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -256,54 +263,22 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
+                            joy_pressed = JOY_NONE;
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
+                        if ((ev.code == NAV_DPAD_VER && ev.value == -1) ||
+                                (ev.code == NAV_ANLG_VER && ev.value <= -(int)device.INPUT.AXIS)) {
+                            joy_pressed = JOY_UP;
+                        } else if ((ev.code == NAV_DPAD_VER && ev.value == 1) ||
+                                (ev.code == NAV_ANLG_VER && ev.value >= (int)device.INPUT.AXIS)) {
+                            joy_pressed = JOY_DOWN;
+                        } else if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
+                            joy_pressed = JOY_NONE;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
-                        if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
-                                if (current_item_index == 0) {
-                                    current_item_index = ui_count - 1;
-                                    nav_prev(ui_group, 1);
-                                    nav_prev(ui_group_glyph, 1);
-                                    nav_prev(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
-                                    list_nav_prev(1);
-                                }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
-                                if (current_item_index == ui_count - 1) {
-                                    current_item_index = 0;
-                                    nav_next(ui_group, 1);
-                                    nav_next(ui_group_glyph, 1);
-                                    nav_next(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                } else if (current_item_index < ui_count) {
-                                    JOYDOWN_pressed = (ev.value != 0);
-                                    list_nav_next(1);
-                                }
-                            } else {
-                                JOYUP_pressed = 0;
-                                JOYDOWN_pressed = 0;
-                            }
-                        }
+                        break;
                     default:
                         break;
                 }
@@ -311,18 +286,49 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
+        bool joy_scrolled = false;
+        if (joy_pressed == JOY_UP) {
+            if (current_item_index == 0) {
+                // Stop scroll acceleration at top of list.
+                if (!joy_hold_delay) {
+                    current_item_index = ui_count - 1;
+                    nav_prev(ui_group, 1);
+                    nav_prev(ui_group_glyph, 1);
+                    nav_prev(ui_group_panel, 1);
+                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                                           current_item_index, ui_pnlContent);
+                    joy_scrolled = true;
                 }
-                if (JOYDOWN_pressed && current_item_index < ui_count) {
-                    list_nav_next(1);
-                }
+            } else if (mux_tick() - joy_hold_tick >= joy_hold_delay) {
+                list_nav_prev(1);
+                joy_scrolled = true;
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
+        } else if (joy_pressed == JOY_DOWN) {
+            if (current_item_index == ui_count - 1) {
+                // Stop scroll acceleration at bottom of list.
+                if (!joy_hold_delay) {
+                    current_item_index = 0;
+                    nav_next(ui_group, 1);
+                    nav_next(ui_group_glyph, 1);
+                    nav_next(ui_group_panel, 1);
+                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                                           current_item_index, ui_pnlContent);
+                    joy_scrolled = true;
+                }
+            } else if (mux_tick() - joy_hold_tick >= joy_hold_delay) {
+                list_nav_next(1);
+                joy_scrolled = true;
+            }
+        }
+
+        if (joy_pressed == JOY_NONE) {
+            joy_hold_delay = 0;
+        } else if (joy_scrolled) {
+            // Skip an extra delay interval before starting scroll acceleration on initial hold.
+            joy_hold_delay = !joy_hold_delay ?
+                2 * config.SETTINGS.ADVANCED.ACCELERATE :
+                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_tick = mux_tick();
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxoption/main.c
+++ b/muxoption/main.c
@@ -281,6 +281,7 @@ void joystick_task() {
             refresh_screen();
         }
 
+        // Handle vertical scrolling.
         bool joy_scrolled = false;
         if (joy_pressed == JOY_UP) {
             if (current_item_index == 0) {
@@ -318,13 +319,12 @@ void joystick_task() {
             }
         }
 
+        // Handle scroll acceleration.
         if (joy_pressed == JOY_NONE) {
             joy_hold_delay = 0;
         } else if (joy_scrolled) {
             // Skip an extra delay interval before starting scroll acceleration on initial hold.
-            joy_hold_delay = !joy_hold_delay ?
-                2 * config.SETTINGS.ADVANCED.ACCELERATE :
-                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_delay = (!joy_hold_delay ? 2 : 1) * config.SETTINGS.ADVANCED.ACCELERATE;
             joy_hold_tick = mux_tick();
         }
 

--- a/muxoption/main.c
+++ b/muxoption/main.c
@@ -156,12 +156,19 @@ void joystick_task() {
     int epoll_fd;
     struct epoll_event event, events[device.DEVICE.EVENT];
 
-    int JOYUP_pressed = 0;
-    int JOYDOWN_pressed = 0;
+    enum {
+        JOY_NONE,
+        JOY_UP,
+        JOY_DOWN,
+    } joy_pressed = JOY_NONE;
+
+    // Delay (millis) before scrolling again on D-pad/joystick hold. Zero indicates no active hold.
+    uint32_t joy_hold_delay = 0;
+    // System clock (millis) when D-pad/joystick hold started. Reset each time we scroll the list.
+    uint32_t joy_hold_tick = 0;
+
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
-
-    int nav_hold = 0;
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -251,58 +258,22 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
+                            joy_pressed = JOY_NONE;
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
+                        if ((ev.code == NAV_DPAD_VER && ev.value == -1) ||
+                                (ev.code == NAV_ANLG_VER && ev.value <= -(int)device.INPUT.AXIS)) {
+                            joy_pressed = JOY_UP;
+                        } else if ((ev.code == NAV_DPAD_VER && ev.value == 1) ||
+                                (ev.code == NAV_ANLG_VER && ev.value >= (int)device.INPUT.AXIS)) {
+                            joy_pressed = JOY_DOWN;
+                        } else if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
+                            joy_pressed = JOY_NONE;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
-                        if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
-                                if (current_item_index == 0) {
-                                    current_item_index = UI_COUNT - 1;
-                                    nav_prev(ui_group, 1);
-                                    nav_prev(ui_group_glyph, 1);
-                                    nav_prev(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
-                                                           current_item_index, ui_pnlContent);
-                                    nav_moved = 1;
-                                } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
-                                    list_nav_prev(1);
-                                    nav_moved = 1;
-                                }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
-                                if (current_item_index == UI_COUNT - 1) {
-                                    current_item_index = 0;
-                                    nav_next(ui_group, 1);
-                                    nav_next(ui_group_glyph, 1);
-                                    nav_next(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
-                                                           current_item_index, ui_pnlContent);
-                                    nav_moved = 1;
-                                } else if (current_item_index < UI_COUNT - 1) {
-                                    JOYDOWN_pressed = (ev.value != 0);
-                                    list_nav_next(1);
-                                    nav_moved = 1;
-                                }
-                            } else {
-                                JOYUP_pressed = 0;
-                                JOYDOWN_pressed = 0;
-                            }
-                        }
+                        break;
                     default:
                         break;
                 }
@@ -310,18 +281,51 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
+        bool joy_scrolled = false;
+        if (joy_pressed == JOY_UP) {
+            if (current_item_index == 0) {
+                // Stop scroll acceleration at top of list.
+                if (!joy_hold_delay) {
+                    current_item_index = UI_COUNT - 1;
+                    nav_prev(ui_group, 1);
+                    nav_prev(ui_group_glyph, 1);
+                    nav_prev(ui_group_panel, 1);
+                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
+                                           current_item_index, ui_pnlContent);
+                    nav_moved = 1;
+                    joy_scrolled = true;
                 }
-                if (JOYDOWN_pressed && current_item_index < UI_COUNT - 1) {
-                    list_nav_next(1);
-                }
+            } else if (mux_tick() - joy_hold_tick >= joy_hold_delay) {
+                list_nav_prev(1);
+                joy_scrolled = true;
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
+        } else if (joy_pressed == JOY_DOWN) {
+            if (current_item_index == ui_count - 1) {
+                // Stop scroll acceleration at bottom of list.
+                if (!joy_hold_delay) {
+                    current_item_index = 0;
+                    nav_next(ui_group, 1);
+                    nav_next(ui_group_glyph, 1);
+                    nav_next(ui_group_panel, 1);
+                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
+                                           current_item_index, ui_pnlContent);
+                    nav_moved = 1;
+                    joy_scrolled = true;
+                }
+            } else if (mux_tick() - joy_hold_tick >= joy_hold_delay) {
+                list_nav_next(1);
+                joy_scrolled = true;
+            }
+        }
+
+        if (joy_pressed == JOY_NONE) {
+            joy_hold_delay = 0;
+        } else if (joy_scrolled) {
+            // Skip an extra delay interval before starting scroll acceleration on initial hold.
+            joy_hold_delay = !joy_hold_delay ?
+                2 * config.SETTINGS.ADVANCED.ACCELERATE :
+                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_tick = mux_tick();
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxplore/main.c
+++ b/muxplore/main.c
@@ -1653,6 +1653,7 @@ void joystick_task() {
             refresh_screen();
         }
 
+        // Handle vertical scrolling.
         bool joy_scrolled = false;
         if (joy_pressed == JOY_UP) {
             if (current_item_index == 0) {
@@ -1698,13 +1699,12 @@ void joystick_task() {
             }
         }
 
+        // Handle scroll acceleration.
         if (joy_pressed == JOY_NONE) {
             joy_hold_delay = 0;
         } else if (joy_scrolled) {
             // Skip an extra delay interval before starting scroll acceleration on initial hold.
-            joy_hold_delay = !joy_hold_delay ?
-                2 * config.SETTINGS.ADVANCED.ACCELERATE :
-                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_delay = (!joy_hold_delay ? 2 : 1) * config.SETTINGS.ADVANCED.ACCELERATE;
             joy_hold_tick = mux_tick();
         }
 

--- a/muxplore/main.c
+++ b/muxplore/main.c
@@ -1630,6 +1630,7 @@ void joystick_task() {
                         }
                         break;
                     case EV_ABS:
+                        if (ui_count == 0) goto nothing_ever_happens;
                         if (msgbox_active) {
                             joy_pressed = JOY_NONE;
                             break;

--- a/muxplore/main.c
+++ b/muxplore/main.c
@@ -1636,10 +1636,10 @@ void joystick_task() {
                             break;
                         }
                         if ((ev.code == NAV_DPAD_VER && ev.value == -1) ||
-                                (ev.code == NAV_ANLG_VER && ev.value <= -4096/*device.INPUT.AXIS*/)) {
+                                (ev.code == NAV_ANLG_VER && ev.value <= -(int)device.INPUT.AXIS)) {
                             joy_pressed = JOY_UP;
                         } else if ((ev.code == NAV_DPAD_VER && ev.value == 1) ||
-                                (ev.code == NAV_ANLG_VER && ev.value >= 4096/*device.INPUT.AXIS*/)) {
+                                (ev.code == NAV_ANLG_VER && ev.value >= (int)device.INPUT.AXIS)) {
                             joy_pressed = JOY_DOWN;
                         } else if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
                             joy_pressed = JOY_NONE;

--- a/muxsysinfo/main.c
+++ b/muxsysinfo/main.c
@@ -350,12 +350,19 @@ void joystick_task() {
     int epoll_fd;
     struct epoll_event event, events[device.DEVICE.EVENT];
 
-    int JOYUP_pressed = 0;
-    int JOYDOWN_pressed = 0;
+    enum {
+        JOY_NONE,
+        JOY_UP,
+        JOY_DOWN,
+    } joy_pressed = JOY_NONE;
+
+    // Delay (millis) before scrolling again on D-pad/joystick hold. Zero indicates no active hold.
+    uint32_t joy_hold_delay = 0;
+    // System clock (millis) when D-pad/joystick hold started. Reset each time we scroll the list.
+    uint32_t joy_hold_tick = 0;
+
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
-
-    int nav_hold = 0;
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -439,60 +446,22 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
+                            joy_pressed = JOY_NONE;
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
+                        if ((ev.code == NAV_DPAD_VER && ev.value == -1) ||
+                                (ev.code == NAV_ANLG_VER && ev.value <= -(int)device.INPUT.AXIS)) {
+                            joy_pressed = JOY_UP;
+                        } else if ((ev.code == NAV_DPAD_VER && ev.value == 1) ||
+                                (ev.code == NAV_ANLG_VER && ev.value >= (int)device.INPUT.AXIS)) {
+                            joy_pressed = JOY_DOWN;
+                        } else if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
+                            joy_pressed = JOY_NONE;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
-                        if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
-                                if (current_item_index == 0) {
-                                    current_item_index = UI_COUNT - 1;
-                                    nav_prev(ui_group, 1);
-                                    nav_prev(ui_group_value, 1);
-                                    nav_prev(ui_group_glyph, 1);
-                                    nav_prev(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
-                                                           current_item_index, ui_pnlContent);
-                                    nav_moved = 1;
-                                } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
-                                    list_nav_prev(1);
-                                    nav_moved = 1;
-                                }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
-                                if (current_item_index == UI_COUNT - 1) {
-                                    current_item_index = 0;
-                                    nav_next(ui_group, 1);
-                                    nav_next(ui_group_value, 1);
-                                    nav_next(ui_group_glyph, 1);
-                                    nav_next(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
-                                                           current_item_index, ui_pnlContent);
-                                    nav_moved = 1;
-                                } else if (current_item_index < UI_COUNT - 1) {
-                                    JOYDOWN_pressed = (ev.value != 0);
-                                    list_nav_next(1);
-                                    nav_moved = 1;
-                                }
-                            } else {
-                                JOYUP_pressed = 0;
-                                JOYDOWN_pressed = 0;
-                            }
-                        }
+                        break;
                     default:
                         break;
                 }
@@ -500,18 +469,53 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
+        bool joy_scrolled = false;
+        if (joy_pressed == JOY_UP) {
+            if (current_item_index == 0) {
+                // Stop scroll acceleration at top of list.
+                if (!joy_hold_delay) {
+                    current_item_index = UI_COUNT - 1;
+                    nav_prev(ui_group, 1);
+                    nav_prev(ui_group_value, 1);
+                    nav_prev(ui_group_glyph, 1);
+                    nav_prev(ui_group_panel, 1);
+                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
+                                           current_item_index, ui_pnlContent);
+                    nav_moved = 1;
+                    joy_scrolled = true;
                 }
-                if (JOYDOWN_pressed && current_item_index < UI_COUNT - 1) {
-                    list_nav_next(1);
-                }
+            } else if (mux_tick() - joy_hold_tick >= joy_hold_delay) {
+                list_nav_prev(1);
+                joy_scrolled = true;
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
+        } else if (joy_pressed == JOY_DOWN) {
+            if (current_item_index == UI_COUNT - 1) {
+                // Stop scroll acceleration at bottom of list.
+                if (!joy_hold_delay) {
+                    current_item_index = 0;
+                    nav_next(ui_group, 1);
+                    nav_next(ui_group_value, 1);
+                    nav_next(ui_group_glyph, 1);
+                    nav_next(ui_group_panel, 1);
+                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
+                                           current_item_index, ui_pnlContent);
+                    nav_moved = 1;
+                    joy_scrolled = true;
+                }
+            } else if (mux_tick() - joy_hold_tick >= joy_hold_delay) {
+                list_nav_next(1);
+                joy_scrolled = true;
+            }
+        }
+
+        if (joy_pressed == JOY_NONE) {
+            joy_hold_delay = 0;
+        } else if (joy_scrolled) {
+            // Skip an extra delay interval before starting scroll acceleration on initial hold.
+            joy_hold_delay = !joy_hold_delay ?
+                2 * config.SETTINGS.ADVANCED.ACCELERATE :
+                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_tick = mux_tick();
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxsysinfo/main.c
+++ b/muxsysinfo/main.c
@@ -469,6 +469,7 @@ void joystick_task() {
             refresh_screen();
         }
 
+        // Handle vertical scrolling.
         bool joy_scrolled = false;
         if (joy_pressed == JOY_UP) {
             if (current_item_index == 0) {
@@ -508,13 +509,12 @@ void joystick_task() {
             }
         }
 
+        // Handle scroll acceleration.
         if (joy_pressed == JOY_NONE) {
             joy_hold_delay = 0;
         } else if (joy_scrolled) {
             // Skip an extra delay interval before starting scroll acceleration on initial hold.
-            joy_hold_delay = !joy_hold_delay ?
-                2 * config.SETTINGS.ADVANCED.ACCELERATE :
-                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_delay = (!joy_hold_delay ? 2 : 1) * config.SETTINGS.ADVANCED.ACCELERATE;
             joy_hold_tick = mux_tick();
         }
 

--- a/muxtask/main.c
+++ b/muxtask/main.c
@@ -243,12 +243,19 @@ void joystick_task() {
     int epoll_fd;
     struct epoll_event event, events[device.DEVICE.EVENT];
 
-    int JOYUP_pressed = 0;
-    int JOYDOWN_pressed = 0;
+    enum {
+        JOY_NONE,
+        JOY_UP,
+        JOY_DOWN,
+    } joy_pressed = JOY_NONE;
+
+    // Delay (millis) before scrolling again on D-pad/joystick hold. Zero indicates no active hold.
+    uint32_t joy_hold_delay = 0;
+    // System clock (millis) when D-pad/joystick hold started. Reset each time we scroll the list.
+    uint32_t joy_hold_tick = 0;
+
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
-
-    int nav_hold = 0;
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -351,54 +358,22 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
+                            joy_pressed = JOY_NONE;
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
+                        if ((ev.code == NAV_DPAD_VER && ev.value == -1) ||
+                                (ev.code == NAV_ANLG_VER && ev.value <= -(int)device.INPUT.AXIS)) {
+                            joy_pressed = JOY_UP;
+                        } else if ((ev.code == NAV_DPAD_VER && ev.value == 1) ||
+                                (ev.code == NAV_ANLG_VER && ev.value >= (int)device.INPUT.AXIS)) {
+                            joy_pressed = JOY_DOWN;
+                        } else if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
+                            joy_pressed = JOY_NONE;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
-                        if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
-                                if (current_item_index == 0) {
-                                    current_item_index = ui_count - 1;
-                                    nav_prev(ui_group, 1);
-                                    nav_prev(ui_group_glyph, 1);
-                                    nav_prev(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
-                                    list_nav_prev(1);
-                                }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
-                                if (current_item_index == ui_count - 1) {
-                                    current_item_index = 0;
-                                    nav_next(ui_group, 1);
-                                    nav_next(ui_group_glyph, 1);
-                                    nav_next(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                } else if (current_item_index < ui_count) {
-                                    JOYDOWN_pressed = (ev.value != 0);
-                                    list_nav_next(1);
-                                }
-                            } else {
-                                JOYUP_pressed = 0;
-                                JOYDOWN_pressed = 0;
-                            }
-                        }
+                        break;
                     default:
                         break;
                 }
@@ -406,18 +381,49 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
+        bool joy_scrolled = false;
+        if (joy_pressed == JOY_UP) {
+            if (current_item_index == 0) {
+                // Stop scroll acceleration at top of list.
+                if (!joy_hold_delay) {
+                    current_item_index = ui_count - 1;
+                    nav_prev(ui_group, 1);
+                    nav_prev(ui_group_glyph, 1);
+                    nav_prev(ui_group_panel, 1);
+                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                                           current_item_index, ui_pnlContent);
+                    joy_scrolled = true;
                 }
-                if (JOYDOWN_pressed && current_item_index < ui_count) {
-                    list_nav_next(1);
-                }
+            } else if (mux_tick() - joy_hold_tick >= joy_hold_delay) {
+                list_nav_prev(1);
+                joy_scrolled = true;
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
+        } else if (joy_pressed == JOY_DOWN) {
+            if (current_item_index == ui_count - 1) {
+                // Stop scroll acceleration at bottom of list.
+                if (!joy_hold_delay) {
+                    current_item_index = 0;
+                    nav_next(ui_group, 1);
+                    nav_next(ui_group_glyph, 1);
+                    nav_next(ui_group_panel, 1);
+                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                                           current_item_index, ui_pnlContent);
+                    joy_scrolled = true;
+                }
+            } else if (mux_tick() - joy_hold_tick >= joy_hold_delay) {
+                list_nav_next(1);
+                joy_scrolled = true;
+            }
+        }
+
+        if (joy_pressed == JOY_NONE) {
+            joy_hold_delay = 0;
+        } else if (joy_scrolled) {
+            // Skip an extra delay interval before starting scroll acceleration on initial hold.
+            joy_hold_delay = !joy_hold_delay ?
+                2 * config.SETTINGS.ADVANCED.ACCELERATE :
+                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_tick = mux_tick();
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxtask/main.c
+++ b/muxtask/main.c
@@ -381,6 +381,7 @@ void joystick_task() {
             refresh_screen();
         }
 
+        // Handle vertical scrolling.
         bool joy_scrolled = false;
         if (joy_pressed == JOY_UP) {
             if (current_item_index == 0) {
@@ -416,13 +417,12 @@ void joystick_task() {
             }
         }
 
+        // Handle scroll acceleration.
         if (joy_pressed == JOY_NONE) {
             joy_hold_delay = 0;
         } else if (joy_scrolled) {
             // Skip an extra delay interval before starting scroll acceleration on initial hold.
-            joy_hold_delay = !joy_hold_delay ?
-                2 * config.SETTINGS.ADVANCED.ACCELERATE :
-                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_delay = (!joy_hold_delay ? 2 : 1) * config.SETTINGS.ADVANCED.ACCELERATE;
             joy_hold_tick = mux_tick();
         }
 

--- a/muxtheme/main.c
+++ b/muxtheme/main.c
@@ -345,6 +345,7 @@ void joystick_task() {
             refresh_screen();
         }
 
+        // Handle vertical scrolling.
         bool joy_scrolled = false;
         if (joy_pressed == JOY_UP) {
             if (current_item_index == 0) {
@@ -382,13 +383,12 @@ void joystick_task() {
             }
         }
 
+        // Handle scroll acceleration.
         if (joy_pressed == JOY_NONE) {
             joy_hold_delay = 0;
         } else if (joy_scrolled) {
             // Skip an extra delay interval before starting scroll acceleration on initial hold.
-            joy_hold_delay = !joy_hold_delay ?
-                2 * config.SETTINGS.ADVANCED.ACCELERATE :
-                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_delay = (!joy_hold_delay ? 2 : 1) * config.SETTINGS.ADVANCED.ACCELERATE;
             joy_hold_tick = mux_tick();
         }
 

--- a/muxtheme/main.c
+++ b/muxtheme/main.c
@@ -203,12 +203,19 @@ void joystick_task() {
     int epoll_fd;
     struct epoll_event event, events[device.DEVICE.EVENT];
 
-    int JOYUP_pressed = 0;
-    int JOYDOWN_pressed = 0;
+    enum {
+        JOY_NONE,
+        JOY_UP,
+        JOY_DOWN,
+    } joy_pressed = JOY_NONE;
+
+    // Delay (millis) before scrolling again on D-pad/joystick hold. Zero indicates no active hold.
+    uint32_t joy_hold_delay = 0;
+    // System clock (millis) when D-pad/joystick hold started. Reset each time we scroll the list.
+    uint32_t joy_hold_tick = 0;
+
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
-
-    int nav_hold = 0;
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -315,56 +322,22 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
+                            joy_pressed = JOY_NONE;
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
+                        if ((ev.code == NAV_DPAD_VER && ev.value == -1) ||
+                                (ev.code == NAV_ANLG_VER && ev.value <= -(int)device.INPUT.AXIS)) {
+                            joy_pressed = JOY_UP;
+                        } else if ((ev.code == NAV_DPAD_VER && ev.value == 1) ||
+                                (ev.code == NAV_ANLG_VER && ev.value >= (int)device.INPUT.AXIS)) {
+                            joy_pressed = JOY_DOWN;
+                        } else if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
+                            joy_pressed = JOY_NONE;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
-                        if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
-                                if (current_item_index == 0) {
-                                    current_item_index = ui_count - 1;
-                                    nav_prev(ui_group, 1);
-                                    nav_prev(ui_group_glyph, 1);
-                                    nav_prev(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                    image_refresh();
-                                } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
-                                    list_nav_prev(1);
-                                }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
-                                if (current_item_index == ui_count - 1) {
-                                    current_item_index = 0;
-                                    nav_next(ui_group, 1);
-                                    nav_next(ui_group_glyph, 1);
-                                    nav_next(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                    image_refresh();
-                                } else if (current_item_index < ui_count) {
-                                    JOYDOWN_pressed = (ev.value != 0);
-                                    list_nav_next(1);
-                                }
-                            } else {
-                                JOYUP_pressed = 0;
-                                JOYDOWN_pressed = 0;
-                            }
-                        }
+                        break;
                     default:
                         break;
                 }
@@ -372,18 +345,51 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
+        bool joy_scrolled = false;
+        if (joy_pressed == JOY_UP) {
+            if (current_item_index == 0) {
+                // Stop scroll acceleration at top of list.
+                if (!joy_hold_delay) {
+                    current_item_index = ui_count - 1;
+                    nav_prev(ui_group, 1);
+                    nav_prev(ui_group_glyph, 1);
+                    nav_prev(ui_group_panel, 1);
+                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                                           current_item_index, ui_pnlContent);
+                    image_refresh();
+                    joy_scrolled = true;
                 }
-                if (JOYDOWN_pressed && current_item_index < ui_count) {
-                    list_nav_next(1);
-                }
+            } else if (mux_tick() - joy_hold_tick >= joy_hold_delay) {
+                list_nav_prev(1);
+                joy_scrolled = true;
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
+        } else if (joy_pressed == JOY_DOWN) {
+            if (current_item_index == ui_count - 1) {
+                // Stop scroll acceleration at bottom of list.
+                if (!joy_hold_delay) {
+                    current_item_index = 0;
+                    nav_next(ui_group, 1);
+                    nav_next(ui_group_glyph, 1);
+                    nav_next(ui_group_panel, 1);
+                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                                           current_item_index, ui_pnlContent);
+                    image_refresh();
+                    joy_scrolled = true;
+                }
+            } else if (mux_tick() - joy_hold_tick >= joy_hold_delay) {
+                list_nav_next(1);
+                joy_scrolled = true;
+            }
+        }
+
+        if (joy_pressed == JOY_NONE) {
+            joy_hold_delay = 0;
+        } else if (joy_scrolled) {
+            // Skip an extra delay interval before starting scroll acceleration on initial hold.
+            joy_hold_delay = !joy_hold_delay ?
+                2 * config.SETTINGS.ADVANCED.ACCELERATE :
+                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_tick = mux_tick();
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxtimezone/main.c
+++ b/muxtimezone/main.c
@@ -263,6 +263,7 @@ void joystick_task() {
             refresh_screen();
         }
 
+        // Handle vertical scrolling.
         bool joy_scrolled = false;
         if (joy_pressed == JOY_UP) {
             if (current_item_index == 0) {
@@ -298,13 +299,12 @@ void joystick_task() {
             }
         }
 
+        // Handle scroll acceleration.
         if (joy_pressed == JOY_NONE) {
             joy_hold_delay = 0;
         } else if (joy_scrolled) {
             // Skip an extra delay interval before starting scroll acceleration on initial hold.
-            joy_hold_delay = !joy_hold_delay ?
-                2 * config.SETTINGS.ADVANCED.ACCELERATE :
-                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_delay = (!joy_hold_delay ? 2 : 1) * config.SETTINGS.ADVANCED.ACCELERATE;
             joy_hold_tick = mux_tick();
         }
 

--- a/muxtimezone/main.c
+++ b/muxtimezone/main.c
@@ -132,12 +132,19 @@ void joystick_task() {
     int epoll_fd;
     struct epoll_event event, events[device.DEVICE.EVENT];
 
-    int JOYUP_pressed = 0;
-    int JOYDOWN_pressed = 0;
+    enum {
+        JOY_NONE,
+        JOY_UP,
+        JOY_DOWN,
+    } joy_pressed = JOY_NONE;
+
+    // Delay (millis) before scrolling again on D-pad/joystick hold. Zero indicates no active hold.
+    uint32_t joy_hold_delay = 0;
+    // System clock (millis) when D-pad/joystick hold started. Reset each time we scroll the list.
+    uint32_t joy_hold_tick = 0;
+
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
-
-    int nav_hold = 0;
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -233,54 +240,22 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
+                            joy_pressed = JOY_NONE;
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
+                        if ((ev.code == NAV_DPAD_VER && ev.value == -1) ||
+                                (ev.code == NAV_ANLG_VER && ev.value <= -(int)device.INPUT.AXIS)) {
+                            joy_pressed = JOY_UP;
+                        } else if ((ev.code == NAV_DPAD_VER && ev.value == 1) ||
+                                (ev.code == NAV_ANLG_VER && ev.value >= (int)device.INPUT.AXIS)) {
+                            joy_pressed = JOY_DOWN;
+                        } else if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
+                            joy_pressed = JOY_NONE;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
-                        if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
-                                if (current_item_index == 0) {
-                                    current_item_index = ui_count - 1;
-                                    nav_prev(ui_group, 1);
-                                    nav_prev(ui_group_glyph, 1);
-                                    nav_prev(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
-                                    list_nav_prev(1);
-                                }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
-                                if (current_item_index == ui_count - 1) {
-                                    current_item_index = 0;
-                                    nav_next(ui_group, 1);
-                                    nav_next(ui_group_glyph, 1);
-                                    nav_next(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                } else if (current_item_index < ui_count) {
-                                    JOYDOWN_pressed = (ev.value != 0);
-                                    list_nav_next(1);
-                                }
-                            } else {
-                                JOYUP_pressed = 0;
-                                JOYDOWN_pressed = 0;
-                            }
-                        }
+                        break;
                     default:
                         break;
                 }
@@ -288,18 +263,49 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
+        bool joy_scrolled = false;
+        if (joy_pressed == JOY_UP) {
+            if (current_item_index == 0) {
+                // Stop scroll acceleration at top of list.
+                if (!joy_hold_delay) {
+                    current_item_index = ui_count - 1;
+                    nav_prev(ui_group, 1);
+                    nav_prev(ui_group_glyph, 1);
+                    nav_prev(ui_group_panel, 1);
+                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                                           current_item_index, ui_pnlContent);
+                    joy_scrolled = true;
                 }
-                if (JOYDOWN_pressed && current_item_index < ui_count) {
-                    list_nav_next(1);
-                }
+            } else if (mux_tick() - joy_hold_tick >= joy_hold_delay) {
+                list_nav_prev(1);
+                joy_scrolled = true;
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
+        } else if (joy_pressed == JOY_DOWN) {
+            if (current_item_index == ui_count - 1) {
+                // Stop scroll acceleration at bottom of list.
+                if (!joy_hold_delay) {
+                    current_item_index = 0;
+                    nav_next(ui_group, 1);
+                    nav_next(ui_group_glyph, 1);
+                    nav_next(ui_group_panel, 1);
+                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                                           current_item_index, ui_pnlContent);
+                    joy_scrolled = true;
+                }
+            } else if (mux_tick() - joy_hold_tick >= joy_hold_delay) {
+                list_nav_next(1);
+                joy_scrolled = true;
+            }
+        }
+
+        if (joy_pressed == JOY_NONE) {
+            joy_hold_delay = 0;
+        } else if (joy_scrolled) {
+            // Skip an extra delay interval before starting scroll acceleration on initial hold.
+            joy_hold_delay = !joy_hold_delay ?
+                2 * config.SETTINGS.ADVANCED.ACCELERATE :
+                config.SETTINGS.ADVANCED.ACCELERATE;
+            joy_hold_tick = mux_tick();
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) && !config.BOOT.FACTORY_RESET) {


### PR DESCRIPTION
This change makes scrolling and acceleration behave the same on my device with Hall-effect sticks (cheap AliExpress K-Silvers) as it does on my device with stock sticks. Additionally, with this change, failure of the stick to fully center (due to lack of deadzone) no longer interrupts acceleration when scrolling with the D-pad.

This PR covers most of the muX apps with scroll acceleration. I did NOT update the following apps yet that have a more complex input loop: muxnetwork, muxrtc, muxstorage, muxtweakadv, muxtweakgen, muxvisual, muxwebserv.

(There's no reason not to update those other apps in a followup; it's just getting late and I wanted to get this out for feedback, with the timezone diff and all.)

---

The majority of the improvement comes from reworking the scrolling acceleration implementation to check the system clock directly rather than relying on the `epoll_wait` timeout. This helps because Hall sticks send significantly more `EV_ABS` events than stock sticks when held in a single cardinal direction, and those extra events otherwise cause `epoll_wait` to return early (hence the excess acceleration problems seen before).

To make this work, I also separated the up/down press and hold detection from the scrolling behavior. (I think this can still be done more cleanly and in a way allowing more code sharing between the different muX programs, but I wanted to keep change relatively small.)

Note that the excessive acceleration bug was possible to trigger with stock sticks too (e.g., by moving the right stick while scrolling with the left); it was just worse with Hall sticks. :)
