### PR TITLE
Reusable input handling library

### DIFF
--- a/common/input.c
+++ b/common/input.c
@@ -1,0 +1,261 @@
+#include "input.h"
+
+#include <linux/input.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/epoll.h>
+#include <unistd.h>
+
+#include "config.h"
+#include "device.h"
+
+extern uint32_t mux_tick();
+
+// Whether to exit the input task before the next iteration of the event loop.
+static bool stop = false;
+
+// Whether or not each input is currently active.
+static bool pressed[MUX_INPUT_COUNT] = {};
+
+// Processes gamepad buttons.
+static void process_key(const mux_input_options *opts, const struct input_event *event) {
+    mux_input_type type;
+    if (event->code == device.RAW_INPUT.BUTTON.A) {
+        type = !opts->swap_nav ? MUX_INPUT_A : MUX_INPUT_B;
+    } else if (event->code == device.RAW_INPUT.BUTTON.B) {
+        type = !opts->swap_nav ? MUX_INPUT_B : MUX_INPUT_A;
+    } else if (event->code == device.RAW_INPUT.BUTTON.C) {
+        type = MUX_INPUT_C;
+    } else if (event->code == device.RAW_INPUT.BUTTON.X) {
+        type = MUX_INPUT_X;
+    } else if (event->code == device.RAW_INPUT.BUTTON.Y) {
+        type = MUX_INPUT_Y;
+    } else if (event->code == device.RAW_INPUT.BUTTON.Z) {
+        type = MUX_INPUT_Z;
+    } else if (event->code == device.RAW_INPUT.BUTTON.L1) {
+        type = MUX_INPUT_L1;
+    } else if (event->code == device.RAW_INPUT.BUTTON.L2) {
+        type = MUX_INPUT_L2;
+    } else if (event->code == device.RAW_INPUT.ANALOG.LEFT.CLICK) {
+        type = MUX_INPUT_L3;
+    } else if (event->code == device.RAW_INPUT.BUTTON.R1) {
+        type = MUX_INPUT_R1;
+    } else if (event->code == device.RAW_INPUT.BUTTON.R2) {
+        type = MUX_INPUT_R2;
+    } else if (event->code == device.RAW_INPUT.ANALOG.RIGHT.CLICK) {
+        type = MUX_INPUT_R3;
+    } else if (event->code == device.RAW_INPUT.BUTTON.SELECT) {
+        type = MUX_INPUT_SELECT;
+    } else if (event->code == device.RAW_INPUT.BUTTON.START) {
+        type = MUX_INPUT_START;
+    } else if (event->code == device.RAW_INPUT.BUTTON.VOLUME_UP) {
+        type = MUX_INPUT_VOL_UP;
+    } else if (event->code == device.RAW_INPUT.BUTTON.VOLUME_DOWN) {
+        type = MUX_INPUT_VOL_DOWN;
+    } else if (event->code == device.RAW_INPUT.BUTTON.MENU_SHORT) {
+        type = MUX_INPUT_MENU_SHORT;
+    } else if (event->code == device.RAW_INPUT.BUTTON.MENU_LONG) {
+        type = MUX_INPUT_MENU_LONG;
+    } else {
+        return;
+    }
+    pressed[type] = (event->value == 1);
+}
+
+// Processes gamepad axes (D-pad and the sticks).
+static void process_abs(const mux_input_options *opts, const struct input_event *event) {
+    int axis;
+    int threshold;
+    if (event->code == device.RAW_INPUT.DPAD.UP) {
+        // Axis: D-pad vertical
+        axis = !opts->swap_axis ? MUX_INPUT_DPAD_UP : MUX_INPUT_DPAD_LEFT;
+        threshold = 1;
+    } else if (event->code == device.RAW_INPUT.DPAD.LEFT) {
+        // Axis: D-pad horizontal
+        axis = !opts->swap_axis ? MUX_INPUT_DPAD_LEFT : MUX_INPUT_DPAD_UP;
+        threshold = 1;
+    } else if (event->code == device.RAW_INPUT.ANALOG.LEFT.UP) {
+        // Axis: left stick vertical
+        axis = !opts->swap_axis ? MUX_INPUT_LS_UP : MUX_INPUT_LS_LEFT;
+        threshold = device.INPUT.AXIS;
+    } else if (event->code == device.RAW_INPUT.ANALOG.LEFT.LEFT) {
+        // Axis: left stick horizontal
+        axis = !opts->swap_axis ? MUX_INPUT_LS_LEFT : MUX_INPUT_LS_UP;
+        threshold = device.INPUT.AXIS;
+    } else if (event->code == device.RAW_INPUT.ANALOG.RIGHT.UP) {
+        // Axis: right stick vertical
+        axis = !opts->swap_axis ? MUX_INPUT_RS_UP : MUX_INPUT_RS_LEFT;
+        threshold = device.INPUT.AXIS;
+    } else if (event->code == device.RAW_INPUT.ANALOG.RIGHT.LEFT) {
+        // Axis: right stick horizontal
+        axis = !opts->swap_axis ? MUX_INPUT_RS_LEFT : MUX_INPUT_RS_UP;
+        threshold = device.INPUT.AXIS;
+    } else {
+        return;
+    }
+
+    if (event->value == -threshold) {
+        // Direction: up/left
+        pressed[axis] = true;
+        pressed[axis + 1] = false;
+    } else if (event->value == threshold) {
+        // Direction: down/right
+        pressed[axis] = false;
+        pressed[axis + 1] = true;
+    } else {
+        // Direction: center
+        pressed[axis] = false;
+        pressed[axis + 1] = false;
+    }
+}
+
+// Process system buttons.
+static void process_sys(const mux_input_options *opts, const struct input_event *event) {
+    if (event->code == device.RAW_INPUT.BUTTON.POWER_SHORT) {
+        if (event->value == 1) {
+            // Power button: short press
+            pressed[MUX_INPUT_POWER_SHORT] = 1;
+            pressed[MUX_INPUT_POWER_LONG] = 0;
+        } else if (event->value == 2) {
+            // Power button: long press
+            pressed[MUX_INPUT_POWER_SHORT] = 0;
+            pressed[MUX_INPUT_POWER_LONG] = 1;
+        } else {
+            // Power button: release
+            pressed[MUX_INPUT_POWER_SHORT] = 0;
+            pressed[MUX_INPUT_POWER_LONG] = 0;
+        }
+    }
+}
+
+// Invokes the relevant handler(s) for a particular input type and action.
+static void handle_input(const mux_input_options *opts,
+                         mux_input_type type,
+                         mux_input_action action) {
+    mux_input_handler handler = NULL;
+    switch (action) {
+        case MUX_INPUT_PRESS:
+            handler = opts->press_handler[type];
+            break;
+        case MUX_INPUT_HOLD:
+            handler = opts->hold_handler[type];
+            break;
+        case MUX_INPUT_RELEASE:
+            handler = opts->release_handler[type];
+            break;
+    }
+
+    // First invoke specific handler (if one was registered for this input type and action).
+    if (handler) {
+        handler();
+    }
+
+    // Then invoke generic handler (if a catchall handler was registered).
+    if (opts->input_handler) {
+        opts->input_handler(type, action);
+    }
+}
+
+void mux_input_task(const mux_input_options *opts) {
+    int epoll_fd = epoll_create1(0);
+    if (epoll_fd == -1) {
+        perror("mux_input_task: epoll_create1");
+        return;
+    }
+
+    struct epoll_event epoll_event[device.DEVICE.EVENT];
+
+    epoll_event[0].events = EPOLLIN;
+    epoll_event[0].data.fd = opts->gamepad_fd;
+    if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, opts->gamepad_fd, &epoll_event[0]) == -1) {
+        perror("mux_input_task: epoll_ctl(gamepad_fd)");
+        return;
+    }
+
+    epoll_event[0].events = EPOLLIN;
+    epoll_event[0].data.fd = opts->system_fd;
+    if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, opts->system_fd, &epoll_event[0]) == -1) {
+        perror("mux_input_task: epoll_ctl(system_fd)");
+        return;
+    }
+
+    // Inputs active during the previous iteration of the event loop.
+    bool held[MUX_INPUT_COUNT] = {};
+    // Delay (millis) before invoking hold handler again.
+    uint32_t hold_delay[MUX_INPUT_COUNT] = {};
+    // Tick (millis) each input was last pressed or held.
+    uint32_t hold_tick[MUX_INPUT_COUNT] = {};
+
+    // Input event loop:
+    while (!stop) {
+        int num_events = epoll_wait(epoll_fd, epoll_event, device.DEVICE.EVENT,
+                                    config.SETTINGS.ADVANCED.ACCELERATE);
+        if (num_events == -1) {
+            perror("mux_input_task: epoll_wait");
+            continue;
+        }
+
+        // Read evdev input events and update pressed/released keys.
+        for (int i = 0; i < num_events; ++i) {
+            struct input_event event;
+            if (read(epoll_event[i].data.fd, &event, sizeof(event)) == -1) {
+                perror("mux_input_task: read");
+                continue;
+            }
+
+            if (epoll_event[i].data.fd == opts->gamepad_fd) {
+                if (event.type == EV_KEY) {
+                    process_key(opts, &event);
+                } else if (event.type == EV_ABS) {
+                    process_abs(opts, &event);
+                }
+            } else if (epoll_event[i].data.fd == opts->system_fd) {
+                process_sys(opts, &event);
+            }
+        }
+
+        // Invoke registered input handlers.
+        uint32_t tick = mux_tick();
+
+        for (int i = 0; i < MUX_INPUT_COUNT; ++i) {
+            if (pressed[i]) {
+                if (!held[i]) {
+                    // Pressed & not held: Invoke "press" handler.
+                    handle_input(opts, i, MUX_INPUT_PRESS);
+
+                    // Double delay before initial repeat.
+                    hold_delay[i] = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
+                    hold_tick[i] = tick;
+                } else if (tick - hold_tick[i] >= hold_delay[i]) {
+                    // Pressed & held: Invoke "hold" handler (every ACCELERATE interval).
+                    handle_input(opts, i, MUX_INPUT_HOLD);
+
+                    // Single delay for each subsequent repeat.
+                    hold_delay[i] = config.SETTINGS.ADVANCED.ACCELERATE;
+                    hold_tick[i] = tick;
+                }
+            } else if (held[i]) {
+                // Held & not pressed: Invoke "release" handler.
+                handle_input(opts, i, MUX_INPUT_RELEASE);
+            }
+        }
+
+        // Keys pressed at the end of iteration N are held at the start of iteration N+1.
+        memcpy(held, pressed, sizeof(pressed));
+
+        // Invoke "idle" handler to run extra logic every iteration of the event loop.
+        if (opts->idle_handler) {
+            opts->idle_handler();
+        }
+    }
+}
+
+bool mux_input_pressed(mux_input_type type) {
+    return pressed[type];
+}
+
+void mux_input_stop() {
+    stop = true;
+}

--- a/common/input.h
+++ b/common/input.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <stdbool.h>
+
+// Every input (button, D-pad, or stick direction) we support.
+typedef enum {
+    // Gamepad buttons:
+    MUX_INPUT_A,
+    MUX_INPUT_B,
+    MUX_INPUT_C,
+    MUX_INPUT_X,
+    MUX_INPUT_Y,
+    MUX_INPUT_Z,
+    MUX_INPUT_L1,
+    MUX_INPUT_L2,
+    MUX_INPUT_L3,
+    MUX_INPUT_R1,
+    MUX_INPUT_R2,
+    MUX_INPUT_R3,
+    MUX_INPUT_SELECT,
+    MUX_INPUT_START,
+
+    // D-pad:
+    MUX_INPUT_DPAD_UP,
+    MUX_INPUT_DPAD_DOWN,
+    MUX_INPUT_DPAD_LEFT,
+    MUX_INPUT_DPAD_RIGHT,
+
+    // Left stick:
+    MUX_INPUT_LS_UP,
+    MUX_INPUT_LS_DOWN,
+    MUX_INPUT_LS_LEFT,
+    MUX_INPUT_LS_RIGHT,
+
+    // Right stick:
+    MUX_INPUT_RS_UP,
+    MUX_INPUT_RS_DOWN,
+    MUX_INPUT_RS_LEFT,
+    MUX_INPUT_RS_RIGHT,
+
+    // Volume buttons:
+    MUX_INPUT_VOL_UP,
+    MUX_INPUT_VOL_DOWN,
+
+    // Function buttons:
+    MUX_INPUT_MENU_SHORT,
+    MUX_INPUT_MENU_LONG,
+
+    // System buttons:
+    MUX_INPUT_POWER_SHORT,
+    MUX_INPUT_POWER_LONG,
+
+    MUX_INPUT_COUNT,
+} mux_input_type;
+
+// Actions that can be performed on an input: press and release, as well as hold.
+typedef enum {
+    MUX_INPUT_PRESS,
+    MUX_INPUT_HOLD,
+    MUX_INPUT_RELEASE,
+} mux_input_action;
+
+// Callback function invoked in response to a single specific input type and action.
+typedef void (*mux_input_handler)();
+
+// Callback function invoked in response to any arbitrary input type and action.
+typedef void (*mux_input_catchall_handler)(mux_input_type, mux_input_action);
+
+// Configuration for the muOS input subsystem.
+typedef struct {
+    // File descriptors for the underlying evdev devices.
+    int gamepad_fd;
+    int system_fd;
+
+    // Whether to swap the A & B buttons.
+    bool swap_nav;
+
+    // Whether to swap the up/down and left/right axes on the D-pad and sticks.
+    bool swap_axis;
+
+    // Callback functions for inputs. Fired in sequence: one press, zero or more holds, one release.
+    //
+    // Handlers may be NULL, in which case that input will be ignored.
+    mux_input_handler press_handler[MUX_INPUT_COUNT];
+    mux_input_handler hold_handler[MUX_INPUT_COUNT];
+    mux_input_handler release_handler[MUX_INPUT_COUNT];
+
+    // Generic handler for input press/hold/release events. For programs that want to "go offroad"
+    // and handle every input event in a custom way.
+    //
+    // Most use case are probably easier to read if they use the individual handlers above instead.
+    //
+    // May be NULL, in which case no input handler will be invoked.
+    mux_input_catchall_handler input_handler;
+
+    // Handler called after each iteration of the event loop, regardless of whether any input fired.
+    //
+    // May be NULL, in which case no idle handler will be invoked.
+    mux_input_handler idle_handler;
+} mux_input_options;
+
+// Starts the main input event loop, which runs until terminated by calling mux_input_stop.
+void mux_input_task(const mux_input_options *opts);
+
+// Returns whether or not the specified input is currently pressed.
+bool mux_input_pressed(mux_input_type type);
+
+// Causes the input task to exit at the start of the next iteration of the event loop (e.g., after
+// processing currently pressed or held inputs).
+void mux_input_stop();

--- a/muxlaunch/Makefile
+++ b/muxlaunch/Makefile
@@ -76,6 +76,7 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/common.c \
 		../common/ui_common.c \
 		../common/theme.c \
+		../common/input.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \

--- a/muxplore/Makefile
+++ b/muxplore/Makefile
@@ -77,6 +77,7 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/common.c \
 		../common/ui_common.c \
 		../common/theme.c \
+		../common/input.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \

--- a/muxplore/main.c
+++ b/muxplore/main.c
@@ -22,6 +22,7 @@
 #include "../common/device.h"
 #include "../common/collection.h"
 #include "../common/json/json.h"
+#include "../common/input.h"
 
 __thread uint64_t start_ms = 0;
 
@@ -1199,546 +1200,496 @@ void cache_message(char *n_dir) {
     }
 }
 
-void joystick_task() {
-    struct input_event ev;
-    int epoll_fd;
-    struct epoll_event event, events[device.DEVICE.EVENT];
-
-    int JOYUP_pressed = 0;
-    int JOYDOWN_pressed = 0;
-    int JOYHOTKEY_pressed = 0;
-    int JOYHOTKEY_screenshot = 0;
-
-    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
-    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
-
-    epoll_fd = epoll_create1(0);
-    if (epoll_fd == -1) {
-        perror("Error creating EPOLL instance");
-        return;
-    }
-
-    event.events = EPOLLIN;
-    event.data.fd = js_fd;
-    if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, js_fd, &event) == -1) {
-        perror("Error with EPOLL controller");
-        return;
-    }
-
-    event.data.fd = js_fd_sys;
-    if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, js_fd_sys, &event) == -1) {
-        perror("Error with EPOLL controller");
-        return;
-    }
-
-    while (1) {
-        int num_events = epoll_wait(epoll_fd, events, device.DEVICE.EVENT, config.SETTINGS.ADVANCED.ACCELERATE);
-        if (num_events == -1) {
-            perror("Error with EPOLL wait event timer");
-            continue;
+void handle_a() {
+    if (msgbox_active) {
+        play_sound("confirm", nav_sound, 1);
+        if (lv_obj_has_flag(ui_pnlHelpPreview, LV_OBJ_FLAG_HIDDEN)) {
+            lv_obj_add_flag(ui_pnlHelpMessage, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_clear_flag(ui_pnlHelpPreview, LV_OBJ_FLAG_HIDDEN);
+        } else {
+            lv_obj_add_flag(ui_pnlHelpPreview, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_clear_flag(ui_pnlHelpMessage, LV_OBJ_FLAG_HIDDEN);
         }
+        return;
+    }
 
-        for (int i = 0; i < num_events; i++) {
-            if (events[i].data.fd == js_fd_sys) {
-                ssize_t ret = read(js_fd_sys, &ev, sizeof(struct input_event));
-                if (ret == -1) {
-                    perror("Error reading input");
-                    continue;
-                }
-                if (JOYHOTKEY_pressed == 1 && ev.type == EV_KEY && ev.value == 1 &&
-                    (ev.code == device.RAW_INPUT.BUTTON.POWER_SHORT || ev.code == device.RAW_INPUT.BUTTON.POWER_LONG)) {
-                    JOYHOTKEY_screenshot = 1;
-                }
-            } else if (events[i].data.fd == js_fd) {
-                ssize_t ret = read(js_fd, &ev, sizeof(struct input_event));
-                if (ret == -1) {
-                    perror("Error reading input");
-                    continue;
-                }
+    if (ui_count == 0) {
+        return;
+    }
 
-                switch (ev.type) {
-                    case EV_KEY:
-                        if (ev.value == 1) {
-                            if (msgbox_active) {
-                                if (ev.code == NAV_B) {
-                                    play_sound("confirm", nav_sound, 1);
-                                    msgbox_active = 0;
-                                    progress_onscreen = 0;
-                                    lv_obj_add_flag(msgbox_element, LV_OBJ_FLAG_HIDDEN);
-                                } else if (ev.code == NAV_A || ev.code == device.RAW_INPUT.ANALOG.LEFT.CLICK) {
-                                    play_sound("confirm", nav_sound, 1);
-                                    if (lv_obj_has_flag(ui_pnlHelpPreview, LV_OBJ_FLAG_HIDDEN)) {
-                                        lv_obj_add_flag(ui_pnlHelpMessage, LV_OBJ_FLAG_HIDDEN);
-                                        lv_obj_clear_flag(ui_pnlHelpPreview, LV_OBJ_FLAG_HIDDEN);
-                                    } else {
-                                        lv_obj_add_flag(ui_pnlHelpPreview, LV_OBJ_FLAG_HIDDEN);
-                                        lv_obj_clear_flag(ui_pnlHelpMessage, LV_OBJ_FLAG_HIDDEN);
-                                    }
-                                }
-                            } else {
-                                if (ev.code == device.RAW_INPUT.BUTTON.MENU_LONG) {
-                                    JOYHOTKEY_pressed = 1;
-                                    JOYHOTKEY_screenshot = 0;
-                                    JOYUP_pressed = 0;
-                                    JOYDOWN_pressed = 0;
-                                } else if (ev.code == NAV_A || ev.code == device.RAW_INPUT.ANALOG.LEFT.CLICK) {
-                                    if (ui_count == 0) goto nothing_ever_happens;
+    play_sound("confirm", nav_sound, 1);
 
-                                    play_sound("confirm", nav_sound, 1);
+    char *content_label = items[current_item_index].name;
 
-                                    char *content_label = items[current_item_index].name;
-
-                                    switch (module) {
-                                        case ROOT: {
-                                            if (strcasecmp(content_label, "SD1 (mmc)") == 0) {
-                                                write_text_to_file("/tmp/explore_card", "w", CHAR, "mmc");
-                                                write_text_to_file("/tmp/explore_dir", "w", CHAR, strip_dir(SD1));
-                                                load_mux("explore");
-                                                break;
-                                            } else if (strcasecmp(content_label, "SD2 (sdcard)") == 0) {
-                                                write_text_to_file("/tmp/explore_card", "w", CHAR, "sdcard");
-                                                write_text_to_file("/tmp/explore_dir", "w", CHAR, strip_dir(SD2));
-                                                load_mux("explore");
-                                                break;
-                                            } else if (strcasecmp(content_label, "USB (external)") == 0) {
-                                                write_text_to_file("/tmp/explore_card", "w", CHAR, "usb");
-                                                write_text_to_file("/tmp/explore_dir", "w", CHAR, strip_dir(E_USB));
-                                                load_mux("explore");
-                                                break;
-                                            }
-                                        }
-                                            break;
-                                        default: {
-                                            char f_content[MAX_BUFFER_SIZE];
-                                            snprintf(f_content, sizeof(f_content), "%s.cfg",
-                                                     strip_ext(items[current_item_index].name));
-
-                                            switch (module) {
-                                                case MMC:
-                                                case SDCARD:
-                                                case USB:
-                                                    if (items[current_item_index].content_type == FOLDER) {
-                                                        char n_dir[MAX_BUFFER_SIZE];
-                                                        snprintf(n_dir, sizeof(n_dir), "%s/%s",
-                                                                 sd_dir,
-                                                                 items[current_item_index].name);
-
-                                                        write_text_to_file("/tmp/explore_dir", "w", CHAR, n_dir);
-                                                        load_mux("explore");
-
-                                                        switch (module) {
-                                                            case MMC:
-                                                            case SDCARD:
-                                                            case USB:
-                                                                cache_message(n_dir);
-                                                                break;
-                                                            default:
-                                                                break;
-                                                        }
-                                                        break;
-                                                    } else {
-                                                        write_text_to_file(MUOS_IDX_LOAD, "w", INT, current_item_index);
-
-                                                        if (load_content(0)) {
-                                                            static char launch_script[MAX_BUFFER_SIZE];
-                                                            snprintf(launch_script, sizeof(launch_script),
-                                                                     "%s/script/mux/launch.sh", INTERNAL_PATH);
-
-                                                            write_text_to_file("/tmp/manual_launch", "w", INT, 1);
-
-                                                            load_mux("explore");
-                                                        }
-                                                        break;
-                                                    }
-                                                    break;
-                                                case FAVOURITE:
-                                                    if (load_cached_content(f_content, "favourite", 0)) {
-                                                        write_text_to_file("/tmp/explore_card", "w", CHAR, "favourite");
-                                                        write_text_to_file("/tmp/explore_dir", "w", CHAR, "");
-                                                        write_text_to_file("/tmp/manual_launch", "w", INT, 1);
-                                                    } else {
-                                                        goto fail_quit;
-                                                    }
-                                                    break;
-                                                case HISTORY:
-                                                    if (load_cached_content(f_content, "history", 0)) {
-                                                        write_text_to_file("/tmp/explore_card", "w", CHAR, "history");
-                                                        write_text_to_file("/tmp/explore_dir", "w", CHAR, "");
-                                                        write_text_to_file("/tmp/manual_launch", "w", INT, 1);
-                                                    } else {
-                                                        goto fail_quit;
-                                                    }
-                                                    break;
-                                                default:
-                                                    break;
-                                            }
-                                        }
-                                            break;
-                                    }
-
-                                    lv_label_set_text(ui_lblMessage, TS("Loading..."));
-                                    lv_obj_clear_flag(ui_pnlMessage, LV_OBJ_FLAG_HIDDEN);
-                                    lv_obj_move_foreground(ui_pnlMessage);
-
-                                    // Refresh and add a small delay to actually display the message!
-                                    refresh_screen();
-                                    usleep(256);
-
-                                    return;
-                                    fail_quit:
-                                    break;
-                                } else if (ev.code == NAV_B) {
-                                    play_sound("back", nav_sound, 1);
-
-                                    switch (module) {
-                                        case FAVOURITE:
-                                        case HISTORY:
-                                            write_text_to_file("/tmp/explore_card", "w", CHAR, "root");
-                                            write_text_to_file("/tmp/explore_dir", "w", CHAR, "");
-                                            load_mux("launcher");
-                                            break;
-                                        default:
-                                            if (sd_dir != NULL) {
-                                                char *b_dir = strrchr(sd_dir, '/');
-                                                if (b_dir != NULL) {
-                                                    if (strcasecmp(str_tolower(b_dir), "/roms") == 0) {
-                                                        if (file_exist("/tmp/single_card")) {
-                                                            write_text_to_file("/tmp/explore_card", "w", CHAR, "root");
-                                                            write_text_to_file("/tmp/explore_dir", "w", CHAR, "");
-                                                            remove("/tmp/single_card");
-                                                            load_mux("launcher");
-                                                        } else {
-                                                            write_text_to_file("/tmp/explore_card", "w", CHAR, "root");
-                                                            write_text_to_file("/tmp/explore_dir", "w", CHAR, "");
-                                                            load_mux("explore");
-                                                        }
-                                                    } else {
-                                                        write_text_to_file("/tmp/explore_dir", "w", CHAR,
-                                                                           strndup(sd_dir, b_dir - sd_dir));
-                                                        load_mux("explore");
-                                                    }
-
-                                                }
-                                            }
-                                            break;
-                                    }
-                                    return;
-                                } else if (ev.code == device.RAW_INPUT.BUTTON.X) {
-                                    if (ui_count == 0) goto nothing_ever_happens;
-
-                                    char n_dir[MAX_BUFFER_SIZE];
-                                    snprintf(n_dir, sizeof(n_dir), "%s", sd_dir);
-
-                                    char f_content[MAX_BUFFER_SIZE];
-                                    snprintf(f_content, sizeof(f_content), "%s.cfg",
-                                             strip_ext(items[current_item_index].name));
-
-                                    char cache_file[MAX_BUFFER_SIZE];
-                                    switch (module) {
-                                        case MMC:
-                                            play_sound("confirm", nav_sound, 1);
-
-                                            snprintf(cache_file, sizeof(cache_file), "%s/MUOS/info/cache/mmc/%s.ini",
-                                                     device.STORAGE.ROM.MOUNT, get_last_subdir(n_dir, '/', 4));
-
-                                            write_text_to_file("/tmp/explore_card", "w", CHAR, "mmc");
-                                            break;
-                                        case SDCARD:
-                                            play_sound("confirm", nav_sound, 1);
-
-                                            snprintf(cache_file, sizeof(cache_file),
-                                                     "%s/MUOS/info/cache/sdcard/%s.ini",
-                                                     device.STORAGE.ROM.MOUNT, get_last_subdir(n_dir, '/', 4));
-
-                                            write_text_to_file("/tmp/explore_card", "w", CHAR, "sdcard");
-                                            break;
-                                        case USB:
-                                            play_sound("confirm", nav_sound, 1);
-
-                                            snprintf(cache_file, sizeof(cache_file), "%s/MUOS/info/cache/usb/%s.ini",
-                                                     device.STORAGE.ROM.MOUNT, get_last_subdir(n_dir, '/', 4));
-
-                                            write_text_to_file("/tmp/explore_card", "w", CHAR, "usb");
-                                            break;
-                                        case FAVOURITE:
-                                            play_sound("confirm", nav_sound, 1);
-
-                                            snprintf(cache_file, sizeof(cache_file), "%s/info/favourite/%s.cfg",
-                                                     STORAGE_PATH, strip_ext(f_content));
-
-                                            remove(cache_file);
-                                            write_text_to_file("/tmp/mux_reload", "w", INT, 1);
-
-                                            goto ttq;
-                                            break;
-                                        case HISTORY:
-                                            play_sound("confirm", nav_sound, 1);
-
-                                            snprintf(cache_file, sizeof(cache_file), "%s/info/history/%s.cfg",
-                                                     STORAGE_PATH, strip_ext(f_content));
-
-                                            remove(cache_file);
-                                            write_text_to_file("/tmp/mux_reload", "w", INT, 1);
-
-                                            goto ttq;
-                                            break;
-                                        default:
-                                            goto nothing_ever_happens;
-                                    }
-
-                                    if (file_exist(cache_file)) {
-                                        remove(cache_file);
-                                        cache_message(n_dir);
-                                    }
-
-                                    write_text_to_file("/tmp/explore_dir", "w", CHAR, n_dir);
-                                    load_mux("explore");
-
-                                    ttq:
-                                    return;
-                                } else if (ev.code == device.RAW_INPUT.BUTTON.Y) {
-                                    if (ui_count == 0) goto nothing_ever_happens;
-
-                                    play_sound("confirm", nav_sound, 1);
-
-                                    char f_content[MAX_BUFFER_SIZE];
-                                    snprintf(f_content, sizeof(f_content), "%s.cfg",
-                                             strip_ext(items[current_item_index].name));
-
-                                    switch (module) {
-                                        case MMC:
-                                        case SDCARD:
-                                        case USB:
-                                            if (items[current_item_index].content_type == FOLDER) {
-                                                lv_label_set_text(ui_lblMessage,
-                                                                  TS("Directories cannot be added to Favourites"));
-                                                lv_obj_clear_flag(ui_pnlMessage, LV_OBJ_FLAG_HIDDEN);
-                                                break;
-                                            } else {
-                                                if (load_content(1)) {
-                                                    lv_label_set_text(ui_lblMessage, TS("Added to Favourites"));
-                                                    lv_obj_clear_flag(ui_pnlMessage, LV_OBJ_FLAG_HIDDEN);
-                                                } else {
-                                                    lv_label_set_text(ui_lblMessage, TS("Error adding to Favourites"));
-                                                    lv_obj_clear_flag(ui_pnlMessage, LV_OBJ_FLAG_HIDDEN);
-                                                }
-                                                if (file_exist(MUOS_ROM_LOAD)) {
-                                                    remove(MUOS_ROM_LOAD);
-                                                }
-                                                break;
-                                            }
-                                            break;
-                                        case HISTORY:
-                                            if (load_cached_content(f_content, "history", 1)) {
-                                                lv_label_set_text(ui_lblMessage, TS("Added to Favourites"));
-                                                lv_obj_clear_flag(ui_pnlMessage, LV_OBJ_FLAG_HIDDEN);
-                                            } else {
-                                                lv_label_set_text(ui_lblMessage, TS("Error adding to Favourites"));
-                                                lv_obj_clear_flag(ui_pnlMessage, LV_OBJ_FLAG_HIDDEN);
-                                            }
-                                            if (file_exist(MUOS_ROM_LOAD)) {
-                                                remove(MUOS_ROM_LOAD);
-                                            }
-                                            break;
-                                        default:
-                                            break;
-                                    }
-                                } else if (ev.code == device.RAW_INPUT.BUTTON.START) {
-                                    switch (module) {
-                                        case MMC:
-                                        case SDCARD:
-                                        case USB:
-                                            play_sound("confirm", nav_sound, 1);
-
-                                            write_text_to_file("/tmp/explore_card", "w", CHAR, "root");
-                                            remove("/tmp/explore_dir");
-                                            load_mux("explore");
-
-                                            return;
-                                            break;
-                                        default:
-                                            break;
-                                    }
-                                } else if (ev.code == device.RAW_INPUT.BUTTON.SELECT) {
-                                    if (ui_count != 0 && module != ROOT && module != FAVOURITE && module != HISTORY
-                                        && !(strcasecmp(get_last_dir(sd_dir), "ROMS") == 0)) {
-                                        play_sound("confirm", nav_sound, 1);
-
-                                        switch (module) {
-                                            case MMC:
-                                            case SDCARD:
-                                            case USB:
-                                                write_text_to_file(MUOS_SAA_LOAD, "w", INT, 1);
-                                                write_text_to_file(MUOS_SAG_LOAD, "w", INT, 1);
-
-                                                load_content_core(1, 0);
-                                                if (safe_quit) return;
-                                                load_content_governor(1, 0);
-                                                if (safe_quit) return;
-
-                                                load_mux("option");
-                                                return;
-                                                break;
-                                            default:
-                                                break;
-                                        }
-                                    }
-                                } else if (ev.code == device.RAW_INPUT.BUTTON.L1) {
-                                    if (current_item_index != 0 && current_item_index < ui_count) {
-                                        list_nav_prev(theme.MUX.ITEM.COUNT);
-                                    }
-                                } else if (ev.code == device.RAW_INPUT.BUTTON.R1) {
-                                    if (current_item_index >= 0 && current_item_index != ui_count - 1) {
-                                        list_nav_next(theme.MUX.ITEM.COUNT);
-                                    }
-                                }
-                            }
-                        } else {
-                            if ((ev.code == device.RAW_INPUT.BUTTON.MENU_SHORT ||
-                                 ev.code == device.RAW_INPUT.BUTTON.MENU_LONG) && !JOYHOTKEY_screenshot) {
-                                JOYHOTKEY_pressed = 0;
-                                if (progress_onscreen == -1) {
-                                    if (ui_count == 0) goto nothing_ever_happens;
-
-                                    play_sound("confirm", nav_sound, 1);
-                                    image_refresh("preview");
-
-                                    lv_obj_add_flag(ui_pnlHelpPreview, LV_OBJ_FLAG_HIDDEN);
-                                    lv_obj_clear_flag(ui_pnlHelpMessage, LV_OBJ_FLAG_HIDDEN);
-                                    lv_obj_clear_flag(ui_pnlHelp, LV_OBJ_FLAG_HIDDEN);
-
-                                    static lv_anim_t desc_anim;
-                                    static lv_style_t desc_style;
-                                    lv_anim_init(&desc_anim);
-                                    lv_anim_set_delay(&desc_anim, 2000);
-                                    lv_style_init(&desc_style);
-                                    lv_style_set_anim(&desc_style, &desc_anim);
-                                    lv_obj_add_style(ui_lblHelpContent, &desc_style, LV_PART_MAIN);
-                                    lv_obj_set_style_anim_speed(ui_lblHelpContent, 25, LV_PART_MAIN);
-
-                                    show_rom_info(ui_pnlHelp, ui_lblHelpHeader, ui_lblHelpPreviewHeader,
-                                                  ui_lblHelpContent,
-                                                  items[current_item_index].display_name,
-                                                  load_content_description());
-                                }
-                            }
-                        }
-                        break;
-                    case EV_ABS:
-                        if (msgbox_active || ui_count == 0) {
-                            break;
-                        }
-                        if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
-                                if (current_item_index == 0) {
-                                    reset_label_long_mode();
-                                    current_item_index = ui_count - 1;
-                                    nav_prev(ui_group, 1);
-                                    nav_prev(ui_group_glyph, 1);
-                                    nav_prev(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                    nav_moved = 1;
-                                    image_refresh("box");
-                                    set_label_long_mode();
-                                    update_file_counter();
-                                } else if (current_item_index > 0) {
-                                    list_nav_prev(1);
-                                }
-                                JOYUP_pressed = 1;
-                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
-                                nav_tick = mux_tick();
-                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
-                                if (current_item_index == ui_count - 1) {
-                                    reset_label_long_mode();
-                                    current_item_index = 0;
-                                    nav_next(ui_group, 1);
-                                    nav_next(ui_group_glyph, 1);
-                                    nav_next(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                    nav_moved = 1;
-                                    image_refresh("box");
-                                    set_label_long_mode();
-                                    update_file_counter();
-                                } else if (current_item_index < ui_count - 1) {
-                                    list_nav_next(1);
-                                }
-                                JOYDOWN_pressed = 1;
-                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
-                                nav_tick = mux_tick();
-                            } else {
-                                JOYUP_pressed = 0;
-                                JOYDOWN_pressed = 0;
-                            }
-                        }
-                        break;
-                    default:
-                    nothing_ever_happens:
-                        break;
-                }
+    switch (module) {
+        case ROOT:
+            if (strcasecmp(content_label, "SD1 (mmc)") == 0) {
+                write_text_to_file("/tmp/explore_card", "w", CHAR, "mmc");
+                write_text_to_file("/tmp/explore_dir", "w", CHAR, strip_dir(SD1));
+                load_mux("explore");
+            } else if (strcasecmp(content_label, "SD2 (sdcard)") == 0) {
+                write_text_to_file("/tmp/explore_card", "w", CHAR, "sdcard");
+                write_text_to_file("/tmp/explore_dir", "w", CHAR, strip_dir(SD2));
+                load_mux("explore");
+            } else if (strcasecmp(content_label, "USB (external)") == 0) {
+                write_text_to_file("/tmp/explore_card", "w", CHAR, "usb");
+                write_text_to_file("/tmp/explore_dir", "w", CHAR, strip_dir(E_USB));
+                load_mux("explore");
             }
-            refresh_screen();
-        }
+            break;
+        default:
+            char f_content[MAX_BUFFER_SIZE];
+            snprintf(f_content, sizeof(f_content), "%s.cfg",
+                     strip_ext(items[current_item_index].name));
 
-        // Handle menu acceleration.
-        if (mux_tick() - nav_tick >= nav_hold) {
-            if (JOYUP_pressed && current_item_index > 0) {
-                list_nav_prev(1);
-                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
-                nav_tick = mux_tick();
-            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
-                list_nav_next(1);
-                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
-                nav_tick = mux_tick();
-            }
-        }
+            switch (module) {
+                case MMC:
+                case SDCARD:
+                case USB:
+                    if (items[current_item_index].content_type == FOLDER) {
+                        char n_dir[MAX_BUFFER_SIZE];
+                        snprintf(n_dir, sizeof(n_dir), "%s/%s",
+                                 sd_dir,
+                                 items[current_item_index].name);
 
-        if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {
-            if (ev.type == EV_KEY && ev.value == 1 &&
-                (ev.code == device.RAW_INPUT.BUTTON.VOLUME_DOWN || ev.code == device.RAW_INPUT.BUTTON.VOLUME_UP)) {
-                if (JOYHOTKEY_pressed) {
-                    progress_onscreen = 1;
-                    lv_obj_add_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
-                    lv_obj_clear_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
-                    lv_label_set_text(ui_icoProgressBrightness, "\uF185");
-                    lv_bar_set_value(ui_barProgressBrightness, atoi(read_text_from_file(BRIGHT_PERC)), LV_ANIM_OFF);
-                } else {
-                    progress_onscreen = 2;
-                    lv_obj_add_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
-                    lv_obj_clear_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
-                    int volume = atoi(read_text_from_file(VOLUME_PERC));
-                    switch (volume) {
-                        default:
-                        case 0:
-                            lv_label_set_text(ui_icoProgressVolume, "\uF6A9");
-                            break;
-                        case 1 ... 46:
-                            lv_label_set_text(ui_icoProgressVolume, "\uF026");
-                            break;
-                        case 47 ... 71:
-                            lv_label_set_text(ui_icoProgressVolume, "\uF027");
-                            break;
-                        case 72 ... 100:
-                            lv_label_set_text(ui_icoProgressVolume, "\uF028");
-                            break;
+                        write_text_to_file("/tmp/explore_dir", "w", CHAR, n_dir);
+                        load_mux("explore");
+
+                        switch (module) {
+                            case MMC:
+                            case SDCARD:
+                            case USB:
+                                cache_message(n_dir);
+                                break;
+                            default:
+                                break;
+                        }
+                    } else {
+                        write_text_to_file(MUOS_IDX_LOAD, "w", INT, current_item_index);
+
+                        if (load_content(0)) {
+                            static char launch_script[MAX_BUFFER_SIZE];
+                            snprintf(launch_script, sizeof(launch_script),
+                                     "%s/script/mux/launch.sh", INTERNAL_PATH);
+
+                            write_text_to_file("/tmp/manual_launch", "w", INT, 1);
+
+                            load_mux("explore");
+                        }
                     }
-                    lv_bar_set_value(ui_barProgressVolume, volume, LV_ANIM_OFF);
+                    break;
+                case FAVOURITE:
+                    if (load_cached_content(f_content, "favourite", 0)) {
+                        write_text_to_file("/tmp/explore_card", "w", CHAR, "favourite");
+                        write_text_to_file("/tmp/explore_dir", "w", CHAR, "");
+                        write_text_to_file("/tmp/manual_launch", "w", INT, 1);
+                    } else {
+                        return;
+                    }
+                    break;
+                case HISTORY:
+                    if (load_cached_content(f_content, "history", 0)) {
+                        write_text_to_file("/tmp/explore_card", "w", CHAR, "history");
+                        write_text_to_file("/tmp/explore_dir", "w", CHAR, "");
+                        write_text_to_file("/tmp/manual_launch", "w", INT, 1);
+                    } else {
+                        return;
+                    }
+                    break;
+                default:
+                    break;
+            }
+            break;
+    }
+
+    lv_label_set_text(ui_lblMessage, TS("Loading..."));
+    lv_obj_clear_flag(ui_pnlMessage, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_move_foreground(ui_pnlMessage);
+
+    // Refresh and add a small delay to actually display the message!
+    refresh_screen();
+    usleep(256);
+
+    mux_input_stop();
+}
+
+void handle_b() {
+    if (msgbox_active) {
+        play_sound("confirm", nav_sound, 1);
+        msgbox_active = 0;
+        progress_onscreen = 0;
+        lv_obj_add_flag(msgbox_element, LV_OBJ_FLAG_HIDDEN);
+        return;
+    }
+
+    play_sound("back", nav_sound, 1);
+
+    switch (module) {
+        case FAVOURITE:
+        case HISTORY:
+            write_text_to_file("/tmp/explore_card", "w", CHAR, "root");
+            write_text_to_file("/tmp/explore_dir", "w", CHAR, "");
+            load_mux("launcher");
+            break;
+        default:
+            if (sd_dir != NULL) {
+                char *b_dir = strrchr(sd_dir, '/');
+                if (b_dir != NULL) {
+                    if (strcasecmp(str_tolower(b_dir), "/roms") == 0) {
+                        if (file_exist("/tmp/single_card")) {
+                            write_text_to_file("/tmp/explore_card", "w", CHAR, "root");
+                            write_text_to_file("/tmp/explore_dir", "w", CHAR, "");
+                            remove("/tmp/single_card");
+                            load_mux("launcher");
+                        } else {
+                            write_text_to_file("/tmp/explore_card", "w", CHAR, "root");
+                            write_text_to_file("/tmp/explore_dir", "w", CHAR, "");
+                            load_mux("explore");
+                        }
+                    } else {
+                        write_text_to_file("/tmp/explore_dir", "w", CHAR,
+                                           strndup(sd_dir, b_dir - sd_dir));
+                        load_mux("explore");
+                    }
+
                 }
             }
-        }
-
-        if (file_exist("/tmp/hdmi_do_refresh")) {
-            if (atoi(read_text_from_file("/tmp/hdmi_do_refresh"))) {
-                remove("/tmp/hdmi_do_refresh");
-                lv_obj_invalidate(ui_pnlHeader);
-                lv_obj_invalidate(ui_pnlContent);
-                lv_obj_invalidate(ui_pnlFooter);
-            }
-        }
-
-        refresh_screen();
+            break;
     }
+    mux_input_stop();
+}
+
+void handle_x() {
+    if (msgbox_active || ui_count == 0) {
+        return;
+    }
+
+    char n_dir[MAX_BUFFER_SIZE];
+    snprintf(n_dir, sizeof(n_dir), "%s", sd_dir);
+
+    char f_content[MAX_BUFFER_SIZE];
+    snprintf(f_content, sizeof(f_content), "%s.cfg",
+             strip_ext(items[current_item_index].name));
+
+    char cache_file[MAX_BUFFER_SIZE];
+    switch (module) {
+        case MMC:
+            play_sound("confirm", nav_sound, 1);
+
+            snprintf(cache_file, sizeof(cache_file), "%s/MUOS/info/cache/mmc/%s.ini",
+                     device.STORAGE.ROM.MOUNT, get_last_subdir(n_dir, '/', 4));
+
+            write_text_to_file("/tmp/explore_card", "w", CHAR, "mmc");
+            break;
+        case SDCARD:
+            play_sound("confirm", nav_sound, 1);
+
+            snprintf(cache_file, sizeof(cache_file),
+                     "%s/MUOS/info/cache/sdcard/%s.ini",
+                     device.STORAGE.ROM.MOUNT, get_last_subdir(n_dir, '/', 4));
+
+            write_text_to_file("/tmp/explore_card", "w", CHAR, "sdcard");
+            break;
+        case USB:
+            play_sound("confirm", nav_sound, 1);
+
+            snprintf(cache_file, sizeof(cache_file), "%s/MUOS/info/cache/usb/%s.ini",
+                     device.STORAGE.ROM.MOUNT, get_last_subdir(n_dir, '/', 4));
+
+            write_text_to_file("/tmp/explore_card", "w", CHAR, "usb");
+            break;
+        case FAVOURITE:
+            play_sound("confirm", nav_sound, 1);
+
+            snprintf(cache_file, sizeof(cache_file), "%s/info/favourite/%s.cfg",
+                     STORAGE_PATH, strip_ext(f_content));
+
+            remove(cache_file);
+            write_text_to_file("/tmp/mux_reload", "w", INT, 1);
+
+            goto ttq;
+        case HISTORY:
+            play_sound("confirm", nav_sound, 1);
+
+            snprintf(cache_file, sizeof(cache_file), "%s/info/history/%s.cfg",
+                     STORAGE_PATH, strip_ext(f_content));
+
+            remove(cache_file);
+            write_text_to_file("/tmp/mux_reload", "w", INT, 1);
+
+            goto ttq;
+        default:
+            return;
+    }
+
+    if (file_exist(cache_file)) {
+        remove(cache_file);
+        cache_message(n_dir);
+    }
+
+    write_text_to_file("/tmp/explore_dir", "w", CHAR, n_dir);
+    load_mux("explore");
+
+ttq:
+    mux_input_stop();
+}
+
+void handle_y() {
+    if (msgbox_active || ui_count == 0) {
+        return;
+    }
+
+    play_sound("confirm", nav_sound, 1);
+
+    char f_content[MAX_BUFFER_SIZE];
+    snprintf(f_content, sizeof(f_content), "%s.cfg",
+             strip_ext(items[current_item_index].name));
+
+    switch (module) {
+        case MMC:
+        case SDCARD:
+        case USB:
+            if (items[current_item_index].content_type == FOLDER) {
+                lv_label_set_text(ui_lblMessage,
+                                  TS("Directories cannot be added to Favourites"));
+                lv_obj_clear_flag(ui_pnlMessage, LV_OBJ_FLAG_HIDDEN);
+            } else {
+                if (load_content(1)) {
+                    lv_label_set_text(ui_lblMessage, TS("Added to Favourites"));
+                    lv_obj_clear_flag(ui_pnlMessage, LV_OBJ_FLAG_HIDDEN);
+                } else {
+                    lv_label_set_text(ui_lblMessage, TS("Error adding to Favourites"));
+                    lv_obj_clear_flag(ui_pnlMessage, LV_OBJ_FLAG_HIDDEN);
+                }
+                if (file_exist(MUOS_ROM_LOAD)) {
+                    remove(MUOS_ROM_LOAD);
+                }
+            }
+            break;
+        case HISTORY:
+            if (load_cached_content(f_content, "history", 1)) {
+                lv_label_set_text(ui_lblMessage, TS("Added to Favourites"));
+                lv_obj_clear_flag(ui_pnlMessage, LV_OBJ_FLAG_HIDDEN);
+            } else {
+                lv_label_set_text(ui_lblMessage, TS("Error adding to Favourites"));
+                lv_obj_clear_flag(ui_pnlMessage, LV_OBJ_FLAG_HIDDEN);
+            }
+            if (file_exist(MUOS_ROM_LOAD)) {
+                remove(MUOS_ROM_LOAD);
+            }
+            break;
+        default:
+            break;
+    }
+}
+
+void handle_start() {
+    if (msgbox_active) {
+        return;
+    }
+
+    switch (module) {
+        case MMC:
+        case SDCARD:
+        case USB:
+            play_sound("confirm", nav_sound, 1);
+
+            write_text_to_file("/tmp/explore_card", "w", CHAR, "root");
+            remove("/tmp/explore_dir");
+            load_mux("explore");
+
+            mux_input_stop();
+            break;
+        default:
+            break;
+    }
+}
+
+void handle_select() {
+    if (msgbox_active || ui_count == 0) {
+        return;
+    }
+
+    if (module != ROOT && module != FAVOURITE && module != HISTORY &&
+            strcasecmp(get_last_dir(sd_dir), "ROMS") != 0) {
+        play_sound("confirm", nav_sound, 1);
+
+        switch (module) {
+            case MMC:
+            case SDCARD:
+            case USB:
+                write_text_to_file(MUOS_SAA_LOAD, "w", INT, 1);
+                write_text_to_file(MUOS_SAG_LOAD, "w", INT, 1);
+
+                load_content_core(1, 0);
+                if (safe_quit) mux_input_stop();
+                load_content_governor(1, 0);
+                if (safe_quit) mux_input_stop();
+
+                load_mux("option");
+                mux_input_stop();
+                break;
+            default:
+                break;
+        }
+    }
+}
+
+void handle_l1() {
+    if (msgbox_active || ui_count == 0) {
+        return;
+    }
+
+    if (current_item_index != 0 && current_item_index < ui_count) {
+        list_nav_prev(theme.MUX.ITEM.COUNT);
+    }
+}
+
+void handle_r1() {
+    if (msgbox_active || ui_count == 0) {
+        return;
+    }
+
+    if (current_item_index >= 0 && current_item_index != ui_count - 1) {
+        list_nav_next(theme.MUX.ITEM.COUNT);
+    }
+}
+
+void handle_menu() {
+    if (msgbox_active || progress_onscreen != -1 || ui_count == 0) {
+        return;
+    }
+
+    play_sound("confirm", nav_sound, 1);
+    image_refresh("preview");
+
+    lv_obj_add_flag(ui_pnlHelpPreview, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(ui_pnlHelpMessage, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(ui_pnlHelp, LV_OBJ_FLAG_HIDDEN);
+
+    static lv_anim_t desc_anim;
+    static lv_style_t desc_style;
+    lv_anim_init(&desc_anim);
+    lv_anim_set_delay(&desc_anim, 2000);
+    lv_style_init(&desc_style);
+    lv_style_set_anim(&desc_style, &desc_anim);
+    lv_obj_add_style(ui_lblHelpContent, &desc_style, LV_PART_MAIN);
+    lv_obj_set_style_anim_speed(ui_lblHelpContent, 25, LV_PART_MAIN);
+
+    show_rom_info(ui_pnlHelp, ui_lblHelpHeader, ui_lblHelpPreviewHeader,
+                  ui_lblHelpContent,
+                  items[current_item_index].display_name,
+                  load_content_description());
+}
+
+void handle_up() {
+    if (msgbox_active || ui_count == 0) {
+        return;
+    }
+
+    if (current_item_index == 0) {
+        reset_label_long_mode();
+        current_item_index = ui_count - 1;
+        nav_prev(ui_group, 1);
+        nav_prev(ui_group_glyph, 1);
+        nav_prev(ui_group_panel, 1);
+        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                               current_item_index, ui_pnlContent);
+        nav_moved = 1;
+        image_refresh("box");
+        set_label_long_mode();
+        update_file_counter();
+    } else if (current_item_index > 0) {
+        list_nav_prev(1);
+    }
+}
+
+void handle_up_hold() {
+    if (msgbox_active || ui_count == 0) {
+        return;
+    }
+
+    if (current_item_index > 0) {
+        list_nav_prev(1);
+    }
+}
+
+void handle_down() {
+    if (msgbox_active || ui_count == 0) {
+        return;
+    }
+
+    if (current_item_index == ui_count - 1) {
+        reset_label_long_mode();
+        current_item_index = 0;
+        nav_next(ui_group, 1);
+        nav_next(ui_group_glyph, 1);
+        nav_next(ui_group_panel, 1);
+        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                               current_item_index, ui_pnlContent);
+        nav_moved = 1;
+        image_refresh("box");
+        set_label_long_mode();
+        update_file_counter();
+    } else if (current_item_index < ui_count - 1) {
+        list_nav_next(1);
+    }
+}
+
+void handle_down_hold() {
+    if (msgbox_active || ui_count == 0) {
+        return;
+    }
+
+    if (current_item_index < ui_count - 1) {
+        list_nav_next(1);
+    }
+}
+
+void handle_volume() {
+    if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {
+        if (mux_input_pressed(MUX_INPUT_MENU_LONG)) {
+            progress_onscreen = 1;
+            lv_obj_add_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_clear_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
+            lv_label_set_text(ui_icoProgressBrightness, "\uF185");
+            lv_bar_set_value(ui_barProgressBrightness, atoi(read_text_from_file(BRIGHT_PERC)), LV_ANIM_OFF);
+        } else {
+            progress_onscreen = 2;
+            lv_obj_add_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_clear_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
+            int volume = atoi(read_text_from_file(VOLUME_PERC));
+            switch (volume) {
+                default:
+                case 0:
+                    lv_label_set_text(ui_icoProgressVolume, "\uF6A9");
+                    break;
+                case 1 ... 46:
+                    lv_label_set_text(ui_icoProgressVolume, "\uF026");
+                    break;
+                case 47 ... 71:
+                    lv_label_set_text(ui_icoProgressVolume, "\uF027");
+                    break;
+                case 72 ... 100:
+                    lv_label_set_text(ui_icoProgressVolume, "\uF028");
+                    break;
+            }
+            lv_bar_set_value(ui_barProgressVolume, volume, LV_ANIM_OFF);
+        }
+    }
+}
+
+void handle_idle() {
+    if (file_exist("/tmp/hdmi_do_refresh")) {
+        if (atoi(read_text_from_file("/tmp/hdmi_do_refresh"))) {
+            remove("/tmp/hdmi_do_refresh");
+            lv_obj_invalidate(ui_pnlHeader);
+            lv_obj_invalidate(ui_pnlContent);
+            lv_obj_invalidate(ui_pnlFooter);
+        }
+    }
+
+    refresh_screen();
 }
 
 void set_nav_text(const char *nav_a, const char *nav_b, const char *nav_x, const char *nav_y, const char *nav_menu) {
@@ -2197,31 +2148,6 @@ int main(int argc, char *argv[]) {
 
     init_elements();
 
-    switch (theme.MISC.NAVIGATION_TYPE) {
-        case 1:
-            NAV_DPAD_HOR = device.RAW_INPUT.DPAD.DOWN;
-            NAV_ANLG_HOR = device.RAW_INPUT.ANALOG.LEFT.DOWN;
-            NAV_DPAD_VER = device.RAW_INPUT.DPAD.RIGHT;
-            NAV_ANLG_VER = device.RAW_INPUT.ANALOG.LEFT.RIGHT;
-            break;
-        default:
-            NAV_DPAD_HOR = device.RAW_INPUT.DPAD.RIGHT;
-            NAV_ANLG_HOR = device.RAW_INPUT.ANALOG.LEFT.RIGHT;
-            NAV_DPAD_VER = device.RAW_INPUT.DPAD.DOWN;
-            NAV_ANLG_VER = device.RAW_INPUT.ANALOG.LEFT.DOWN;
-    }
-
-    switch (config.SETTINGS.ADVANCED.SWAP) {
-        case 1:
-            NAV_A = device.RAW_INPUT.BUTTON.B;
-            NAV_B = device.RAW_INPUT.BUTTON.A;
-            break;
-        default:
-            NAV_A = device.RAW_INPUT.BUTTON.A;
-            NAV_B = device.RAW_INPUT.BUTTON.B;
-            break;
-    }
-
     current_wall = load_wallpaper(ui_screen, NULL, theme.MISC.ANIMATED_BACKGROUND, theme.MISC.RANDOM_BACKGROUND);
     if (strlen(current_wall) > 3) {
         if (theme.MISC.RANDOM_BACKGROUND) {
@@ -2385,7 +2311,41 @@ int main(int argc, char *argv[]) {
     update_file_counter();
 
     refresh_screen();
-    joystick_task();
+
+    mux_input_options input_opts = {
+        .gamepad_fd = js_fd,
+        .system_fd = js_fd_sys,
+        .swap_nav = config.SETTINGS.ADVANCED.SWAP,
+        .swap_axis = (theme.MISC.NAVIGATION_TYPE == 1),
+        .press_handler = {
+            [MUX_INPUT_A] = handle_a,
+            [MUX_INPUT_L3] = handle_a,
+            [MUX_INPUT_B] = handle_b,
+            [MUX_INPUT_X] = handle_x,
+            [MUX_INPUT_Y] = handle_y,
+            [MUX_INPUT_L1] = handle_l1,
+            [MUX_INPUT_R1] = handle_r1,
+            [MUX_INPUT_SELECT] = handle_select,
+            [MUX_INPUT_START] = handle_start,
+            [MUX_INPUT_DPAD_UP] = handle_up,
+            [MUX_INPUT_LS_UP] = handle_up,
+            [MUX_INPUT_DPAD_DOWN] = handle_down,
+            [MUX_INPUT_LS_DOWN] = handle_down,
+            [MUX_INPUT_VOL_UP] = handle_volume,
+            [MUX_INPUT_VOL_DOWN] = handle_volume,
+            [MUX_INPUT_MENU_SHORT] = handle_menu,
+        },
+        .hold_handler = {
+            [MUX_INPUT_L1] = handle_l1,
+            [MUX_INPUT_R1] = handle_r1,
+            [MUX_INPUT_DPAD_UP] = handle_up_hold,
+            [MUX_INPUT_LS_UP] = handle_up_hold,
+            [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
+            [MUX_INPUT_LS_DOWN] = handle_down_hold,
+        },
+        .idle_handler = handle_idle,
+    };
+    mux_input_task(&input_opts);
 
     free_items(items, item_count);
     close(js_fd);

--- a/muxtester/Makefile
+++ b/muxtester/Makefile
@@ -77,6 +77,7 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/common.c \
 		../common/ui_common.c \
 		../common/theme.c \
+		../common/input.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \


### PR DESCRIPTION
I was trying to tweak the stick direction detection and menu acceleration a bit more, and I kept getting frustrated by the duplication of input handling code across the various apps, plus the entanglement of the app logic directly in the evdev loop (which makes it hard to add deadzones and things without making the app-specific logic really complex).

I started prototyping an abstraction layer between evdev and the apps themselves, and... I got a little carried away. 😄 I wound up factoring the core event loop, evdev decoding logic, press/hold detection, etc. into a reusable library (`input.c`/`input.h`). It provides an "input task" that a muX app can configure, registering handlers for press, release, and hold actions on specific buttons and inputs.

The idea is that if we want to change the hold behavior (e.g., adding an acceleration curve instead of a fixed speed, etc.), or the stick detection logic (e.g., adding an outer deadzone, debouncing to ignore noisy inputs, whatever), we can do that centrally without touching each app. We also get the ability to configure hold behavior/acceleration for any inputs for free, rather than it just being available for scrolling.

---

I ported muxplore and muxtester over to the new library to show two very different types of input pattern. muxplore uses the handler functions broken out by input type, whereas muxtester just reads the pressed inputs directly every time through the input loop (but still uses the common logic to detect stick presses and such).

If you're a fan of this approach, I figured the other apps could be ported incrementally. And if not, I understand, and honestly, the input lib was just fun to write. 😃

P.S. The GitHub diffing algorithm makes the changes in muxplore kind of hard to parse, IMO. It may be easier to just open old vs. new `muxplore.c` side by side and manually compare the old `joystick_task` to the new `handle_foo` functions to see if you like the new approach or not.

---

Ignoring any bugs I might have introduced, there's also two intended behavioral changes here:

1. muxplore: Allow holding L1/R1 to repeatedly scroll by page. This is both because I think it's a useful feature for large folders, and also to demonstrate that the input library makes it easy. All I had to do was register the existing L1/R1 callback functions as hold handlers in muxplore's main function, no extra logic needed.
2. muxplore: Only show message box on Menu _short_ press, not long press. This avoids triggering the popup while trying to take a screenshot. (It also seems to most of the other muX apps, which only show the popup on short press.)