### PR TITLE
Overhaul menu acceleration to improve Hall-effect stick compatibility

### DIFF
--- a/muxapp/main.c
+++ b/muxapp/main.c
@@ -248,7 +248,8 @@ void joystick_task() {
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
 
-    int nav_hold = 0;
+    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
+    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -353,12 +354,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
                             if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
@@ -370,9 +365,11 @@ void joystick_task() {
                                                            current_item_index, ui_pnlContent);
                                     nav_moved = 1;
                                 } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
                                 }
+                                JOYUP_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
@@ -383,9 +380,11 @@ void joystick_task() {
                                                            current_item_index, ui_pnlContent);
                                     nav_moved = 1;
                                 } else if (current_item_index < ui_count - 1) {
-                                    JOYDOWN_pressed = (ev.value != 0);
                                     list_nav_next(1);
                                 }
+                                JOYDOWN_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else {
                                 JOYUP_pressed = 0;
                                 JOYDOWN_pressed = 0;
@@ -399,18 +398,17 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
-                }
-                if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
-                    list_nav_next(1);
-                }
+        // Handle menu acceleration.
+        if (mux_tick() - nav_tick >= nav_hold) {
+            if (JOYUP_pressed && current_item_index > 0) {
+                list_nav_prev(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
+            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
+                list_nav_next(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxarchive/main.c
+++ b/muxarchive/main.c
@@ -373,7 +373,7 @@ void joystick_task() {
                                     JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
                                 }
-                            if (ev.value == device.INPUT.AXIS || ev.value == 1) {
+                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
                                     nav_next(ui_group, 1);

--- a/muxarchive/main.c
+++ b/muxarchive/main.c
@@ -243,7 +243,8 @@ void joystick_task() {
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
 
-    int nav_hold = 0;
+    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
+    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -352,12 +353,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
                             if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
@@ -370,9 +365,11 @@ void joystick_task() {
                                     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
                                                            current_item_index, ui_pnlContent);
                                 } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
                                 }
+                                JOYUP_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
@@ -384,9 +381,11 @@ void joystick_task() {
                                     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
                                                            current_item_index, ui_pnlContent);
                                 } else if (current_item_index < ui_count) {
-                                    JOYDOWN_pressed = (ev.value != 0);
                                     list_nav_next(1);
                                 }
+                                JOYDOWN_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else {
                                 JOYUP_pressed = 0;
                                 JOYDOWN_pressed = 0;
@@ -400,18 +399,17 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
-                }
-                if (JOYDOWN_pressed && current_item_index < ui_count) {
-                    list_nav_next(1);
-                }
+        // Handle menu acceleration.
+        if (mux_tick() - nav_tick >= nav_hold) {
+            if (JOYUP_pressed && current_item_index > 0) {
+                list_nav_prev(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
+            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
+                list_nav_next(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxassign/main.c
+++ b/muxassign/main.c
@@ -461,7 +461,8 @@ void joystick_task() {
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
 
-    int nav_hold = 0;
+    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
+    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -652,12 +653,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
                             if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
@@ -668,9 +663,11 @@ void joystick_task() {
                                     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
                                                            current_item_index, ui_pnlContent);
                                 } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
                                 }
+                                JOYUP_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
@@ -680,9 +677,11 @@ void joystick_task() {
                                     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
                                                            current_item_index, ui_pnlContent);
                                 } else if (current_item_index < ui_count) {
-                                    JOYDOWN_pressed = (ev.value != 0);
                                     list_nav_next(1);
                                 }
+                                JOYDOWN_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else {
                                 JOYUP_pressed = 0;
                                 JOYDOWN_pressed = 0;
@@ -696,18 +695,17 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
-                }
-                if (JOYDOWN_pressed && current_item_index < ui_count) {
-                    list_nav_next(1);
-                }
+        // Handle menu acceleration.
+        if (mux_tick() - nav_tick >= nav_hold) {
+            if (JOYUP_pressed && current_item_index > 0) {
+                list_nav_prev(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
+            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
+                list_nav_next(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxconfig/main.c
+++ b/muxconfig/main.c
@@ -192,7 +192,8 @@ void joystick_task() {
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
 
-    int nav_hold = 0;
+    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
+    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -290,12 +291,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
                             if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
@@ -307,10 +302,11 @@ void joystick_task() {
                                                            current_item_index, ui_pnlContent);
                                     nav_moved = 1;
                                 } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
-                                    nav_moved = 1;
                                 }
+                                JOYUP_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
@@ -321,10 +317,11 @@ void joystick_task() {
                                                            current_item_index, ui_pnlContent);
                                     nav_moved = 1;
                                 } else if (current_item_index < ui_count - 1) {
-                                    JOYDOWN_pressed = (ev.value != 0);
                                     list_nav_next(1);
-                                    nav_moved = 1;
                                 }
+                                JOYDOWN_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else {
                                 JOYUP_pressed = 0;
                                 JOYDOWN_pressed = 0;
@@ -338,18 +335,17 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
-                }
-                if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
-                    list_nav_next(1);
-                }
+        // Handle menu acceleration.
+        if (mux_tick() - nav_tick >= nav_hold) {
+            if (JOYUP_pressed && current_item_index > 0) {
+                list_nav_prev(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
+            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
+                list_nav_next(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxgov/main.c
+++ b/muxgov/main.c
@@ -373,7 +373,8 @@ void joystick_task() {
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
 
-    int nav_hold = 0;
+    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
+    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -489,12 +490,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
                             if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
@@ -505,9 +500,11 @@ void joystick_task() {
                                     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
                                                            current_item_index, ui_pnlContent);
                                 } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
                                 }
+                                JOYUP_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
@@ -517,9 +514,11 @@ void joystick_task() {
                                     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
                                                            current_item_index, ui_pnlContent);
                                 } else if (current_item_index < ui_count) {
-                                    JOYDOWN_pressed = (ev.value != 0);
                                     list_nav_next(1);
                                 }
+                                JOYDOWN_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else {
                                 JOYUP_pressed = 0;
                                 JOYDOWN_pressed = 0;
@@ -533,18 +532,17 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
-                }
-                if (JOYDOWN_pressed && current_item_index < ui_count) {
-                    list_nav_next(1);
-                }
+        // Handle menu acceleration.
+        if (mux_tick() - nav_tick >= nav_hold) {
+            if (JOYUP_pressed && current_item_index > 0) {
+                list_nav_prev(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
+            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
+                list_nav_next(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxinfo/main.c
+++ b/muxinfo/main.c
@@ -171,7 +171,8 @@ void joystick_task() {
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
 
-    int nav_hold = 0;
+    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
+    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -265,12 +266,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
                             if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
@@ -282,10 +277,11 @@ void joystick_task() {
                                                            current_item_index, ui_pnlContent);
                                     nav_moved = 1;
                                 } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
-                                    nav_moved = 1;
                                 }
+                                JOYUP_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == UI_COUNT - 1) {
                                     current_item_index = 0;
@@ -296,10 +292,11 @@ void joystick_task() {
                                                            current_item_index, ui_pnlContent);
                                     nav_moved = 1;
                                 } else if (current_item_index < UI_COUNT - 1) {
-                                    JOYDOWN_pressed = (ev.value != 0);
                                     list_nav_next(1);
-                                    nav_moved = 1;
                                 }
+                                JOYDOWN_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else {
                                 JOYUP_pressed = 0;
                                 JOYDOWN_pressed = 0;
@@ -313,18 +310,17 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
-                }
-                if (JOYDOWN_pressed && current_item_index < UI_COUNT - 1) {
-                    list_nav_next(1);
-                }
+        // Handle menu acceleration.
+        if (mux_tick() - nav_tick >= nav_hold) {
+            if (JOYUP_pressed && current_item_index > 0) {
+                list_nav_prev(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
+            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
+                list_nav_next(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxlanguage/main.c
+++ b/muxlanguage/main.c
@@ -171,7 +171,8 @@ void joystick_task() {
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
 
-    int nav_hold = 0;
+    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
+    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -270,12 +271,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
                             if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
@@ -286,9 +281,11 @@ void joystick_task() {
                                     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
                                                            current_item_index, ui_pnlContent);
                                 } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
                                 }
+                                JOYUP_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
@@ -298,9 +295,11 @@ void joystick_task() {
                                     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
                                                            current_item_index, ui_pnlContent);
                                 } else if (current_item_index < ui_count) {
-                                    JOYDOWN_pressed = (ev.value != 0);
                                     list_nav_next(1);
                                 }
+                                JOYDOWN_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else {
                                 JOYUP_pressed = 0;
                                 JOYDOWN_pressed = 0;
@@ -314,18 +313,17 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
-                }
-                if (JOYDOWN_pressed && current_item_index < ui_count) {
-                    list_nav_next(1);
-                }
+        // Handle menu acceleration.
+        if (mux_tick() - nav_tick >= nav_hold) {
+            if (JOYUP_pressed && current_item_index > 0) {
+                list_nav_prev(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
+            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
+                list_nav_next(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) && !config.BOOT.FACTORY_RESET) {

--- a/muxnetprofile/main.c
+++ b/muxnetprofile/main.c
@@ -338,7 +338,8 @@ void joystick_task() {
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
 
-    int nav_hold = 0;
+    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
+    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -446,12 +447,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
                             if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
@@ -462,9 +457,11 @@ void joystick_task() {
                                     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
                                                            current_item_index, ui_pnlContent);
                                 } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
                                 }
+                                JOYUP_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
@@ -474,9 +471,11 @@ void joystick_task() {
                                     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
                                                            current_item_index, ui_pnlContent);
                                 } else if (current_item_index < ui_count) {
-                                    JOYDOWN_pressed = (ev.value != 0);
                                     list_nav_next(1);
                                 }
+                                JOYDOWN_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else {
                                 JOYUP_pressed = 0;
                                 JOYDOWN_pressed = 0;
@@ -490,18 +489,17 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
-                }
-                if (JOYDOWN_pressed && current_item_index < ui_count) {
-                    list_nav_next(1);
-                }
+        // Handle menu acceleration.
+        if (mux_tick() - nav_tick >= nav_hold) {
+            if (JOYUP_pressed && current_item_index > 0) {
+                list_nav_prev(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
+            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
+                list_nav_next(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxnetscan/main.c
+++ b/muxnetscan/main.c
@@ -159,7 +159,8 @@ void joystick_task() {
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
 
-    int nav_hold = 0;
+    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
+    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -261,12 +262,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
                             if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
@@ -277,9 +272,11 @@ void joystick_task() {
                                     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
                                                            current_item_index, ui_pnlContent);
                                 } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
                                 }
+                                JOYUP_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
@@ -289,9 +286,11 @@ void joystick_task() {
                                     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
                                                            current_item_index, ui_pnlContent);
                                 } else if (current_item_index < ui_count) {
-                                    JOYDOWN_pressed = (ev.value != 0);
                                     list_nav_next(1);
                                 }
+                                JOYDOWN_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else {
                                 JOYUP_pressed = 0;
                                 JOYDOWN_pressed = 0;
@@ -305,18 +304,17 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
-                }
-                if (JOYDOWN_pressed && current_item_index < ui_count) {
-                    list_nav_next(1);
-                }
+        // Handle menu acceleration.
+        if (mux_tick() - nav_tick >= nav_hold) {
+            if (JOYUP_pressed && current_item_index > 0) {
+                list_nav_prev(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
+            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
+                list_nav_next(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxnetwork/main.c
+++ b/muxnetwork/main.c
@@ -389,7 +389,8 @@ void joystick_task() {
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
 
-    int nav_hold = 0;
+    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
+    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -750,12 +751,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
                             if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (key_show > 0) {
@@ -810,11 +805,12 @@ void joystick_task() {
                                         update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
                                                                current_item_index, ui_pnlContent);
                                     } else if (current_item_index > 0) {
-                                        JOYUP_pressed = (ev.value != 0);
                                         list_nav_prev(1);
-                                        nav_moved = 1;
                                     }
                                     lblCurrentValue = lv_label_get_text(lv_group_get_focused(ui_group_value));
+                                    JOYUP_pressed = 1;
+                                    nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                    nav_tick = mux_tick();
                                     break;
                                 }
                             } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
@@ -879,11 +875,12 @@ void joystick_task() {
                                         update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
                                                                current_item_index, ui_pnlContent);
                                     } else if (current_item_index < ui_count - 1) {
-                                        JOYDOWN_pressed = (ev.value != 0);
                                         list_nav_next(1);
-                                        nav_moved = 1;
                                     }
                                     lblCurrentValue = lv_label_get_text(lv_group_get_focused(ui_group_value));
+                                    JOYDOWN_pressed = 1;
+                                    nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                    nav_tick = mux_tick();
                                     break;
                                 }
                             } else {
@@ -1069,18 +1066,17 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
-                }
-                if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
-                    list_nav_next(1);
-                }
+        // Handle menu acceleration.
+        if (mux_tick() - nav_tick >= nav_hold) {
+            if (JOYUP_pressed && current_item_index > 0) {
+                list_nav_prev(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
+            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
+                list_nav_next(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxoption/main.c
+++ b/muxoption/main.c
@@ -160,7 +160,8 @@ void joystick_task() {
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
 
-    int nav_hold = 0;
+    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
+    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -255,12 +256,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
                             if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
@@ -272,10 +267,11 @@ void joystick_task() {
                                                            current_item_index, ui_pnlContent);
                                     nav_moved = 1;
                                 } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
-                                    nav_moved = 1;
                                 }
+                                JOYUP_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == UI_COUNT - 1) {
                                     current_item_index = 0;
@@ -286,10 +282,11 @@ void joystick_task() {
                                                            current_item_index, ui_pnlContent);
                                     nav_moved = 1;
                                 } else if (current_item_index < UI_COUNT - 1) {
-                                    JOYDOWN_pressed = (ev.value != 0);
                                     list_nav_next(1);
-                                    nav_moved = 1;
                                 }
+                                JOYDOWN_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else {
                                 JOYUP_pressed = 0;
                                 JOYDOWN_pressed = 0;
@@ -303,18 +300,17 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
-                }
-                if (JOYDOWN_pressed && current_item_index < UI_COUNT - 1) {
-                    list_nav_next(1);
-                }
+        // Handle menu acceleration.
+        if (mux_tick() - nav_tick >= nav_hold) {
+            if (JOYUP_pressed && current_item_index > 0) {
+                list_nav_prev(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
+            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
+                list_nav_next(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxplore/main.c
+++ b/muxplore/main.c
@@ -1209,7 +1209,8 @@ void joystick_task() {
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
 
-    int nav_hold = 0;
+    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
+    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -1280,7 +1281,6 @@ void joystick_task() {
                                     JOYHOTKEY_screenshot = 0;
                                     JOYUP_pressed = 0;
                                     JOYDOWN_pressed = 0;
-                                    nav_hold = 0;
                                 } else if (ev.code == NAV_A || ev.code == device.RAW_INPUT.ANALOG.LEFT.CLICK) {
                                     if (ui_count == 0) goto nothing_ever_happens;
 
@@ -1628,12 +1628,6 @@ void joystick_task() {
                         if (msgbox_active || ui_count == 0) {
                             break;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
                             if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
@@ -1649,10 +1643,11 @@ void joystick_task() {
                                     set_label_long_mode();
                                     update_file_counter();
                                 } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
-                                    nav_moved = 1;
                                 }
+                                JOYUP_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     reset_label_long_mode();
@@ -1667,10 +1662,11 @@ void joystick_task() {
                                     set_label_long_mode();
                                     update_file_counter();
                                 } else if (current_item_index < ui_count - 1) {
-                                    JOYDOWN_pressed = (ev.value != 0);
                                     list_nav_next(1);
-                                    nav_moved = 1;
                                 }
+                                JOYDOWN_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else {
                                 JOYUP_pressed = 0;
                                 JOYDOWN_pressed = 0;
@@ -1685,18 +1681,17 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
-                }
-                if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
-                    list_nav_next(1);
-                }
+        // Handle menu acceleration.
+        if (mux_tick() - nav_tick >= nav_hold) {
+            if (JOYUP_pressed && current_item_index > 0) {
+                list_nav_prev(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
+            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
+                list_nav_next(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxplore/main.c
+++ b/muxplore/main.c
@@ -1625,7 +1625,7 @@ void joystick_task() {
                         }
                         break;
                     case EV_ABS:
-                        if (msgbox_active) {
+                        if (msgbox_active || ui_count == 0) {
                             break;
                         }
                         if (ev.code == ABS_Y) {

--- a/muxrtc/main.c
+++ b/muxrtc/main.c
@@ -346,7 +346,8 @@ void joystick_task() {
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
 
-    int nav_hold = 0;
+    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
+    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -510,12 +511,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
                             if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
@@ -528,10 +523,11 @@ void joystick_task() {
                                                            current_item_index, ui_pnlContent);
                                     nav_moved = 1;
                                 } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
-                                    nav_moved = 1;
                                 }
+                                JOYUP_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == UI_COUNT - 1) {
                                     current_item_index = 0;
@@ -543,10 +539,11 @@ void joystick_task() {
                                                            current_item_index, ui_pnlContent);
                                     nav_moved = 1;
                                 } else if (current_item_index < UI_COUNT - 1) {
-                                    JOYDOWN_pressed = (ev.value != 0);
                                     list_nav_next(1);
-                                    nav_moved = 1;
                                 }
+                                JOYDOWN_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else {
                                 JOYUP_pressed = 0;
                                 JOYDOWN_pressed = 0;
@@ -677,18 +674,17 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
-                }
-                if (JOYDOWN_pressed && current_item_index < UI_COUNT - 1) {
-                    list_nav_next(1);
-                }
+        // Handle menu acceleration.
+        if (mux_tick() - nav_tick >= nav_hold) {
+            if (JOYUP_pressed && current_item_index > 0) {
+                list_nav_prev(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
+            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
+                list_nav_next(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) && !config.BOOT.FACTORY_RESET) {

--- a/muxstorage/main.c
+++ b/muxstorage/main.c
@@ -383,7 +383,8 @@ void joystick_task() {
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
 
-    int nav_hold = 0;
+    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
+    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -516,12 +517,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
                             if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
@@ -534,10 +529,11 @@ void joystick_task() {
                                                            ui_count, current_item_index, ui_pnlContent);
                                     nav_moved = 1;
                                 } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
-                                    nav_moved = 1;
                                 }
+                                JOYUP_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
@@ -549,10 +545,11 @@ void joystick_task() {
                                                            ui_count, current_item_index, ui_pnlContent);
                                     nav_moved = 1;
                                 } else if (current_item_index < ui_count - 1) {
-                                    JOYDOWN_pressed = (ev.value != 0);
                                     list_nav_next(1);
-                                    nav_moved = 1;
                                 }
+                                JOYDOWN_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else {
                                 JOYUP_pressed = 0;
                                 JOYDOWN_pressed = 0;
@@ -654,18 +651,17 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
-                }
-                if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
-                    list_nav_next(1);
-                }
+        // Handle menu acceleration.
+        if (mux_tick() - nav_tick >= nav_hold) {
+            if (JOYUP_pressed && current_item_index > 0) {
+                list_nav_prev(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
+            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
+                list_nav_next(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxsysinfo/main.c
+++ b/muxsysinfo/main.c
@@ -355,7 +355,8 @@ void joystick_task() {
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
 
-    int nav_hold = 0;
+    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
+    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -444,12 +445,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
                             if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
@@ -462,10 +457,11 @@ void joystick_task() {
                                                            current_item_index, ui_pnlContent);
                                     nav_moved = 1;
                                 } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
-                                    nav_moved = 1;
                                 }
+                                JOYUP_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == UI_COUNT - 1) {
                                     current_item_index = 0;
@@ -477,10 +473,11 @@ void joystick_task() {
                                                            current_item_index, ui_pnlContent);
                                     nav_moved = 1;
                                 } else if (current_item_index < UI_COUNT - 1) {
-                                    JOYDOWN_pressed = (ev.value != 0);
                                     list_nav_next(1);
-                                    nav_moved = 1;
                                 }
+                                JOYDOWN_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else {
                                 JOYUP_pressed = 0;
                                 JOYDOWN_pressed = 0;
@@ -494,18 +491,17 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
-                }
-                if (JOYDOWN_pressed && current_item_index < UI_COUNT - 1) {
-                    list_nav_next(1);
-                }
+        // Handle menu acceleration.
+        if (mux_tick() - nav_tick >= nav_hold) {
+            if (JOYUP_pressed && current_item_index > 0) {
+                list_nav_prev(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
+            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
+                list_nav_next(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxtask/main.c
+++ b/muxtask/main.c
@@ -248,7 +248,8 @@ void joystick_task() {
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
 
-    int nav_hold = 0;
+    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
+    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -356,12 +357,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
                             if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
@@ -372,9 +367,11 @@ void joystick_task() {
                                     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
                                                            current_item_index, ui_pnlContent);
                                 } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
                                 }
+                                JOYUP_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
@@ -384,9 +381,11 @@ void joystick_task() {
                                     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
                                                            current_item_index, ui_pnlContent);
                                 } else if (current_item_index < ui_count) {
-                                    JOYDOWN_pressed = (ev.value != 0);
                                     list_nav_next(1);
                                 }
+                                JOYDOWN_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else {
                                 JOYUP_pressed = 0;
                                 JOYDOWN_pressed = 0;
@@ -400,18 +399,17 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
-                }
-                if (JOYDOWN_pressed && current_item_index < ui_count) {
-                    list_nav_next(1);
-                }
+        // Handle menu acceleration.
+        if (mux_tick() - nav_tick >= nav_hold) {
+            if (JOYUP_pressed && current_item_index > 0) {
+                list_nav_prev(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
+            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
+                list_nav_next(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxtheme/main.c
+++ b/muxtheme/main.c
@@ -208,7 +208,8 @@ void joystick_task() {
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
 
-    int nav_hold = 0;
+    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
+    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -320,12 +321,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
                             if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
@@ -337,9 +332,11 @@ void joystick_task() {
                                                            current_item_index, ui_pnlContent);
                                     image_refresh();
                                 } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
                                 }
+                                JOYUP_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
@@ -350,9 +347,11 @@ void joystick_task() {
                                                            current_item_index, ui_pnlContent);
                                     image_refresh();
                                 } else if (current_item_index < ui_count) {
-                                    JOYDOWN_pressed = (ev.value != 0);
                                     list_nav_next(1);
                                 }
+                                JOYDOWN_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else {
                                 JOYUP_pressed = 0;
                                 JOYDOWN_pressed = 0;
@@ -366,18 +365,17 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
-                }
-                if (JOYDOWN_pressed && current_item_index < ui_count) {
-                    list_nav_next(1);
-                }
+        // Handle menu acceleration.
+        if (mux_tick() - nav_tick >= nav_hold) {
+            if (JOYUP_pressed && current_item_index > 0) {
+                list_nav_prev(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
+            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
+                list_nav_next(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxtimezone/main.c
+++ b/muxtimezone/main.c
@@ -137,7 +137,8 @@ void joystick_task() {
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
 
-    int nav_hold = 0;
+    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
+    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -238,12 +239,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
                             if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
@@ -254,9 +249,11 @@ void joystick_task() {
                                     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
                                                            current_item_index, ui_pnlContent);
                                 } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
                                 }
+                                JOYUP_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
@@ -266,9 +263,11 @@ void joystick_task() {
                                     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
                                                            current_item_index, ui_pnlContent);
                                 } else if (current_item_index < ui_count) {
-                                    JOYDOWN_pressed = (ev.value != 0);
                                     list_nav_next(1);
                                 }
+                                JOYDOWN_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else {
                                 JOYUP_pressed = 0;
                                 JOYDOWN_pressed = 0;
@@ -282,18 +281,17 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
-                }
-                if (JOYDOWN_pressed && current_item_index < ui_count) {
-                    list_nav_next(1);
-                }
+        // Handle menu acceleration.
+        if (mux_tick() - nav_tick >= nav_hold) {
+            if (JOYUP_pressed && current_item_index > 0) {
+                list_nav_prev(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
+            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
+                list_nav_next(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) && !config.BOOT.FACTORY_RESET) {

--- a/muxtweakadv/main.c
+++ b/muxtweakadv/main.c
@@ -704,7 +704,8 @@ void joystick_task() {
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
 
-    int nav_hold = 0;
+    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
+    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -862,12 +863,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
                             if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
@@ -880,10 +875,11 @@ void joystick_task() {
                                                            ui_count, current_item_index, ui_pnlContent);
                                     nav_moved = 1;
                                 } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
-                                    nav_moved = 1;
                                 }
+                                JOYUP_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
@@ -895,10 +891,11 @@ void joystick_task() {
                                                            ui_count, current_item_index, ui_pnlContent);
                                     nav_moved = 1;
                                 } else if (current_item_index < ui_count - 1) {
-                                    JOYDOWN_pressed = (ev.value != 0);
                                     list_nav_next(1);
-                                    nav_moved = 1;
                                 }
+                                JOYDOWN_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else {
                                 JOYUP_pressed = 0;
                                 JOYDOWN_pressed = 0;
@@ -1040,18 +1037,17 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
-                }
-                if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
-                    list_nav_next(1);
-                }
+        // Handle menu acceleration.
+        if (mux_tick() - nav_tick >= nav_hold) {
+            if (JOYUP_pressed && current_item_index > 0) {
+                list_nav_prev(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
+            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
+                list_nav_next(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxtweakgen/main.c
+++ b/muxtweakgen/main.c
@@ -816,7 +816,8 @@ void joystick_task() {
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
 
-    int nav_hold = 0;
+    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
+    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -970,12 +971,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
                             if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 if (current_item_index == 0) {
@@ -988,10 +983,11 @@ void joystick_task() {
                                                            current_item_index, ui_pnlContent);
                                     nav_moved = 1;
                                 } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
-                                    nav_moved = 1;
                                 }
+                                JOYUP_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 if (current_item_index == ui_count - 1) {
                                     current_item_index = 0;
@@ -1003,10 +999,11 @@ void joystick_task() {
                                                            current_item_index, ui_pnlContent);
                                     nav_moved = 1;
                                 } else if (current_item_index < ui_count - 1) {
-                                    JOYDOWN_pressed = (ev.value != 0);
                                     list_nav_next(1);
-                                    nav_moved = 1;
                                 }
+                                JOYDOWN_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else {
                                 JOYUP_pressed = 0;
                                 JOYDOWN_pressed = 0;
@@ -1100,18 +1097,17 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
-                }
-                if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
-                    list_nav_next(1);
-                }
+        // Handle menu acceleration.
+        if (mux_tick() - nav_tick >= nav_hold) {
+            if (JOYUP_pressed && current_item_index > 0) {
+                list_nav_prev(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
+            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
+                list_nav_next(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxvisual/main.c
+++ b/muxvisual/main.c
@@ -453,7 +453,8 @@ void joystick_task() {
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
 
-    int nav_hold = 0;
+    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
+    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -598,12 +599,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
                             if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 play_sound("navigate", nav_sound, 0);
@@ -617,10 +612,11 @@ void joystick_task() {
                                                            ui_count, current_item_index, ui_pnlContent);
                                     nav_moved = 1;
                                 } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
-                                    nav_moved = 1;
                                 }
+                                JOYUP_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 play_sound("navigate", nav_sound, 0);
                                 if (current_item_index == ui_count - 1) {
@@ -633,10 +629,11 @@ void joystick_task() {
                                                            ui_count, current_item_index, ui_pnlContent);
                                     nav_moved = 1;
                                 } else if (current_item_index < ui_count - 1) {
-                                    JOYDOWN_pressed = (ev.value != 0);
                                     list_nav_next(1);
-                                    nav_moved = 1;
                                 }
+                                JOYDOWN_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else {
                                 JOYUP_pressed = 0;
                                 JOYDOWN_pressed = 0;
@@ -762,18 +759,17 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
-                }
-                if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
-                    list_nav_next(1);
-                }
+        // Handle menu acceleration.
+        if (mux_tick() - nav_tick >= nav_hold) {
+            if (JOYUP_pressed && current_item_index > 0) {
+                list_nav_prev(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
+            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
+                list_nav_next(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {

--- a/muxwebserv/main.c
+++ b/muxwebserv/main.c
@@ -321,7 +321,8 @@ void joystick_task() {
     int JOYHOTKEY_pressed = 0;
     int JOYHOTKEY_screenshot = 0;
 
-    int nav_hold = 0;
+    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
+    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
@@ -438,12 +439,6 @@ void joystick_task() {
                         if (msgbox_active) {
                             break;
                         }
-                        if (ev.code == ABS_Y) {
-                            JOYUP_pressed = 0;
-                            JOYDOWN_pressed = 0;
-                            nav_hold = 0;
-                            break;
-                        }
                         if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
                             if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
                                 play_sound("navigate", nav_sound, 0);
@@ -457,10 +452,11 @@ void joystick_task() {
                                                            ui_count, current_item_index, ui_pnlContent);
                                     nav_moved = 1;
                                 } else if (current_item_index > 0) {
-                                    JOYUP_pressed = (ev.value != 0);
                                     list_nav_prev(1);
-                                    nav_moved = 1;
                                 }
+                                JOYUP_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
                                 play_sound("navigate", nav_sound, 0);
                                 if (current_item_index == ui_count - 1) {
@@ -473,10 +469,11 @@ void joystick_task() {
                                                            ui_count, current_item_index, ui_pnlContent);
                                     nav_moved = 1;
                                 } else if (current_item_index < ui_count - 1) {
-                                    JOYDOWN_pressed = (ev.value != 0);
                                     list_nav_next(1);
-                                    nav_moved = 1;
                                 }
+                                JOYDOWN_pressed = 1;
+                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                                nav_tick = mux_tick();
                             } else {
                                 JOYUP_pressed = 0;
                                 JOYDOWN_pressed = 0;
@@ -546,18 +543,17 @@ void joystick_task() {
             refresh_screen();
         }
 
-        if (JOYUP_pressed || JOYDOWN_pressed) {
-            if (nav_hold > 2) {
-                if (JOYUP_pressed && current_item_index > 0) {
-                    list_nav_prev(1);
-                }
-                if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
-                    list_nav_next(1);
-                }
+        // Handle menu acceleration.
+        if (mux_tick() - nav_tick >= nav_hold) {
+            if (JOYUP_pressed && current_item_index > 0) {
+                list_nav_prev(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
+            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
+                list_nav_next(1);
+                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
+                nav_tick = mux_tick();
             }
-            nav_hold++;
-        } else {
-            nav_hold = 0;
         }
 
         if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {


### PR DESCRIPTION
This change makes scrolling and acceleration behave the same on my device with Hall-effect sticks (cheap AliExpress K-Silvers) as it does on my device with stock sticks. Additionally, with this change, failure of the stick to fully center (due to lack of deadzone) no longer interrupts acceleration when scrolling with the D-pad.

Note that this still assumes the stick can reach the max axis value (4096 by default). For sticks that can't physically reach the full range, changing the `AXIS` config value might help... but they'll likely cause issues in emulators too, so this may not be worth worrying about.

Incidentally, this change also reenables scrolling left and right in the settings menus with the stick, which there was already code for, but seems to have broken at some point. :)

---

The current acceleration implementation relies on the `epoll_wait` timeout to set the scrolling repeat interval. The problem is that `epoll_wait` returns before the timeout when _any_ input event is received, not just an up/down event.

This is especially problematic with Hall-effect sticks since (unlike stock sticks) they tend to return small horizontal movements when held up or down, as well as small movements when centered due to lack of deadzone. These characteristics result in unpredictable or nonfunctional scroll acceleration with Hall sticks.

Technically, the problem can occur with stock sticks; it just seems much rarer. It's also possible to trigger on a purely stock setup by e.g. holding the right stick while scrolling with the left.

The reworked acceleration implementation checks the system clock directly to determine when scrolling should repeat rather than relying solely on the `epoll_wait` timeout, which resolves these issues and also allows us to remove the "stop acceleration on horizontal movement" logic that causes acceleration to randomly stop with Hall sticks.