### PR TITLE
Make muxtester compatible with Hall sticks

### DIFF
--- a/muxtester/main.c
+++ b/muxtester/main.c
@@ -46,6 +46,12 @@ lv_obj_t *msgbox_element = NULL;
 void *joystick_task() {
     struct input_event ev;
 
+    // Track pressed joystick directions to filter out jitter when the stick is centered.
+    bool analog_left_vert = false;
+    bool analog_left_hor = false;
+    bool analog_right_vert = false;
+    bool analog_right_hor = false;
+
     while (1) {
         read(js_fd, &ev, sizeof(struct input_event));
         switch (ev.type) {
@@ -125,10 +131,13 @@ void *joystick_task() {
                     lv_obj_clear_flag(ui_lblButton, LV_OBJ_FLAG_HIDDEN);
                     if (ev.value == -device.INPUT.AXIS) {
                         lv_label_set_text(ui_lblButton, "↾");
+                        analog_left_vert = true;
                     } else if (ev.value == device.INPUT.AXIS) {
                         lv_label_set_text(ui_lblButton, "⇂");
-                    } else {
+                        analog_left_vert = true;
+                    } else if (analog_left_vert) {
                         lv_label_set_text(ui_lblButton, " ");
+                        analog_left_vert = false;
                     }
                 } else if (ev.code == device.RAW_INPUT.ANALOG.LEFT.LEFT ||
                            ev.code == device.RAW_INPUT.ANALOG.LEFT.RIGHT) {
@@ -136,30 +145,41 @@ void *joystick_task() {
                     lv_obj_clear_flag(ui_lblButton, LV_OBJ_FLAG_HIDDEN);
                     if (ev.value == -device.INPUT.AXIS) {
                         lv_label_set_text(ui_lblButton, "↼");
+                        analog_left_hor = true;
                     } else if (ev.value == device.INPUT.AXIS) {
                         lv_label_set_text(ui_lblButton, "⇀");
-                    } else {
+                        analog_left_hor = true;
+                    } else if (analog_left_hor) {
                         lv_label_set_text(ui_lblButton, " ");
+                        analog_left_hor = false;
                     }
-                } else if (ev.code == ABS_RZ) {
+                } else if (ev.code == device.RAW_INPUT.ANALOG.RIGHT.UP ||
+                           ev.code == device.RAW_INPUT.ANALOG.RIGHT.DOWN) {
                     lv_obj_add_flag(ui_lblFirst, LV_OBJ_FLAG_HIDDEN);
                     lv_obj_clear_flag(ui_lblButton, LV_OBJ_FLAG_HIDDEN);
                     if (ev.value == -device.INPUT.AXIS) {
                         lv_label_set_text(ui_lblButton, "↿");
+                        analog_right_vert = true;
                     } else if (ev.value >= device.INPUT.AXIS && ev.value <= device.INPUT.AXIS) {
                         lv_label_set_text(ui_lblButton, "⇃");
-                    } else {
+                        analog_right_vert = true;
+                    } else if (analog_right_vert) {
                         lv_label_set_text(ui_lblButton, " ");
+                        analog_right_vert = false;
                     }
-                } else if (ev.code == ABS_RY) {
+                } else if (ev.code == device.RAW_INPUT.ANALOG.RIGHT.LEFT ||
+                           ev.code == device.RAW_INPUT.ANALOG.RIGHT.RIGHT) {
                     lv_obj_add_flag(ui_lblFirst, LV_OBJ_FLAG_HIDDEN);
                     lv_obj_clear_flag(ui_lblButton, LV_OBJ_FLAG_HIDDEN);
                     if (ev.value == -device.INPUT.AXIS) {
                         lv_label_set_text(ui_lblButton, "↽");
+                        analog_right_hor = true;
                     } else if (ev.value == device.INPUT.AXIS) {
                         lv_label_set_text(ui_lblButton, "⇁");
-                    } else {
+                        analog_right_hor = true;
+                    } else if (analog_right_hor) {
                         lv_label_set_text(ui_lblButton, " ");
+                        analog_right_hor = false;
                     }
                 }
                 break;


### PR DESCRIPTION
Currently, the input tester behaves strangely for sticks that have jitter around the center point, like the Hall-effect sticks too. This change fixes that so that folks can use it to see if their Hall stacks can hit the full axis range or not.

(Fun fact, in all this testing I found out one of my cheap AliExpress sticks can't hit the whole range either! Swapped it for an extra and it seems fine. Clearly some hardware variation out there...)