### PR TITLE
Fix signed/unsigned comparison bug with device.INPUT.AXIS

### DIFF
--- a/common/device.h
+++ b/common/device.h
@@ -107,7 +107,7 @@ struct mux_device {
     struct {
         char EV0[MAX_BUFFER_SIZE];
         char EV1[MAX_BUFFER_SIZE];
-        uint32_t AXIS;
+        int32_t AXIS;
     } INPUT;
 
     struct {

--- a/muxapp/main.c
+++ b/muxapp/main.c
@@ -352,10 +352,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
-                        }
                         if (ev.code == ABS_Y) {
                             JOYUP_pressed = 0;
                             JOYDOWN_pressed = 0;
@@ -363,9 +359,7 @@ void joystick_task() {
                             break;
                         }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
                                     current_item_index = ui_count - 1;
                                     nav_prev(ui_group, 1);
@@ -378,9 +372,7 @@ void joystick_task() {
                                     JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
                                     nav_next(ui_group, 1);

--- a/muxapp/main.c
+++ b/muxapp/main.c
@@ -348,6 +348,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
                             break;
@@ -390,6 +391,7 @@ void joystick_task() {
                                 JOYDOWN_pressed = 0;
                             }
                         }
+                        break;
                     default:
                         break;
                 }

--- a/muxarchive/main.c
+++ b/muxarchive/main.c
@@ -351,10 +351,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
-                        }
                         if (ev.code == ABS_Y) {
                             JOYUP_pressed = 0;
                             JOYDOWN_pressed = 0;
@@ -362,9 +358,7 @@ void joystick_task() {
                             break;
                         }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
                                     current_item_index = ui_count - 1;
                                     nav_prev(ui_group, 1);
@@ -378,9 +372,7 @@ void joystick_task() {
                                     JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
                                     nav_next(ui_group, 1);

--- a/muxarchive/main.c
+++ b/muxarchive/main.c
@@ -347,6 +347,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
                             break;
@@ -391,6 +392,7 @@ void joystick_task() {
                                 JOYDOWN_pressed = 0;
                             }
                         }
+                        break;
                     default:
                         break;
                 }

--- a/muxassign/main.c
+++ b/muxassign/main.c
@@ -647,6 +647,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
                             break;
@@ -687,6 +688,7 @@ void joystick_task() {
                                 JOYDOWN_pressed = 0;
                             }
                         }
+                        break;
                     default:
                         break;
                 }

--- a/muxassign/main.c
+++ b/muxassign/main.c
@@ -651,10 +651,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
-                        }
                         if (ev.code == ABS_Y) {
                             JOYUP_pressed = 0;
                             JOYDOWN_pressed = 0;
@@ -662,9 +658,7 @@ void joystick_task() {
                             break;
                         }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
                                     current_item_index = ui_count - 1;
                                     nav_prev(ui_group, 1);
@@ -676,9 +670,7 @@ void joystick_task() {
                                     JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
                                     nav_next(ui_group, 1);

--- a/muxconfig/main.c
+++ b/muxconfig/main.c
@@ -285,6 +285,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
                             break;
@@ -328,6 +329,7 @@ void joystick_task() {
                                 JOYUP_pressed = 0;
                                 JOYDOWN_pressed = 0;
                             }
+                            break;
                         }
                     default:
                         break;

--- a/muxconfig/main.c
+++ b/muxconfig/main.c
@@ -289,10 +289,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
-                        }
                         if (ev.code == ABS_Y) {
                             JOYUP_pressed = 0;
                             JOYDOWN_pressed = 0;
@@ -300,9 +296,7 @@ void joystick_task() {
                             break;
                         }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
                                     current_item_index = ui_count - 1;
                                     nav_prev(ui_group, 1);
@@ -316,9 +310,7 @@ void joystick_task() {
                                     list_nav_prev(1);
                                     nav_moved = 1;
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
                                     nav_next(ui_group, 1);

--- a/muxgov/main.c
+++ b/muxgov/main.c
@@ -484,6 +484,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
                             break;
@@ -524,6 +525,7 @@ void joystick_task() {
                                 JOYDOWN_pressed = 0;
                             }
                         }
+                        break;
                     default:
                         break;
                 }

--- a/muxgov/main.c
+++ b/muxgov/main.c
@@ -488,10 +488,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
-                        }
                         if (ev.code == ABS_Y) {
                             JOYUP_pressed = 0;
                             JOYDOWN_pressed = 0;
@@ -499,9 +495,7 @@ void joystick_task() {
                             break;
                         }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
                                     current_item_index = ui_count - 1;
                                     nav_prev(ui_group, 1);
@@ -513,9 +507,7 @@ void joystick_task() {
                                     JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
                                     nav_next(ui_group, 1);

--- a/muxinfo/main.c
+++ b/muxinfo/main.c
@@ -264,10 +264,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
-                        }
                         if (ev.code == ABS_Y) {
                             JOYUP_pressed = 0;
                             JOYDOWN_pressed = 0;
@@ -275,9 +271,7 @@ void joystick_task() {
                             break;
                         }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
                                     current_item_index = UI_COUNT - 1;
                                     nav_prev(ui_group, 1);
@@ -291,9 +285,7 @@ void joystick_task() {
                                     list_nav_prev(1);
                                     nav_moved = 1;
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == UI_COUNT - 1) {
                                     current_item_index = 0;
                                     nav_next(ui_group, 1);

--- a/muxinfo/main.c
+++ b/muxinfo/main.c
@@ -260,6 +260,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
                             break;
@@ -304,6 +305,7 @@ void joystick_task() {
                                 JOYDOWN_pressed = 0;
                             }
                         }
+                        break;
                     default:
                         break;
                 }

--- a/muxlanguage/main.c
+++ b/muxlanguage/main.c
@@ -265,6 +265,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
                             break;
@@ -305,6 +306,7 @@ void joystick_task() {
                                 JOYDOWN_pressed = 0;
                             }
                         }
+                        break;
                     default:
                         break;
                 }

--- a/muxlanguage/main.c
+++ b/muxlanguage/main.c
@@ -269,10 +269,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
-                        }
                         if (ev.code == ABS_Y) {
                             JOYUP_pressed = 0;
                             JOYDOWN_pressed = 0;
@@ -280,9 +276,7 @@ void joystick_task() {
                             break;
                         }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
                                     current_item_index = ui_count - 1;
                                     nav_prev(ui_group, 1);
@@ -294,9 +288,7 @@ void joystick_task() {
                                     JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
                                     nav_next(ui_group, 1);

--- a/muxlaunch/main.c
+++ b/muxlaunch/main.c
@@ -310,14 +310,8 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
-                        }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 // Horizontal Navigation with 2 rows of 4 items.  Wrap on Row.
                                 if (theme.MISC.NAVIGATION_TYPE == 4 &&
                                     (current_item_index == 0 || current_item_index == 4)) {
@@ -331,10 +325,7 @@ void joystick_task() {
                                 } else {
                                     list_nav_prev(1);
                                 }
-
-                            } else if ((ev.value >= device.INPUT.AXIS &&
-                                        ev.value <= device.INPUT.AXIS) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 // Horizontal Navigation with 2 rows of 4 items.  Wrap on Row.
                                 if (theme.MISC.NAVIGATION_TYPE == 4 &&
                                     (current_item_index == 3 || current_item_index == 7)) {
@@ -353,22 +344,16 @@ void joystick_task() {
                         // Horizontal Navigation with 2 rows of 4 items
                         if ((theme.MISC.NAVIGATION_TYPE == 2 || theme.MISC.NAVIGATION_TYPE == 4) &&
                             (ev.code == NAV_DPAD_HOR || ev.code == NAV_ANLG_HOR)) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 list_nav_prev(4);
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 list_nav_next(4);
                             }
                         }
                         // Horizontal Navigation with 3 item first row, 5 item second row
                         if ((theme.MISC.NAVIGATION_TYPE == 3 || theme.MISC.NAVIGATION_TYPE == 5) &&
                             (ev.code == NAV_DPAD_HOR || ev.code == NAV_ANLG_HOR)) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 switch (current_item_index) {
                                     case 3:
                                     case 4:
@@ -382,9 +367,7 @@ void joystick_task() {
                                         list_nav_prev(5);
                                         break;
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 switch (current_item_index) {
                                     case 0:
                                         list_nav_next(3);

--- a/muxlaunch/main.c
+++ b/muxlaunch/main.c
@@ -306,6 +306,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
                             break;
@@ -381,6 +382,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     default:
                         break;
                 }

--- a/muxnetprofile/main.c
+++ b/muxnetprofile/main.c
@@ -441,6 +441,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
                             break;
@@ -481,6 +482,7 @@ void joystick_task() {
                                 JOYDOWN_pressed = 0;
                             }
                         }
+                        break;
                     default:
                         break;
                 }

--- a/muxnetprofile/main.c
+++ b/muxnetprofile/main.c
@@ -445,10 +445,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
-                        }
                         if (ev.code == ABS_Y) {
                             JOYUP_pressed = 0;
                             JOYDOWN_pressed = 0;
@@ -456,9 +452,7 @@ void joystick_task() {
                             break;
                         }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
                                     current_item_index = ui_count - 1;
                                     nav_prev(ui_group, 1);
@@ -470,9 +464,7 @@ void joystick_task() {
                                     JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
                                     nav_next(ui_group, 1);

--- a/muxnetscan/main.c
+++ b/muxnetscan/main.c
@@ -260,10 +260,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
-                        }
                         if (ev.code == ABS_Y) {
                             JOYUP_pressed = 0;
                             JOYDOWN_pressed = 0;
@@ -271,9 +267,7 @@ void joystick_task() {
                             break;
                         }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
                                     current_item_index = ui_count - 1;
                                     nav_prev(ui_group, 1);
@@ -285,9 +279,7 @@ void joystick_task() {
                                     JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
                                     nav_next(ui_group, 1);

--- a/muxnetscan/main.c
+++ b/muxnetscan/main.c
@@ -256,6 +256,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
                             break;
@@ -296,6 +297,7 @@ void joystick_task() {
                                 JOYDOWN_pressed = 0;
                             }
                         }
+                        break;
                     default:
                         break;
                 }

--- a/muxnetwork/main.c
+++ b/muxnetwork/main.c
@@ -750,10 +750,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
-                        }
                         if (ev.code == ABS_Y) {
                             JOYUP_pressed = 0;
                             JOYDOWN_pressed = 0;
@@ -761,9 +757,7 @@ void joystick_task() {
                             break;
                         }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (key_show > 0) {
                                     if (key_curr >= 1) {
                                         switch (key_curr) {
@@ -823,9 +817,7 @@ void joystick_task() {
                                     lblCurrentValue = lv_label_get_text(lv_group_get_focused(ui_group_value));
                                     break;
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (key_show > 0) {
                                     int max_key;
                                     if (lv_obj_has_flag(key_entry, LV_OBJ_FLAG_HIDDEN)) {
@@ -899,9 +891,7 @@ void joystick_task() {
                                 JOYDOWN_pressed = 0;
                             }
                         } else if (ev.code == NAV_DPAD_HOR || ev.code == NAV_ANLG_HOR) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (key_show > 0) {
                                     if (key_curr >= 1) {
                                         key_curr--;
@@ -982,9 +972,7 @@ void joystick_task() {
                                         break;
                                     }
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (key_show > 0) {
                                     int max_key;
                                     if (lv_obj_has_flag(key_entry, LV_OBJ_FLAG_HIDDEN)) {

--- a/muxnetwork/main.c
+++ b/muxnetwork/main.c
@@ -1061,6 +1061,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     default:
                         break;
                 }

--- a/muxoption/main.c
+++ b/muxoption/main.c
@@ -254,10 +254,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
-                        }
                         if (ev.code == ABS_Y) {
                             JOYUP_pressed = 0;
                             JOYDOWN_pressed = 0;
@@ -265,9 +261,7 @@ void joystick_task() {
                             break;
                         }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
                                     current_item_index = UI_COUNT - 1;
                                     nav_prev(ui_group, 1);
@@ -281,9 +275,7 @@ void joystick_task() {
                                     list_nav_prev(1);
                                     nav_moved = 1;
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == UI_COUNT - 1) {
                                     current_item_index = 0;
                                     nav_next(ui_group, 1);

--- a/muxoption/main.c
+++ b/muxoption/main.c
@@ -250,6 +250,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
                             break;
@@ -294,6 +295,7 @@ void joystick_task() {
                                 JOYDOWN_pressed = 0;
                             }
                         }
+                        break;
                     default:
                         break;
                 }

--- a/muxpass/main.c
+++ b/muxpass/main.c
@@ -136,29 +136,21 @@ int joystick_task() {
                         }
                     case EV_ABS:
                         if (ev.code == NAV_DPAD_HOR || ev.code == NAV_ANLG_HOR) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 play_sound("navigate", nav_sound, 0);
                                 nav_prev(ui_group, 1);
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 play_sound("navigate", nav_sound, 0);
                                 nav_next(ui_group, 1);
                             }
                         }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 play_sound("navigate", nav_sound, 0);
                                 lv_roller_set_selected(element_focused,
                                                        lv_roller_get_selected(element_focused) - 1,
                                                        LV_ANIM_ON);
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 play_sound("navigate", nav_sound, 0);
                                 lv_roller_set_selected(element_focused,
                                                        lv_roller_get_selected(element_focused) + 1,

--- a/muxpass/main.c
+++ b/muxpass/main.c
@@ -134,6 +134,7 @@ int joystick_task() {
                                 return 2;
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (ev.code == NAV_DPAD_HOR || ev.code == NAV_ANLG_HOR) {
                             if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
@@ -157,6 +158,7 @@ int joystick_task() {
                                                        LV_ANIM_ON);
                             }
                         }
+                        break;
                     default:
                         break;
                 }

--- a/muxplore/main.c
+++ b/muxplore/main.c
@@ -1623,6 +1623,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
                             break;
@@ -1675,6 +1676,7 @@ void joystick_task() {
                                 JOYDOWN_pressed = 0;
                             }
                         }
+                        break;
                     default:
                     nothing_ever_happens:
                         break;

--- a/muxplore/main.c
+++ b/muxplore/main.c
@@ -1627,10 +1627,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
-                        }
                         if (ev.code == ABS_Y) {
                             JOYUP_pressed = 0;
                             JOYDOWN_pressed = 0;
@@ -1638,9 +1634,7 @@ void joystick_task() {
                             break;
                         }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
                                     reset_label_long_mode();
                                     current_item_index = ui_count - 1;
@@ -1658,9 +1652,7 @@ void joystick_task() {
                                     list_nav_prev(1);
                                     nav_moved = 1;
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     reset_label_long_mode();
                                     current_item_index = 0;

--- a/muxrtc/main.c
+++ b/muxrtc/main.c
@@ -509,10 +509,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
-                        }
                         if (ev.code == ABS_Y) {
                             JOYUP_pressed = 0;
                             JOYDOWN_pressed = 0;
@@ -520,9 +516,7 @@ void joystick_task() {
                             break;
                         }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
                                     current_item_index = UI_COUNT - 1;
                                     nav_prev(ui_group, 1);
@@ -537,9 +531,7 @@ void joystick_task() {
                                     list_nav_prev(1);
                                     nav_moved = 1;
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == UI_COUNT - 1) {
                                     current_item_index = 0;
                                     nav_next(ui_group, 1);
@@ -559,9 +551,7 @@ void joystick_task() {
                                 JOYDOWN_pressed = 0;
                             }
                         } else if (ev.code == NAV_DPAD_HOR || ev.code == NAV_ANLG_HOR) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 play_sound("navigate", nav_sound, 0);
                                 if (element_focused == ui_lblYear) {
                                     if (rtcYearValue > 1970 && rtcYearValue <= 2199) {
@@ -619,9 +609,7 @@ void joystick_task() {
 
                                     lv_label_set_text(ui_lblNotationValue, notation[rtcNotationValue]);
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 play_sound("navigate", nav_sound, 0);
                                 if (element_focused == ui_lblYear) {
                                     if (rtcYearValue >= 1970 && rtcYearValue < 2199) {

--- a/muxrtc/main.c
+++ b/muxrtc/main.c
@@ -505,6 +505,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
                             break;
@@ -668,6 +669,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     default:
                         break;
                 }

--- a/muxstorage/main.c
+++ b/muxstorage/main.c
@@ -515,10 +515,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
-                        }
                         if (ev.code == ABS_Y) {
                             JOYUP_pressed = 0;
                             JOYDOWN_pressed = 0;
@@ -526,9 +522,7 @@ void joystick_task() {
                             break;
                         }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
                                     current_item_index = ui_count - 1;
                                     nav_prev(ui_group, 1);
@@ -543,9 +537,7 @@ void joystick_task() {
                                     list_nav_prev(1);
                                     nav_moved = 1;
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
                                     nav_next(ui_group, 1);
@@ -565,9 +557,7 @@ void joystick_task() {
                                 JOYDOWN_pressed = 0;
                             }
                         } else if (ev.code == NAV_DPAD_HOR || ev.code == NAV_ANLG_HOR) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 play_sound("navigate", nav_sound, 0);
                                 if (element_focused == ui_lblBIOS) {
                                     decrease_option_value(ui_droBIOS,
@@ -610,9 +600,7 @@ void joystick_task() {
                                                           &network_current,
                                                           network_total);
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 play_sound("navigate", nav_sound, 0);
                                 if (element_focused == ui_lblBIOS) {
                                     increase_option_value(ui_droBIOS,

--- a/muxstorage/main.c
+++ b/muxstorage/main.c
@@ -511,6 +511,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
                             break;
@@ -645,6 +646,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     default:
                         break;
                 }

--- a/muxsysinfo/main.c
+++ b/muxsysinfo/main.c
@@ -439,6 +439,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
                             break;
@@ -485,6 +486,7 @@ void joystick_task() {
                                 JOYDOWN_pressed = 0;
                             }
                         }
+                        break;
                     default:
                         break;
                 }

--- a/muxsysinfo/main.c
+++ b/muxsysinfo/main.c
@@ -443,10 +443,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
-                        }
                         if (ev.code == ABS_Y) {
                             JOYUP_pressed = 0;
                             JOYDOWN_pressed = 0;
@@ -454,9 +450,7 @@ void joystick_task() {
                             break;
                         }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
                                     current_item_index = UI_COUNT - 1;
                                     nav_prev(ui_group, 1);
@@ -471,9 +465,7 @@ void joystick_task() {
                                     list_nav_prev(1);
                                     nav_moved = 1;
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == UI_COUNT - 1) {
                                     current_item_index = 0;
                                     nav_next(ui_group, 1);

--- a/muxtask/main.c
+++ b/muxtask/main.c
@@ -355,10 +355,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
-                        }
                         if (ev.code == ABS_Y) {
                             JOYUP_pressed = 0;
                             JOYDOWN_pressed = 0;
@@ -366,9 +362,7 @@ void joystick_task() {
                             break;
                         }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
                                     current_item_index = ui_count - 1;
                                     nav_prev(ui_group, 1);
@@ -380,9 +374,7 @@ void joystick_task() {
                                     JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
                                     nav_next(ui_group, 1);

--- a/muxtask/main.c
+++ b/muxtask/main.c
@@ -351,6 +351,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
                             break;
@@ -391,6 +392,7 @@ void joystick_task() {
                                 JOYDOWN_pressed = 0;
                             }
                         }
+                        break;
                     default:
                         break;
                 }

--- a/muxtester/main.c
+++ b/muxtester/main.c
@@ -123,9 +123,9 @@ void *joystick_task() {
                            ev.code == device.RAW_INPUT.ANALOG.LEFT.DOWN) {
                     lv_obj_add_flag(ui_lblFirst, LV_OBJ_FLAG_HIDDEN);
                     lv_obj_clear_flag(ui_lblButton, LV_OBJ_FLAG_HIDDEN);
-                    if (ev.value >= -device.INPUT.AXIS && ev.value <= -device.INPUT.AXIS) {
+                    if (ev.value == -device.INPUT.AXIS) {
                         lv_label_set_text(ui_lblButton, "↾");
-                    } else if (ev.value >= device.INPUT.AXIS && ev.value <= device.INPUT.AXIS) {
+                    } else if (ev.value == device.INPUT.AXIS) {
                         lv_label_set_text(ui_lblButton, "⇂");
                     } else {
                         lv_label_set_text(ui_lblButton, " ");
@@ -134,9 +134,9 @@ void *joystick_task() {
                            ev.code == device.RAW_INPUT.ANALOG.LEFT.RIGHT) {
                     lv_obj_add_flag(ui_lblFirst, LV_OBJ_FLAG_HIDDEN);
                     lv_obj_clear_flag(ui_lblButton, LV_OBJ_FLAG_HIDDEN);
-                    if (ev.value >= -device.INPUT.AXIS && ev.value <= -device.INPUT.AXIS) {
+                    if (ev.value == -device.INPUT.AXIS) {
                         lv_label_set_text(ui_lblButton, "↼");
-                    } else if (ev.value >= device.INPUT.AXIS && ev.value <= device.INPUT.AXIS) {
+                    } else if (ev.value == device.INPUT.AXIS) {
                         lv_label_set_text(ui_lblButton, "⇀");
                     } else {
                         lv_label_set_text(ui_lblButton, " ");
@@ -144,7 +144,7 @@ void *joystick_task() {
                 } else if (ev.code == ABS_RZ) {
                     lv_obj_add_flag(ui_lblFirst, LV_OBJ_FLAG_HIDDEN);
                     lv_obj_clear_flag(ui_lblButton, LV_OBJ_FLAG_HIDDEN);
-                    if (ev.value >= -device.INPUT.AXIS && ev.value <= -device.INPUT.AXIS) {
+                    if (ev.value == -device.INPUT.AXIS) {
                         lv_label_set_text(ui_lblButton, "↿");
                     } else if (ev.value >= device.INPUT.AXIS && ev.value <= device.INPUT.AXIS) {
                         lv_label_set_text(ui_lblButton, "⇃");
@@ -154,9 +154,9 @@ void *joystick_task() {
                 } else if (ev.code == ABS_RY) {
                     lv_obj_add_flag(ui_lblFirst, LV_OBJ_FLAG_HIDDEN);
                     lv_obj_clear_flag(ui_lblButton, LV_OBJ_FLAG_HIDDEN);
-                    if (ev.value >= -device.INPUT.AXIS && ev.value <= -device.INPUT.AXIS) {
+                    if (ev.value == -device.INPUT.AXIS) {
                         lv_label_set_text(ui_lblButton, "↽");
-                    } else if (ev.value >= device.INPUT.AXIS && ev.value <= device.INPUT.AXIS) {
+                    } else if (ev.value == device.INPUT.AXIS) {
                         lv_label_set_text(ui_lblButton, "⇁");
                     } else {
                         lv_label_set_text(ui_lblButton, " ");

--- a/muxtester/main.c
+++ b/muxtester/main.c
@@ -162,6 +162,7 @@ void *joystick_task() {
                         lv_label_set_text(ui_lblButton, " ");
                     }
                 }
+                break;
             default:
                 break;
         }

--- a/muxtheme/main.c
+++ b/muxtheme/main.c
@@ -315,6 +315,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
                             break;
@@ -357,6 +358,7 @@ void joystick_task() {
                                 JOYDOWN_pressed = 0;
                             }
                         }
+                        break;
                     default:
                         break;
                 }

--- a/muxtheme/main.c
+++ b/muxtheme/main.c
@@ -319,10 +319,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
-                        }
                         if (ev.code == ABS_Y) {
                             JOYUP_pressed = 0;
                             JOYDOWN_pressed = 0;
@@ -330,9 +326,7 @@ void joystick_task() {
                             break;
                         }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
                                     current_item_index = ui_count - 1;
                                     nav_prev(ui_group, 1);
@@ -345,9 +339,7 @@ void joystick_task() {
                                     JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
                                     nav_next(ui_group, 1);

--- a/muxtimezone/main.c
+++ b/muxtimezone/main.c
@@ -237,10 +237,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
-                        }
                         if (ev.code == ABS_Y) {
                             JOYUP_pressed = 0;
                             JOYDOWN_pressed = 0;
@@ -248,9 +244,7 @@ void joystick_task() {
                             break;
                         }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
                                     current_item_index = ui_count - 1;
                                     nav_prev(ui_group, 1);
@@ -262,9 +256,7 @@ void joystick_task() {
                                     JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
                                     nav_next(ui_group, 1);

--- a/muxtimezone/main.c
+++ b/muxtimezone/main.c
@@ -233,6 +233,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
                             break;
@@ -273,6 +274,7 @@ void joystick_task() {
                                 JOYDOWN_pressed = 0;
                             }
                         }
+                        break;
                     default:
                         break;
                 }

--- a/muxtweakadv/main.c
+++ b/muxtweakadv/main.c
@@ -857,6 +857,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
                             break;
@@ -1031,6 +1032,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     default:
                         break;
                 }

--- a/muxtweakadv/main.c
+++ b/muxtweakadv/main.c
@@ -861,10 +861,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
-                        }
                         if (ev.code == ABS_Y) {
                             JOYUP_pressed = 0;
                             JOYDOWN_pressed = 0;
@@ -872,9 +868,7 @@ void joystick_task() {
                             break;
                         }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
                                     current_item_index = ui_count - 1;
                                     nav_prev(ui_group, 1);
@@ -889,9 +883,7 @@ void joystick_task() {
                                     list_nav_prev(1);
                                     nav_moved = 1;
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
                                     nav_next(ui_group, 1);
@@ -911,9 +903,7 @@ void joystick_task() {
                                 JOYDOWN_pressed = 0;
                             }
                         } else if (ev.code == NAV_DPAD_HOR || ev.code == NAV_ANLG_HOR) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 play_sound("navigate", nav_sound, 0);
                                 if (element_focused == ui_lblAccelerate) {
                                     decrease_option_value(ui_droAccelerate,
@@ -976,9 +966,7 @@ void joystick_task() {
                                                           &hdmi_output_current,
                                                           hdmi_output_total);
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 play_sound("navigate", nav_sound, 0);
                                 if (element_focused == ui_lblAccelerate) {
                                     increase_option_value(ui_droAccelerate,

--- a/muxtweakgen/main.c
+++ b/muxtweakgen/main.c
@@ -965,6 +965,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
                             break;
@@ -1091,6 +1092,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     default:
                         break;
                 }

--- a/muxtweakgen/main.c
+++ b/muxtweakgen/main.c
@@ -969,10 +969,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
-                        }
                         if (ev.code == ABS_Y) {
                             JOYUP_pressed = 0;
                             JOYDOWN_pressed = 0;
@@ -980,9 +976,7 @@ void joystick_task() {
                             break;
                         }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
                                     current_item_index = ui_count - 1;
                                     nav_prev(ui_group, 1);
@@ -997,9 +991,7 @@ void joystick_task() {
                                     list_nav_prev(1);
                                     nav_moved = 1;
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
                                     nav_next(ui_group, 1);
@@ -1019,9 +1011,7 @@ void joystick_task() {
                                 JOYDOWN_pressed = 0;
                             }
                         } else if (ev.code == NAV_DPAD_HOR || ev.code == NAV_ANLG_HOR) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 play_sound("navigate", nav_sound, 0);
                                 if (element_focused == ui_lblHidden) {
                                     decrease_option_value(ui_droHidden,
@@ -1060,9 +1050,7 @@ void joystick_task() {
                                                           &battery_current,
                                                           battery_total);
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 play_sound("navigate", nav_sound, 0);
                                 if (element_focused == ui_lblHidden) {
                                     decrease_option_value(ui_droHidden,

--- a/muxvisual/main.c
+++ b/muxvisual/main.c
@@ -593,6 +593,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
                             break;
@@ -753,6 +754,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     default:
                         break;
                 }

--- a/muxvisual/main.c
+++ b/muxvisual/main.c
@@ -597,10 +597,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
-                        }
                         if (ev.code == ABS_Y) {
                             JOYUP_pressed = 0;
                             JOYDOWN_pressed = 0;
@@ -608,9 +604,7 @@ void joystick_task() {
                             break;
                         }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 play_sound("navigate", nav_sound, 0);
                                 if (current_item_index == 0) {
                                     current_item_index = ui_count - 1;
@@ -626,9 +620,7 @@ void joystick_task() {
                                     list_nav_prev(1);
                                     nav_moved = 1;
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 play_sound("navigate", nav_sound, 0);
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
@@ -649,9 +641,7 @@ void joystick_task() {
                                 JOYDOWN_pressed = 0;
                             }
                         } else if (ev.code == NAV_DPAD_HOR || ev.code == NAV_ANLG_HOR) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 play_sound("navigate", nav_sound, 0);
                                 if (element_focused == ui_lblBattery) {
                                     decrease_option_value(ui_droBattery,
@@ -706,9 +696,7 @@ void joystick_task() {
                                                           &background_animation_current,
                                                           background_animation_total);
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 play_sound("navigate", nav_sound, 0);
                                 if (element_focused == ui_lblBattery) {
                                     increase_option_value(ui_droBattery,

--- a/muxwebserv/main.c
+++ b/muxwebserv/main.c
@@ -437,10 +437,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if ((ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) &&
-                            (ev.value > -device.INPUT.AXIS && ev.value < device.INPUT.AXIS)) {
-                            break;
-                        }
                         if (ev.code == ABS_Y) {
                             JOYUP_pressed = 0;
                             JOYDOWN_pressed = 0;
@@ -448,9 +444,7 @@ void joystick_task() {
                             break;
                         }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 play_sound("navigate", nav_sound, 0);
                                 if (current_item_index == 0) {
                                     current_item_index = ui_count - 1;
@@ -466,9 +460,7 @@ void joystick_task() {
                                     list_nav_prev(1);
                                     nav_moved = 1;
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 play_sound("navigate", nav_sound, 0);
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
@@ -489,9 +481,7 @@ void joystick_task() {
                                 JOYDOWN_pressed = 0;
                             }
                         } else if (ev.code == NAV_DPAD_HOR || ev.code == NAV_ANLG_HOR) {
-                            if ((ev.value >= -device.INPUT.AXIS &&
-                                 ev.value <= -device.INPUT.AXIS) ||
-                                ev.value == -1) {
+                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 play_sound("navigate", nav_sound, 0);
                                 if (element_focused == ui_lblShell) {
                                     decrease_option_value(ui_droShell,
@@ -518,9 +508,7 @@ void joystick_task() {
                                                           &ntp_current,
                                                           ntp_total);
                                 }
-                            } else if ((ev.value >= (device.INPUT.AXIS) &&
-                                        ev.value <= (device.INPUT.AXIS)) ||
-                                       ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 play_sound("navigate", nav_sound, 0);
                                 if (element_focused == ui_lblShell) {
                                     increase_option_value(ui_droShell,

--- a/muxwebserv/main.c
+++ b/muxwebserv/main.c
@@ -433,6 +433,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     case EV_ABS:
                         if (msgbox_active) {
                             break;
@@ -537,6 +538,7 @@ void joystick_task() {
                                 }
                             }
                         }
+                        break;
                     default:
                         break;
                 }


### PR DESCRIPTION
Turns out that when comparing signed and unsigned ints of the same size, [C converts the signed value to unsigned and does an unsigned comparison](https://stackoverflow.com/a/70642482/152208). Of course, this doesn't work well when the signed value can be negative (like `ev.value` we get for joystick inputs, which is negative over half the axis). This leads to comparisons giving absurd and very confusing results.

The easiest fix that doesn't involve adding casts all over the place is just changing the `AXIS` config value to a signed `int32_t`. (It looks like all the other config values are already signed anyway.) Then the comparisons behave as expected and we don't seem to need so many sanity checks (which it turns out were behaving differently than expected).

Also a quick code simplification: `value >= AXIS && value <= AXIS` is just `value == AXIS`. :)