### PR TITLE
Tweak new input library and port a couple more apps over to it

### DIFF
--- a/common/input.c
+++ b/common/input.c
@@ -166,6 +166,15 @@ static void handle_input(const mux_input_options *opts,
 }
 
 void mux_input_task(const mux_input_options *opts) {
+    // Delay (millis) to wait for an input event before timing out. This determines two things:
+    //
+    // 1. The min rate at which hold_handlers are called. (This delay should be no longer than the
+    //    shortly expected "menu acceleration" setting.)
+    // 2. The min rate at which idle_handler is called. (This controls the screen refresh interval.)
+    //
+    // We use 16ms, as this is the shortest acceleration setting in the UI, and also roughly 60 FPS.
+    const int IDLE_DELAY = 16;
+
     int epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
         perror("mux_input_task: epoll_create1");
@@ -197,8 +206,7 @@ void mux_input_task(const mux_input_options *opts) {
 
     // Input event loop:
     while (!stop) {
-        int num_events = epoll_wait(epoll_fd, epoll_event, device.DEVICE.EVENT,
-                                    config.SETTINGS.ADVANCED.ACCELERATE);
+        int num_events = epoll_wait(epoll_fd, epoll_event, device.DEVICE.EVENT, IDLE_DELAY);
         if (num_events == -1) {
             perror("mux_input_task: epoll_wait");
             continue;

--- a/muxapp/Makefile
+++ b/muxapp/Makefile
@@ -77,6 +77,7 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/common.c \
 		../common/ui_common.c \
 		../common/theme.c \
+		../common/input.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \

--- a/muxapp/main.c
+++ b/muxapp/main.c
@@ -21,19 +21,13 @@
 #include "../common/collection.h"
 #include "../common/config.h"
 #include "../common/device.h"
+#include "../common/input.h"
 
 __thread uint64_t start_ms = 0;
 
 char *mux_prog;
 static int js_fd;
 static int js_fd_sys;
-
-int NAV_DPAD_HOR;
-int NAV_ANLG_HOR;
-int NAV_DPAD_VER;
-int NAV_ANLG_VER;
-int NAV_A;
-int NAV_B;
 
 int turbo_mode = 0;
 int msgbox_active = 0;
@@ -238,224 +232,173 @@ void list_nav_next(int steps) {
     nav_moved = 1;
 }
 
-void joystick_task() {
-    struct input_event ev;
-    int epoll_fd;
-    struct epoll_event event, events[device.DEVICE.EVENT];
-
-    int JOYUP_pressed = 0;
-    int JOYDOWN_pressed = 0;
-    int JOYHOTKEY_pressed = 0;
-    int JOYHOTKEY_screenshot = 0;
-
-    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
-    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
-
-    epoll_fd = epoll_create1(0);
-    if (epoll_fd == -1) {
-        perror("Error creating EPOLL instance");
+void handle_a() {
+    if (msgbox_active) {
         return;
     }
 
-    event.events = EPOLLIN;
-    event.data.fd = js_fd;
-    if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, js_fd, &event) == -1) {
-        perror("Error with EPOLL controller");
+    if (ui_count > 0) {
+        play_sound("confirm", nav_sound, 1);
+
+        lv_label_set_text(ui_lblMessage, TS("Loading Application"));
+        lv_obj_clear_flag(ui_pnlMessage, LV_OBJ_FLAG_HIDDEN);
+
+        static char command[MAX_BUFFER_SIZE];
+        snprintf(command, sizeof(command), "%s/MUOS/application/%s.sh",
+                 device.STORAGE.ROM.MOUNT, items[current_item_index].name);
+        write_text_to_file(MUOS_APP_LOAD, "w", CHAR, command);
+
+        write_text_to_file(MUOS_AIN_LOAD, "w", INT, current_item_index);
+
+        mux_input_stop();
+    }
+}
+
+void handle_b() {
+    if (msgbox_active) {
+        play_sound("confirm", nav_sound, 1);
+        msgbox_active = 0;
+        progress_onscreen = 0;
+        lv_obj_add_flag(msgbox_element, LV_OBJ_FLAG_HIDDEN);
         return;
     }
 
-    event.data.fd = js_fd_sys;
-    if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, js_fd_sys, &event) == -1) {
-        perror("Error with EPOLL controller");
+    play_sound("back", nav_sound, 1);
+    write_text_to_file(MUOS_PDI_LOAD, "w", CHAR, "apps");
+    mux_input_stop();
+}
+
+void handle_l1() {
+    if (msgbox_active) {
         return;
     }
 
-    while (1) {
-        int num_events = epoll_wait(epoll_fd, events, device.DEVICE.EVENT, config.SETTINGS.ADVANCED.ACCELERATE);
-        if (num_events == -1) {
-            perror("Error with EPOLL wait event timer");
-            continue;
-        }
-
-        for (int i = 0; i < num_events; i++) {
-            if (events[i].data.fd == js_fd_sys) {
-                ssize_t ret = read(js_fd_sys, &ev, sizeof(struct input_event));
-                if (ret == -1) {
-                    perror("Error reading input");
-                    continue;
-                }
-                if (JOYHOTKEY_pressed == 1 && ev.type == EV_KEY && ev.value == 1 &&
-                    (ev.code == device.RAW_INPUT.BUTTON.POWER_SHORT || ev.code == device.RAW_INPUT.BUTTON.POWER_LONG)) {
-                    JOYHOTKEY_screenshot = 1;
-                }
-            } else if (events[i].data.fd == js_fd) {
-                ssize_t ret = read(js_fd, &ev, sizeof(struct input_event));
-                if (ret == -1) {
-                    perror("Error reading input");
-                    continue;
-                }
-
-                switch (ev.type) {
-                    case EV_KEY:
-                        if (ev.value == 1) {
-                            if (msgbox_active) {
-                                if (ev.code == NAV_B) {
-                                    play_sound("confirm", nav_sound, 1);
-                                    msgbox_active = 0;
-                                    progress_onscreen = 0;
-                                    lv_obj_add_flag(msgbox_element, LV_OBJ_FLAG_HIDDEN);
-                                }
-                            } else {
-                                if (ev.code == device.RAW_INPUT.BUTTON.MENU_LONG) {
-                                    JOYHOTKEY_pressed = 1;
-                                    JOYHOTKEY_screenshot = 0;
-                                } else if (ev.code == NAV_A || ev.code == device.RAW_INPUT.ANALOG.LEFT.CLICK) {
-                                    if (ui_count > 0) {
-                                        play_sound("confirm", nav_sound, 1);
-
-                                        lv_label_set_text(ui_lblMessage, TS("Loading Application"));
-                                        lv_obj_clear_flag(ui_pnlMessage, LV_OBJ_FLAG_HIDDEN);
-
-                                        static char command[MAX_BUFFER_SIZE];
-                                        snprintf(command, sizeof(command), "%s/MUOS/application/%s.sh",
-                                                 device.STORAGE.ROM.MOUNT, items[current_item_index].name);
-                                        write_text_to_file(MUOS_APP_LOAD, "w", CHAR, command);
-
-                                        write_text_to_file(MUOS_AIN_LOAD, "w", INT, current_item_index);
-
-                                        return;
-                                    }
-                                } else if (ev.code == NAV_B) {
-                                    play_sound("back", nav_sound, 1);
-                                    write_text_to_file(MUOS_PDI_LOAD, "w", CHAR, "apps");
-                                    return;
-                                } else if (ev.code == device.RAW_INPUT.BUTTON.L1) {
-                                    if (current_item_index >= 0 && current_item_index < ui_count) {
-                                        list_nav_prev(theme.MUX.ITEM.COUNT);
-                                    }
-                                } else if (ev.code == device.RAW_INPUT.BUTTON.R1) {
-                                    if (current_item_index >= 0 && current_item_index < ui_count) {
-                                        list_nav_next(theme.MUX.ITEM.COUNT);
-                                    }
-                                }
-                            }
-                        } else {
-                            if ((ev.code == device.RAW_INPUT.BUTTON.MENU_SHORT ||
-                                 ev.code == device.RAW_INPUT.BUTTON.MENU_LONG) && !JOYHOTKEY_screenshot) {
-                                JOYHOTKEY_pressed = 0;
-                                if (progress_onscreen == -1) {
-                                    play_sound("confirm", nav_sound, 1);
-                                    show_help();
-                                }
-                            }
-                        }
-                        break;
-                    case EV_ABS:
-                        if (msgbox_active) {
-                            break;
-                        }
-                        if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
-                                if (current_item_index == 0) {
-                                    current_item_index = ui_count - 1;
-                                    nav_prev(ui_group, 1);
-                                    nav_prev(ui_group_glyph, 1);
-                                    nav_prev(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                    nav_moved = 1;
-                                } else if (current_item_index > 0) {
-                                    list_nav_prev(1);
-                                }
-                                JOYUP_pressed = 1;
-                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
-                                nav_tick = mux_tick();
-                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
-                                if (current_item_index == ui_count - 1) {
-                                    current_item_index = 0;
-                                    nav_next(ui_group, 1);
-                                    nav_next(ui_group_glyph, 1);
-                                    nav_next(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                    nav_moved = 1;
-                                } else if (current_item_index < ui_count - 1) {
-                                    list_nav_next(1);
-                                }
-                                JOYDOWN_pressed = 1;
-                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
-                                nav_tick = mux_tick();
-                            } else {
-                                JOYUP_pressed = 0;
-                                JOYDOWN_pressed = 0;
-                            }
-                        }
-                        break;
-                    default:
-                        break;
-                }
-            }
-            refresh_screen();
-        }
-
-        // Handle menu acceleration.
-        if (mux_tick() - nav_tick >= nav_hold) {
-            if (JOYUP_pressed && current_item_index > 0) {
-                list_nav_prev(1);
-                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
-                nav_tick = mux_tick();
-            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
-                list_nav_next(1);
-                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
-                nav_tick = mux_tick();
-            }
-        }
-
-        if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {
-            if (ev.type == EV_KEY && ev.value == 1 &&
-                (ev.code == device.RAW_INPUT.BUTTON.VOLUME_DOWN || ev.code == device.RAW_INPUT.BUTTON.VOLUME_UP)) {
-                if (JOYHOTKEY_pressed) {
-                    progress_onscreen = 1;
-                    lv_obj_add_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
-                    lv_obj_clear_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
-                    lv_label_set_text(ui_icoProgressBrightness, "\uF185");
-                    lv_bar_set_value(ui_barProgressBrightness, atoi(read_text_from_file(BRIGHT_PERC)), LV_ANIM_ON);
-                } else {
-                    progress_onscreen = 2;
-                    lv_obj_add_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
-                    lv_obj_clear_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
-                    int volume = atoi(read_text_from_file(VOLUME_PERC));
-                    switch (volume) {
-                        default:
-                        case 0:
-                            lv_label_set_text(ui_icoProgressVolume, "\uF6A9");
-                            break;
-                        case 1 ... 46:
-                            lv_label_set_text(ui_icoProgressVolume, "\uF026");
-                            break;
-                        case 47 ... 71:
-                            lv_label_set_text(ui_icoProgressVolume, "\uF027");
-                            break;
-                        case 72 ... 100:
-                            lv_label_set_text(ui_icoProgressVolume, "\uF028");
-                            break;
-                    }
-                    lv_bar_set_value(ui_barProgressVolume, volume, LV_ANIM_ON);
-                }
-            }
-        }
-
-        if (file_exist("/tmp/hdmi_do_refresh")) {
-            if (atoi(read_text_from_file("/tmp/hdmi_do_refresh"))) {
-                remove("/tmp/hdmi_do_refresh");
-                lv_obj_invalidate(ui_pnlHeader);
-                lv_obj_invalidate(ui_pnlContent);
-                lv_obj_invalidate(ui_pnlFooter);
-            }
-        }
-
-        refresh_screen();
+    if (current_item_index >= 0 && current_item_index < ui_count) {
+        list_nav_prev(theme.MUX.ITEM.COUNT);
     }
+}
+
+void handle_r1() {
+    if (msgbox_active) {
+        return;
+    }
+
+    if (current_item_index >= 0 && current_item_index < ui_count) {
+        list_nav_next(theme.MUX.ITEM.COUNT);
+    }
+}
+
+void handle_menu() {
+    if (msgbox_active) {
+        return;
+    }
+
+    if (progress_onscreen == -1) {
+        play_sound("confirm", nav_sound, 1);
+        show_help();
+    }
+}
+
+void handle_up() {
+    if (msgbox_active) {
+        return;
+    }
+
+    if (current_item_index == 0) {
+        current_item_index = ui_count - 1;
+        nav_prev(ui_group, 1);
+        nav_prev(ui_group_glyph, 1);
+        nav_prev(ui_group_panel, 1);
+        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                               current_item_index, ui_pnlContent);
+        nav_moved = 1;
+    } else if (current_item_index > 0) {
+        list_nav_prev(1);
+    }
+}
+
+void handle_up_hold() {
+    if (msgbox_active) {
+        return;
+    }
+
+    if (current_item_index > 0) {
+        list_nav_prev(1);
+    }
+}
+
+void handle_down() {
+    if (msgbox_active) {
+        return;
+    }
+
+    if (current_item_index == ui_count - 1) {
+        current_item_index = 0;
+        nav_next(ui_group, 1);
+        nav_next(ui_group_glyph, 1);
+        nav_next(ui_group_panel, 1);
+        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                               current_item_index, ui_pnlContent);
+        nav_moved = 1;
+    } else if (current_item_index < ui_count - 1) {
+        list_nav_next(1);
+    }
+}
+
+void handle_down_hold() {
+    if (msgbox_active) {
+        return;
+    }
+
+    if (current_item_index < ui_count - 1) {
+        list_nav_next(1);
+    }
+}
+
+void handle_volume() {
+    if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {
+        if (mux_input_pressed(MUX_INPUT_MENU_LONG)) {
+            progress_onscreen = 1;
+            lv_obj_add_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_clear_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
+            lv_label_set_text(ui_icoProgressBrightness, "\uF185");
+            lv_bar_set_value(ui_barProgressBrightness, atoi(read_text_from_file(BRIGHT_PERC)), LV_ANIM_ON);
+        } else {
+            progress_onscreen = 2;
+            lv_obj_add_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_clear_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
+            int volume = atoi(read_text_from_file(VOLUME_PERC));
+            switch (volume) {
+                default:
+                case 0:
+                    lv_label_set_text(ui_icoProgressVolume, "\uF6A9");
+                    break;
+                case 1 ... 46:
+                    lv_label_set_text(ui_icoProgressVolume, "\uF026");
+                    break;
+                case 47 ... 71:
+                    lv_label_set_text(ui_icoProgressVolume, "\uF027");
+                    break;
+                case 72 ... 100:
+                    lv_label_set_text(ui_icoProgressVolume, "\uF028");
+                    break;
+            }
+            lv_bar_set_value(ui_barProgressVolume, volume, LV_ANIM_ON);
+        }
+    }
+}
+
+void handle_idle() {
+    if (file_exist("/tmp/hdmi_do_refresh")) {
+        if (atoi(read_text_from_file("/tmp/hdmi_do_refresh"))) {
+            remove("/tmp/hdmi_do_refresh");
+            lv_obj_invalidate(ui_pnlHeader);
+            lv_obj_invalidate(ui_pnlContent);
+            lv_obj_invalidate(ui_pnlFooter);
+        }
+    }
+
+    refresh_screen();
 }
 
 void init_elements() {
@@ -671,31 +614,6 @@ int main(int argc, char *argv[]) {
 
     lv_label_set_text(ui_lblDatetime, get_datetime());
 
-    switch (theme.MISC.NAVIGATION_TYPE) {
-        case 1:
-            NAV_DPAD_HOR = device.RAW_INPUT.DPAD.DOWN;
-            NAV_ANLG_HOR = device.RAW_INPUT.ANALOG.LEFT.DOWN;
-            NAV_DPAD_VER = device.RAW_INPUT.DPAD.RIGHT;
-            NAV_ANLG_VER = device.RAW_INPUT.ANALOG.LEFT.RIGHT;
-            break;
-        default:
-            NAV_DPAD_HOR = device.RAW_INPUT.DPAD.RIGHT;
-            NAV_ANLG_HOR = device.RAW_INPUT.ANALOG.LEFT.RIGHT;
-            NAV_DPAD_VER = device.RAW_INPUT.DPAD.DOWN;
-            NAV_ANLG_VER = device.RAW_INPUT.ANALOG.LEFT.DOWN;
-    }
-
-    switch (config.SETTINGS.ADVANCED.SWAP) {
-        case 1:
-            NAV_A = device.RAW_INPUT.BUTTON.B;
-            NAV_B = device.RAW_INPUT.BUTTON.A;
-            break;
-        default:
-            NAV_A = device.RAW_INPUT.BUTTON.A;
-            NAV_B = device.RAW_INPUT.BUTTON.B;
-            break;
-    }
-
     load_font_text(basename(argv[0]), ui_screen);
     load_font_section(basename(argv[0]), FONT_PANEL_FOLDER, ui_pnlContent);
     load_font_section(mux_prog, FONT_HEADER_FOLDER, ui_pnlHeader);
@@ -794,7 +712,37 @@ int main(int argc, char *argv[]) {
     lv_timer_ready(ui_refresh_timer);
 
     refresh_screen();
-    joystick_task();
+
+    mux_input_options input_opts = {
+        .gamepad_fd = js_fd,
+        .system_fd = js_fd_sys,
+        .swap_nav = config.SETTINGS.ADVANCED.SWAP,
+        .swap_axis = (theme.MISC.NAVIGATION_TYPE == 1),
+        .press_handler = {
+            [MUX_INPUT_A] = handle_a,
+            [MUX_INPUT_L3] = handle_a,
+            [MUX_INPUT_B] = handle_b,
+            [MUX_INPUT_L1] = handle_l1,
+            [MUX_INPUT_R1] = handle_r1,
+            [MUX_INPUT_DPAD_UP] = handle_up,
+            [MUX_INPUT_LS_UP] = handle_up,
+            [MUX_INPUT_DPAD_DOWN] = handle_down,
+            [MUX_INPUT_LS_DOWN] = handle_down,
+            [MUX_INPUT_VOL_UP] = handle_volume,
+            [MUX_INPUT_VOL_DOWN] = handle_volume,
+            [MUX_INPUT_MENU_SHORT] = handle_menu,
+        },
+        .hold_handler = {
+            [MUX_INPUT_L1] = handle_l1,
+            [MUX_INPUT_R1] = handle_r1,
+            [MUX_INPUT_DPAD_UP] = handle_up_hold,
+            [MUX_INPUT_LS_UP] = handle_up_hold,
+            [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
+            [MUX_INPUT_LS_DOWN] = handle_down_hold,
+        },
+        .idle_handler = handle_idle,
+    };
+    mux_input_task(&input_opts);
 
     free_items(items, item_count);
     close(js_fd);

--- a/muxarchive/Makefile
+++ b/muxarchive/Makefile
@@ -76,6 +76,7 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/common.c \
 		../common/ui_common.c \
 		../common/theme.c \
+		../common/input.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \

--- a/muxarchive/main.c
+++ b/muxarchive/main.c
@@ -20,6 +20,7 @@
 #include "../common/ui_common.h"
 #include "../common/config.h"
 #include "../common/device.h"
+#include "../common/input.h"
 
 __thread uint64_t start_ms = 0;
 
@@ -233,230 +234,178 @@ void list_nav_next(int steps) {
     nav_moved = 1;
 }
 
-void joystick_task() {
-    struct input_event ev;
-    int epoll_fd;
-    struct epoll_event event, events[device.DEVICE.EVENT];
-
-    int JOYUP_pressed = 0;
-    int JOYDOWN_pressed = 0;
-    int JOYHOTKEY_pressed = 0;
-    int JOYHOTKEY_screenshot = 0;
-
-    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
-    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
-
-    epoll_fd = epoll_create1(0);
-    if (epoll_fd == -1) {
-        perror("Error creating EPOLL instance");
+void handle_a() {
+    if (msgbox_active) {
         return;
     }
 
-    event.events = EPOLLIN;
-    event.data.fd = js_fd;
-    if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, js_fd, &event) == -1) {
-        perror("Error with EPOLL controller");
+    if (ui_count > 0) {
+        play_sound("confirm", nav_sound, 1);
+
+        static char extract_script[MAX_BUFFER_SIZE];
+        snprintf(extract_script, sizeof(extract_script),
+                 "%s/script/mux/extract.sh", INTERNAL_PATH);
+
+        static char command[MAX_BUFFER_SIZE];
+        snprintf(command, sizeof(command), "/opt/muos/bin/fbpad %s \"%s\"",
+                 extract_script, lv_label_get_text(lv_group_get_focused(ui_group_data)));
+        setenv("TERM", "xterm-256color", 1);
+        printf("RUNNING: %s\n", command);
+        system(command);
+
+        write_text_to_file(MUOS_IDX_LOAD, "w", INT, current_item_index);
+
+        load_mux("archive");
+        mux_input_stop();
+    }
+}
+
+void handle_b() {
+    if (msgbox_active) {
+        play_sound("confirm", nav_sound, 1);
+        msgbox_active = 0;
+        progress_onscreen = 0;
+        lv_obj_add_flag(msgbox_element, LV_OBJ_FLAG_HIDDEN);
         return;
     }
 
-    event.data.fd = js_fd_sys;
-    if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, js_fd_sys, &event) == -1) {
-        perror("Error with EPOLL controller");
+    play_sound("back", nav_sound, 1);
+    mux_input_stop();
+}
+
+void handle_l1() {
+    if (msgbox_active) {
         return;
     }
 
-    while (1) {
-        int num_events = epoll_wait(epoll_fd, events, device.DEVICE.EVENT, config.SETTINGS.ADVANCED.ACCELERATE);
-        if (num_events == -1) {
-            perror("Error with EPOLL wait event timer");
-            continue;
-        }
-
-        for (int i = 0; i < num_events; i++) {
-            if (events[i].data.fd == js_fd_sys) {
-                ssize_t ret = read(js_fd_sys, &ev, sizeof(struct input_event));
-                if (ret == -1) {
-                    perror("Error reading input");
-                    continue;
-                }
-                if (JOYHOTKEY_pressed == 1 && ev.type == EV_KEY && ev.value == 1 &&
-                    (ev.code == device.RAW_INPUT.BUTTON.POWER_SHORT || ev.code == device.RAW_INPUT.BUTTON.POWER_LONG)) {
-                    JOYHOTKEY_screenshot = 1;
-                }
-            } else if (events[i].data.fd == js_fd) {
-                ssize_t ret = read(js_fd, &ev, sizeof(struct input_event));
-                if (ret == -1) {
-                    perror("Error reading input");
-                    continue;
-                }
-
-                struct _lv_obj_t *data_focused = lv_group_get_focused(ui_group_data);
-                switch (ev.type) {
-                    case EV_KEY:
-                        if (ev.value == 1) {
-                            if (msgbox_active) {
-                                if (ev.code == NAV_B) {
-                                    play_sound("confirm", nav_sound, 1);
-                                    msgbox_active = 0;
-                                    progress_onscreen = 0;
-                                    lv_obj_add_flag(msgbox_element, LV_OBJ_FLAG_HIDDEN);
-                                }
-                            } else {
-                                if (ev.code == device.RAW_INPUT.BUTTON.MENU_LONG) {
-                                    JOYHOTKEY_pressed = 1;
-                                    JOYHOTKEY_screenshot = 0;
-                                } else if (ev.code == NAV_A || ev.code == device.RAW_INPUT.ANALOG.LEFT.CLICK) {
-                                    if (ui_count > 0) {
-                                        play_sound("confirm", nav_sound, 1);
-
-                                        static char extract_script[MAX_BUFFER_SIZE];
-                                        snprintf(extract_script, sizeof(extract_script),
-                                                 "%s/script/mux/extract.sh", INTERNAL_PATH);
-
-                                        static char command[MAX_BUFFER_SIZE];
-                                        snprintf(command, sizeof(command), "/opt/muos/bin/fbpad %s \"%s\"",
-                                                 extract_script, lv_label_get_text(data_focused));
-                                        setenv("TERM", "xterm-256color", 1);
-                                        printf("RUNNING: %s\n", command);
-                                        system(command);
-
-                                        write_text_to_file(MUOS_IDX_LOAD, "w", INT, current_item_index);
-
-                                        load_mux("archive");
-                                        return;
-                                    }
-                                } else if (ev.code == NAV_B) {
-                                    play_sound("back", nav_sound, 1);
-                                    return;
-                                } else if (ev.code == device.RAW_INPUT.BUTTON.L1) {
-                                    if (current_item_index >= 0 && current_item_index < ui_count) {
-                                        list_nav_prev(theme.MUX.ITEM.COUNT);
-                                    }
-                                } else if (ev.code == device.RAW_INPUT.BUTTON.R1) {
-                                    if (current_item_index >= 0 && current_item_index < ui_count) {
-                                        list_nav_next(theme.MUX.ITEM.COUNT);
-                                    }
-                                }
-                            }
-                        } else {
-                            if ((ev.code == device.RAW_INPUT.BUTTON.MENU_SHORT ||
-                                 ev.code == device.RAW_INPUT.BUTTON.MENU_LONG) && !JOYHOTKEY_screenshot) {
-                                JOYHOTKEY_pressed = 0;
-                                if (progress_onscreen == -1) {
-                                    play_sound("confirm", nav_sound, 1);
-                                    show_help();
-                                }
-                            }
-                        }
-                        break;
-                    case EV_ABS:
-                        if (msgbox_active) {
-                            break;
-                        }
-                        if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
-                                if (current_item_index == 0) {
-                                    current_item_index = ui_count - 1;
-                                    nav_prev(ui_group, 1);
-                                    nav_prev(ui_group_glyph, 1);
-                                    nav_prev(ui_group_panel, 1);
-                                    nav_prev(ui_group_installed, 1);
-                                    nav_prev(ui_group_data, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                } else if (current_item_index > 0) {
-                                    list_nav_prev(1);
-                                }
-                                JOYUP_pressed = 1;
-                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
-                                nav_tick = mux_tick();
-                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
-                                if (current_item_index == ui_count - 1) {
-                                    current_item_index = 0;
-                                    nav_next(ui_group, 1);
-                                    nav_next(ui_group_glyph, 1);
-                                    nav_next(ui_group_panel, 1);
-                                    nav_next(ui_group_installed, 1);
-                                    nav_next(ui_group_data, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                } else if (current_item_index < ui_count) {
-                                    list_nav_next(1);
-                                }
-                                JOYDOWN_pressed = 1;
-                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
-                                nav_tick = mux_tick();
-                            } else {
-                                JOYUP_pressed = 0;
-                                JOYDOWN_pressed = 0;
-                            }
-                        }
-                        break;
-                    default:
-                        break;
-                }
-            }
-            refresh_screen();
-        }
-
-        // Handle menu acceleration.
-        if (mux_tick() - nav_tick >= nav_hold) {
-            if (JOYUP_pressed && current_item_index > 0) {
-                list_nav_prev(1);
-                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
-                nav_tick = mux_tick();
-            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
-                list_nav_next(1);
-                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
-                nav_tick = mux_tick();
-            }
-        }
-
-        if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {
-            if (ev.type == EV_KEY && ev.value == 1 &&
-                (ev.code == device.RAW_INPUT.BUTTON.VOLUME_DOWN || ev.code == device.RAW_INPUT.BUTTON.VOLUME_UP)) {
-                if (JOYHOTKEY_pressed) {
-                    progress_onscreen = 1;
-                    lv_obj_add_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
-                    lv_obj_clear_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
-                    lv_label_set_text(ui_icoProgressBrightness, "\uF185");
-                    lv_bar_set_value(ui_barProgressBrightness, atoi(read_text_from_file(BRIGHT_PERC)), LV_ANIM_OFF);
-                } else {
-                    progress_onscreen = 2;
-                    lv_obj_add_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
-                    lv_obj_clear_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
-                    int volume = atoi(read_text_from_file(VOLUME_PERC));
-                    switch (volume) {
-                        default:
-                        case 0:
-                            lv_label_set_text(ui_icoProgressVolume, "\uF6A9");
-                            break;
-                        case 1 ... 46:
-                            lv_label_set_text(ui_icoProgressVolume, "\uF026");
-                            break;
-                        case 47 ... 71:
-                            lv_label_set_text(ui_icoProgressVolume, "\uF027");
-                            break;
-                        case 72 ... 100:
-                            lv_label_set_text(ui_icoProgressVolume, "\uF028");
-                            break;
-                    }
-                    lv_bar_set_value(ui_barProgressVolume, volume, LV_ANIM_OFF);
-                }
-            }
-        }
-
-        if (file_exist("/tmp/hdmi_do_refresh")) {
-            if (atoi(read_text_from_file("/tmp/hdmi_do_refresh"))) {
-                remove("/tmp/hdmi_do_refresh");
-                lv_obj_invalidate(ui_pnlHeader);
-                lv_obj_invalidate(ui_pnlContent);
-                lv_obj_invalidate(ui_pnlFooter);
-            }
-        }
-
-        refresh_screen();
+    if (current_item_index >= 0 && current_item_index < ui_count) {
+        list_nav_prev(theme.MUX.ITEM.COUNT);
     }
+}
+
+void handle_r1() {
+    if (msgbox_active) {
+        return;
+    }
+
+    if (current_item_index >= 0 && current_item_index < ui_count) {
+        list_nav_next(theme.MUX.ITEM.COUNT);
+    }
+}
+
+void handle_menu() {
+    if (msgbox_active) {
+        return;
+    }
+
+    if (progress_onscreen == -1) {
+        play_sound("confirm", nav_sound, 1);
+        show_help();
+    }
+}
+
+void handle_up() {
+    if (msgbox_active) {
+        return;
+    }
+
+    if (current_item_index == 0) {
+        current_item_index = ui_count - 1;
+        nav_prev(ui_group, 1);
+        nav_prev(ui_group_glyph, 1);
+        nav_prev(ui_group_panel, 1);
+        nav_prev(ui_group_installed, 1);
+        nav_prev(ui_group_data, 1);
+        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                               current_item_index, ui_pnlContent);
+    } else if (current_item_index > 0) {
+        list_nav_prev(1);
+    }
+}
+
+void handle_up_hold() {
+    if (msgbox_active) {
+        return;
+    }
+
+    if (current_item_index > 0) {
+        list_nav_prev(1);
+    }
+}
+
+void handle_down() {
+    if (msgbox_active) {
+        return;
+    }
+
+    if (current_item_index == ui_count - 1) {
+        current_item_index = 0;
+        nav_next(ui_group, 1);
+        nav_next(ui_group_glyph, 1);
+        nav_next(ui_group_panel, 1);
+        nav_next(ui_group_installed, 1);
+        nav_next(ui_group_data, 1);
+        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                               current_item_index, ui_pnlContent);
+    } else if (current_item_index < ui_count - 1) {
+        list_nav_next(1);
+    }
+}
+
+void handle_down_hold() {
+    if (msgbox_active) {
+        return;
+    }
+
+    if (current_item_index < ui_count - 1) {
+        list_nav_next(1);
+    }
+}
+
+void handle_volume() {
+    if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {
+        if (mux_input_pressed(MUX_INPUT_MENU_LONG)) {
+            progress_onscreen = 1;
+            lv_obj_add_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_clear_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
+            lv_label_set_text(ui_icoProgressBrightness, "\uF185");
+            lv_bar_set_value(ui_barProgressBrightness, atoi(read_text_from_file(BRIGHT_PERC)), LV_ANIM_OFF);
+        } else {
+            progress_onscreen = 2;
+            lv_obj_add_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_clear_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
+            int volume = atoi(read_text_from_file(VOLUME_PERC));
+            switch (volume) {
+                default:
+                case 0:
+                    lv_label_set_text(ui_icoProgressVolume, "\uF6A9");
+                    break;
+                case 1 ... 46:
+                    lv_label_set_text(ui_icoProgressVolume, "\uF026");
+                    break;
+                case 47 ... 71:
+                    lv_label_set_text(ui_icoProgressVolume, "\uF027");
+                    break;
+                case 72 ... 100:
+                    lv_label_set_text(ui_icoProgressVolume, "\uF028");
+                    break;
+            }
+            lv_bar_set_value(ui_barProgressVolume, volume, LV_ANIM_OFF);
+        }
+    }
+}
+
+void handle_idle() {
+    if (file_exist("/tmp/hdmi_do_refresh")) {
+        if (atoi(read_text_from_file("/tmp/hdmi_do_refresh"))) {
+            remove("/tmp/hdmi_do_refresh");
+            lv_obj_invalidate(ui_pnlHeader);
+            lv_obj_invalidate(ui_pnlContent);
+            lv_obj_invalidate(ui_pnlFooter);
+        }
+    }
+
+    refresh_screen();
 }
 
 void init_elements() {
@@ -785,7 +734,37 @@ int main(int argc, char *argv[]) {
     }
 
     refresh_screen();
-    joystick_task();
+
+    mux_input_options input_opts = {
+        .gamepad_fd = js_fd,
+        .system_fd = js_fd_sys,
+        .swap_nav = config.SETTINGS.ADVANCED.SWAP,
+        .swap_axis = (theme.MISC.NAVIGATION_TYPE == 1),
+        .press_handler = {
+            [MUX_INPUT_A] = handle_a,
+            [MUX_INPUT_L3] = handle_a,
+            [MUX_INPUT_B] = handle_b,
+            [MUX_INPUT_L1] = handle_l1,
+            [MUX_INPUT_R1] = handle_r1,
+            [MUX_INPUT_DPAD_UP] = handle_up,
+            [MUX_INPUT_LS_UP] = handle_up,
+            [MUX_INPUT_DPAD_DOWN] = handle_down,
+            [MUX_INPUT_LS_DOWN] = handle_down,
+            [MUX_INPUT_VOL_UP] = handle_volume,
+            [MUX_INPUT_VOL_DOWN] = handle_volume,
+            [MUX_INPUT_MENU_SHORT] = handle_menu,
+        },
+        .hold_handler = {
+            [MUX_INPUT_L1] = handle_l1,
+            [MUX_INPUT_R1] = handle_r1,
+            [MUX_INPUT_DPAD_UP] = handle_up_hold,
+            [MUX_INPUT_LS_UP] = handle_up_hold,
+            [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
+            [MUX_INPUT_LS_DOWN] = handle_down_hold,
+        },
+        .idle_handler = handle_idle,
+    };
+    mux_input_task(&input_opts);
 
     close(js_fd);
     close(js_fd_sys);

--- a/muxinfo/Makefile
+++ b/muxinfo/Makefile
@@ -76,6 +76,7 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/common.c \
 		../common/ui_common.c \
 		../common/theme.c \
+		../common/input.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \

--- a/muxinfo/main.c
+++ b/muxinfo/main.c
@@ -20,19 +20,13 @@
 #include "../common/ui_common.h"
 #include "../common/config.h"
 #include "../common/device.h"
+#include "../common/input.h"
 
 __thread uint64_t start_ms = 0;
 
 char *mux_prog;
 static int js_fd;
 static int js_fd_sys;
-
-int NAV_DPAD_HOR;
-int NAV_ANLG_HOR;
-int NAV_DPAD_VER;
-int NAV_ANLG_VER;
-int NAV_A;
-int NAV_B;
 
 int turbo_mode = 0;
 int msgbox_active = 0;
@@ -161,213 +155,150 @@ void list_nav_next(int steps) {
     nav_moved = 1;
 }
 
-void joystick_task() {
-    struct input_event ev;
-    int epoll_fd;
-    struct epoll_event event, events[device.DEVICE.EVENT];
-
-    int JOYUP_pressed = 0;
-    int JOYDOWN_pressed = 0;
-    int JOYHOTKEY_pressed = 0;
-    int JOYHOTKEY_screenshot = 0;
-
-    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
-    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
-
-    epoll_fd = epoll_create1(0);
-    if (epoll_fd == -1) {
-        perror("Error creating EPOLL instance");
+void handle_a() {
+    if (msgbox_active) {
         return;
     }
 
-    event.events = EPOLLIN;
-    event.data.fd = js_fd;
-    if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, js_fd, &event) == -1) {
-        perror("Error with EPOLL controller");
+    struct _lv_obj_t *element_focused = lv_group_get_focused(ui_group);
+
+    play_sound("confirm", nav_sound, 1);
+
+    if (element_focused == ui_lblTester) {
+        load_mux("tester");
+    } else if (element_focused == ui_lblSystem) {
+        load_mux("system");
+    } else if (element_focused == ui_lblCredits) {
+        load_mux("credits");
+    }
+    mux_input_stop();
+}
+
+void handle_b() {
+    if (msgbox_active) {
+        play_sound("confirm", nav_sound, 1);
+        msgbox_active = 0;
+        progress_onscreen = 0;
+        lv_obj_add_flag(msgbox_element, LV_OBJ_FLAG_HIDDEN);
         return;
     }
 
-    event.data.fd = js_fd_sys;
-    if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, js_fd_sys, &event) == -1) {
-        perror("Error with EPOLL controller");
+    play_sound("back", nav_sound, 1);
+    write_text_to_file(MUOS_PDI_LOAD, "w", CHAR, "info");
+    mux_input_stop();
+}
+
+void handle_menu() {
+    if (msgbox_active) {
         return;
     }
 
-    while (1) {
-        int num_events = epoll_wait(epoll_fd, events, device.DEVICE.EVENT, config.SETTINGS.ADVANCED.ACCELERATE);
-        if (num_events == -1) {
-            perror("Error with EPOLL wait event timer");
-            continue;
-        }
-
-        for (int i = 0; i < num_events; i++) {
-            if (events[i].data.fd == js_fd_sys) {
-                ssize_t ret = read(js_fd_sys, &ev, sizeof(struct input_event));
-                if (ret == -1) {
-                    perror("Error reading input");
-                    continue;
-                }
-                if (JOYHOTKEY_pressed == 1 && ev.type == EV_KEY && ev.value == 1 &&
-                    (ev.code == device.RAW_INPUT.BUTTON.POWER_SHORT || ev.code == device.RAW_INPUT.BUTTON.POWER_LONG)) {
-                    JOYHOTKEY_screenshot = 1;
-                }
-            } else if (events[i].data.fd == js_fd) {
-                ssize_t ret = read(js_fd, &ev, sizeof(struct input_event));
-                if (ret == -1) {
-                    perror("Error reading input");
-                    continue;
-                }
-
-                struct _lv_obj_t *element_focused = lv_group_get_focused(ui_group);
-                switch (ev.type) {
-                    case EV_KEY:
-                        if (ev.value == 1) {
-                            if (msgbox_active) {
-                                if (ev.code == NAV_B) {
-                                    play_sound("confirm", nav_sound, 1);
-                                    msgbox_active = 0;
-                                    progress_onscreen = 0;
-                                    lv_obj_add_flag(msgbox_element, LV_OBJ_FLAG_HIDDEN);
-                                }
-                            } else {
-                                if (ev.code == device.RAW_INPUT.BUTTON.MENU_LONG) {
-                                    JOYHOTKEY_pressed = 1;
-                                    JOYHOTKEY_screenshot = 0;
-                                } else if (ev.code == NAV_A || ev.code == device.RAW_INPUT.ANALOG.LEFT.CLICK) {
-                                    play_sound("confirm", nav_sound, 1);
-
-                                    if (element_focused == ui_lblTester) {
-                                        load_mux("tester");
-                                    } else if (element_focused == ui_lblSystem) {
-                                        load_mux("system");
-                                    } else if (element_focused == ui_lblCredits) {
-                                        load_mux("credits");
-                                    }
-
-                                    return;
-                                } else if (ev.code == NAV_B) {
-                                    play_sound("back", nav_sound, 1);
-                                    write_text_to_file(MUOS_PDI_LOAD, "w", CHAR, "info");
-                                    return;
-                                }
-                            }
-                        } else {
-                            if ((ev.code == device.RAW_INPUT.BUTTON.MENU_SHORT ||
-                                 ev.code == device.RAW_INPUT.BUTTON.MENU_LONG) && !JOYHOTKEY_screenshot) {
-                                JOYHOTKEY_pressed = 0;
-                                if (progress_onscreen == -1) {
-                                    play_sound("confirm", nav_sound, 1);
-                                    show_help(element_focused);
-                                }
-                            }
-                        }
-                        break;
-                    case EV_ABS:
-                        if (msgbox_active) {
-                            break;
-                        }
-                        if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
-                                if (current_item_index == 0) {
-                                    current_item_index = UI_COUNT - 1;
-                                    nav_prev(ui_group, 1);
-                                    nav_prev(ui_group_glyph, 1);
-                                    nav_prev(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
-                                                           current_item_index, ui_pnlContent);
-                                    nav_moved = 1;
-                                } else if (current_item_index > 0) {
-                                    list_nav_prev(1);
-                                }
-                                JOYUP_pressed = 1;
-                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
-                                nav_tick = mux_tick();
-                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
-                                if (current_item_index == UI_COUNT - 1) {
-                                    current_item_index = 0;
-                                    nav_next(ui_group, 1);
-                                    nav_next(ui_group_glyph, 1);
-                                    nav_next(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
-                                                           current_item_index, ui_pnlContent);
-                                    nav_moved = 1;
-                                } else if (current_item_index < UI_COUNT - 1) {
-                                    list_nav_next(1);
-                                }
-                                JOYDOWN_pressed = 1;
-                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
-                                nav_tick = mux_tick();
-                            } else {
-                                JOYUP_pressed = 0;
-                                JOYDOWN_pressed = 0;
-                            }
-                        }
-                        break;
-                    default:
-                        break;
-                }
-            }
-            refresh_screen();
-        }
-
-        // Handle menu acceleration.
-        if (mux_tick() - nav_tick >= nav_hold) {
-            if (JOYUP_pressed && current_item_index > 0) {
-                list_nav_prev(1);
-                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
-                nav_tick = mux_tick();
-            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
-                list_nav_next(1);
-                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
-                nav_tick = mux_tick();
-            }
-        }
-
-        if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {
-            if (ev.type == EV_KEY && ev.value == 1 &&
-                (ev.code == device.RAW_INPUT.BUTTON.VOLUME_DOWN || ev.code == device.RAW_INPUT.BUTTON.VOLUME_UP)) {
-                if (JOYHOTKEY_pressed) {
-                    progress_onscreen = 1;
-                    lv_obj_add_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
-                    lv_obj_clear_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
-                    lv_label_set_text(ui_icoProgressBrightness, "\uF185");
-                    lv_bar_set_value(ui_barProgressBrightness, atoi(read_text_from_file(BRIGHT_PERC)), LV_ANIM_OFF);
-                } else {
-                    progress_onscreen = 2;
-                    lv_obj_add_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
-                    lv_obj_clear_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
-                    int volume = atoi(read_text_from_file(VOLUME_PERC));
-                    switch (volume) {
-                        default:
-                        case 0:
-                            lv_label_set_text(ui_icoProgressVolume, "\uF6A9");
-                            break;
-                        case 1 ... 46:
-                            lv_label_set_text(ui_icoProgressVolume, "\uF026");
-                            break;
-                        case 47 ... 71:
-                            lv_label_set_text(ui_icoProgressVolume, "\uF027");
-                            break;
-                        case 72 ... 100:
-                            lv_label_set_text(ui_icoProgressVolume, "\uF028");
-                            break;
-                    }
-                    lv_bar_set_value(ui_barProgressVolume, volume, LV_ANIM_OFF);
-                }
-            }
-        }
-
-        if (file_exist("/tmp/hdmi_do_refresh")) {
-            if (atoi(read_text_from_file("/tmp/hdmi_do_refresh"))) {
-                remove("/tmp/hdmi_do_refresh");
-                lv_obj_invalidate(ui_pnlHeader);
-                lv_obj_invalidate(ui_pnlContent);
-                lv_obj_invalidate(ui_pnlFooter);
-            }
-        }
-
-        refresh_screen();
+    if (progress_onscreen == -1) {
+        play_sound("confirm", nav_sound, 1);
+        show_help(lv_group_get_focused(ui_group));
     }
+}
+
+void handle_up() {
+    if (msgbox_active) {
+        return;
+    }
+
+    if (current_item_index == 0) {
+        current_item_index = UI_COUNT - 1;
+        nav_prev(ui_group, 1);
+        nav_prev(ui_group_glyph, 1);
+        nav_prev(ui_group_panel, 1);
+        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
+                               current_item_index, ui_pnlContent);
+        nav_moved = 1;
+    } else if (current_item_index > 0) {
+        list_nav_prev(1);
+    }
+}
+
+void handle_down() {
+    if (msgbox_active) {
+        return;
+    }
+
+    if (current_item_index == UI_COUNT - 1) {
+        current_item_index = 0;
+        nav_next(ui_group, 1);
+        nav_next(ui_group_glyph, 1);
+        nav_next(ui_group_panel, 1);
+        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
+                               current_item_index, ui_pnlContent);
+        nav_moved = 1;
+    } else if (current_item_index < UI_COUNT - 1) {
+        list_nav_next(1);
+    }
+}
+
+void handle_up_hold() {
+    if (msgbox_active) {
+        return;
+    }
+
+    if (current_item_index > 0) {
+        list_nav_prev(1);
+    }
+}
+
+void handle_down_hold() {
+    if (msgbox_active) {
+        return;
+    }
+
+    if (current_item_index < ui_count - 1) {
+        list_nav_next(1);
+    }
+}
+
+void handle_volume() {
+    if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {
+        if (mux_input_pressed(MUX_INPUT_MENU_LONG)) {
+            progress_onscreen = 1;
+            lv_obj_add_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_clear_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
+            lv_label_set_text(ui_icoProgressBrightness, "\uF185");
+            lv_bar_set_value(ui_barProgressBrightness, atoi(read_text_from_file(BRIGHT_PERC)), LV_ANIM_OFF);
+        } else {
+            progress_onscreen = 2;
+            lv_obj_add_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_clear_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
+            int volume = atoi(read_text_from_file(VOLUME_PERC));
+            switch (volume) {
+                default:
+                case 0:
+                    lv_label_set_text(ui_icoProgressVolume, "\uF6A9");
+                    break;
+                case 1 ... 46:
+                    lv_label_set_text(ui_icoProgressVolume, "\uF026");
+                    break;
+                case 47 ... 71:
+                    lv_label_set_text(ui_icoProgressVolume, "\uF027");
+                    break;
+                case 72 ... 100:
+                    lv_label_set_text(ui_icoProgressVolume, "\uF028");
+                    break;
+            }
+            lv_bar_set_value(ui_barProgressVolume, volume, LV_ANIM_OFF);
+        }
+    }
+}
+
+void handle_idle() {
+    if (file_exist("/tmp/hdmi_do_refresh")) {
+        if (atoi(read_text_from_file("/tmp/hdmi_do_refresh"))) {
+            remove("/tmp/hdmi_do_refresh");
+            lv_obj_invalidate(ui_pnlHeader);
+            lv_obj_invalidate(ui_pnlContent);
+            lv_obj_invalidate(ui_pnlFooter);
+        }
+    }
+
+    refresh_screen();
 }
 
 void init_elements() {
@@ -593,31 +524,6 @@ int main(int argc, char *argv[]) {
 
     lv_label_set_text(ui_lblDatetime, get_datetime());
 
-    switch (theme.MISC.NAVIGATION_TYPE) {
-        case 1:
-            NAV_DPAD_HOR = device.RAW_INPUT.DPAD.DOWN;
-            NAV_ANLG_HOR = device.RAW_INPUT.ANALOG.LEFT.DOWN;
-            NAV_DPAD_VER = device.RAW_INPUT.DPAD.RIGHT;
-            NAV_ANLG_VER = device.RAW_INPUT.ANALOG.LEFT.RIGHT;
-            break;
-        default:
-            NAV_DPAD_HOR = device.RAW_INPUT.DPAD.RIGHT;
-            NAV_ANLG_HOR = device.RAW_INPUT.ANALOG.LEFT.RIGHT;
-            NAV_DPAD_VER = device.RAW_INPUT.DPAD.DOWN;
-            NAV_ANLG_VER = device.RAW_INPUT.ANALOG.LEFT.DOWN;
-    }
-
-    switch (config.SETTINGS.ADVANCED.SWAP) {
-        case 1:
-            NAV_A = device.RAW_INPUT.BUTTON.B;
-            NAV_B = device.RAW_INPUT.BUTTON.A;
-            break;
-        default:
-            NAV_A = device.RAW_INPUT.BUTTON.A;
-            NAV_B = device.RAW_INPUT.BUTTON.B;
-            break;
-    }
-
     current_wall = load_wallpaper(ui_screen, NULL, theme.MISC.ANIMATED_BACKGROUND, theme.MISC.RANDOM_BACKGROUND);
     if (strlen(current_wall) > 3) {
         if (theme.MISC.RANDOM_BACKGROUND) {
@@ -707,7 +613,33 @@ int main(int argc, char *argv[]) {
     direct_to_previous();
 
     refresh_screen();
-    joystick_task();
+
+    mux_input_options input_opts = {
+        .gamepad_fd = js_fd,
+        .system_fd = js_fd_sys,
+        .swap_nav = config.SETTINGS.ADVANCED.SWAP,
+        .swap_axis = (theme.MISC.NAVIGATION_TYPE == 1),
+        .press_handler = {
+            [MUX_INPUT_A] = handle_a,
+            [MUX_INPUT_L3] = handle_a,
+            [MUX_INPUT_B] = handle_b,
+            [MUX_INPUT_DPAD_UP] = handle_up,
+            [MUX_INPUT_LS_UP] = handle_up,
+            [MUX_INPUT_DPAD_DOWN] = handle_down,
+            [MUX_INPUT_LS_DOWN] = handle_down,
+            [MUX_INPUT_VOL_UP] = handle_volume,
+            [MUX_INPUT_VOL_DOWN] = handle_volume,
+            [MUX_INPUT_MENU_SHORT] = handle_menu,
+        },
+        .hold_handler = {
+            [MUX_INPUT_DPAD_UP] = handle_up_hold,
+            [MUX_INPUT_LS_UP] = handle_up_hold,
+            [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
+            [MUX_INPUT_LS_DOWN] = handle_down_hold,
+        },
+        .idle_handler = handle_idle,
+    };
+    mux_input_task(&input_opts);
 
     close(js_fd);
     close(js_fd_sys);

--- a/muxlaunch/main.c
+++ b/muxlaunch/main.c
@@ -28,13 +28,6 @@ char *mux_prog;
 static int js_fd;
 static int js_fd_sys;
 
-int NAV_DPAD_HOR;
-int NAV_ANLG_HOR;
-int NAV_DPAD_VER;
-int NAV_ANLG_VER;
-int NAV_A;
-int NAV_B;
-
 int turbo_mode = 0;
 int msgbox_active = 0;
 int input_disable = 0;

--- a/muxplore/main.c
+++ b/muxplore/main.c
@@ -32,13 +32,6 @@ struct theme_config theme;
 static int js_fd;
 static int js_fd_sys;
 
-int NAV_DPAD_HOR;
-int NAV_ANLG_HOR;
-int NAV_DPAD_VER;
-int NAV_ANLG_VER;
-int NAV_A;
-int NAV_B;
-
 int turbo_mode = 0;
 int msgbox_active = 0;
 int input_disable = 0;

--- a/muxsysinfo/Makefile
+++ b/muxsysinfo/Makefile
@@ -76,6 +76,7 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/common.c \
 		../common/ui_common.c \
 		../common/theme.c \
+		../common/input.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \

--- a/muxsysinfo/main.c
+++ b/muxsysinfo/main.c
@@ -20,19 +20,13 @@
 #include "../common/ui_common.h"
 #include "../common/config.h"
 #include "../common/device.h"
+#include "../common/input.h"
 
 __thread uint64_t start_ms = 0;
 
 char *mux_prog;
 static int js_fd;
 static int js_fd_sys;
-
-int NAV_DPAD_HOR;
-int NAV_ANLG_HOR;
-int NAV_DPAD_VER;
-int NAV_ANLG_VER;
-int NAV_A;
-int NAV_B;
 
 int turbo_mode = 0;
 int msgbox_active = 0;
@@ -345,210 +339,146 @@ void list_nav_next(int steps) {
     nav_moved = 1;
 }
 
-void joystick_task() {
-    struct input_event ev;
-    int epoll_fd;
-    struct epoll_event event, events[device.DEVICE.EVENT];
-
-    int JOYUP_pressed = 0;
-    int JOYDOWN_pressed = 0;
-    int JOYHOTKEY_pressed = 0;
-    int JOYHOTKEY_screenshot = 0;
-
-    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
-    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
-
-    epoll_fd = epoll_create1(0);
-    if (epoll_fd == -1) {
-        perror("Error creating EPOLL instance");
+void handle_a() {
+    if (msgbox_active) {
         return;
     }
 
-    event.events = EPOLLIN;
-    event.data.fd = js_fd;
-    if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, js_fd, &event) == -1) {
-        perror("Error with EPOLL controller");
+    if (lv_group_get_focused(ui_group) == ui_lblVersion) {
+        osd_message = "Thank you for using muOS!";
+        lv_label_set_text(ui_lblMessage, osd_message);
+        lv_obj_clear_flag(ui_pnlMessage, LV_OBJ_FLAG_HIDDEN);
+    }
+}
+
+void handle_b() {
+    if (msgbox_active) {
+        play_sound("confirm", nav_sound, 1);
+        msgbox_active = 0;
+        progress_onscreen = 0;
+        lv_obj_add_flag(msgbox_element, LV_OBJ_FLAG_HIDDEN);
         return;
     }
 
-    event.data.fd = js_fd_sys;
-    if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, js_fd_sys, &event) == -1) {
-        perror("Error with EPOLL controller");
+    play_sound("back", nav_sound, 1);
+    input_disable = 1;
+    write_text_to_file(MUOS_PDI_LOAD, "w", CHAR, "system");
+    mux_input_stop();
+}
+
+void handle_menu() {
+    if (msgbox_active) {
         return;
     }
 
-    while (1) {
-        int num_events = epoll_wait(epoll_fd, events, device.DEVICE.EVENT, config.SETTINGS.ADVANCED.ACCELERATE);
-        if (num_events == -1) {
-            perror("Error with EPOLL wait event timer");
-            continue;
-        }
-
-        for (int i = 0; i < num_events; i++) {
-            if (events[i].data.fd == js_fd_sys) {
-                ssize_t ret = read(js_fd_sys, &ev, sizeof(struct input_event));
-                if (ret == -1) {
-                    perror("Error reading input");
-                    continue;
-                }
-                if (JOYHOTKEY_pressed == 1 && ev.type == EV_KEY && ev.value == 1 &&
-                    (ev.code == device.RAW_INPUT.BUTTON.POWER_SHORT || ev.code == device.RAW_INPUT.BUTTON.POWER_LONG)) {
-                    JOYHOTKEY_screenshot = 1;
-                }
-            } else if (events[i].data.fd == js_fd) {
-                ssize_t ret = read(js_fd, &ev, sizeof(struct input_event));
-                if (ret == -1) {
-                    perror("Error reading input");
-                    continue;
-                }
-
-                struct _lv_obj_t *element_focused = lv_group_get_focused(ui_group);
-                switch (ev.type) {
-                    case EV_KEY:
-                        if (ev.value == 1) {
-                            if (msgbox_active) {
-                                if (ev.code == NAV_B) {
-                                    play_sound("confirm", nav_sound, 1);
-                                    msgbox_active = 0;
-                                    progress_onscreen = 0;
-                                    lv_obj_add_flag(msgbox_element, LV_OBJ_FLAG_HIDDEN);
-                                }
-                            } else {
-                                if (ev.code == device.RAW_INPUT.BUTTON.MENU_LONG) {
-                                    JOYHOTKEY_pressed = 1;
-                                    JOYHOTKEY_screenshot = 0;
-                                } else if (ev.code == NAV_A || ev.code == device.RAW_INPUT.ANALOG.LEFT.CLICK) {
-                                    if (element_focused == ui_lblVersion) {
-                                        osd_message = "Thank you for using muOS!";
-                                        lv_label_set_text(ui_lblMessage, osd_message);
-                                        lv_obj_clear_flag(ui_pnlMessage, LV_OBJ_FLAG_HIDDEN);
-                                    }
-                                } else if (ev.code == NAV_B) {
-                                    play_sound("back", nav_sound, 1);
-                                    input_disable = 1;
-                                    write_text_to_file(MUOS_PDI_LOAD, "w", CHAR, "system");
-                                    return;
-                                }
-                            }
-                        } else {
-                            if ((ev.code == device.RAW_INPUT.BUTTON.MENU_SHORT ||
-                                 ev.code == device.RAW_INPUT.BUTTON.MENU_LONG) && !JOYHOTKEY_screenshot) {
-                                JOYHOTKEY_pressed = 0;
-                                if (progress_onscreen == -1) {
-                                    play_sound("confirm", nav_sound, 1);
-                                    show_help(element_focused);
-                                }
-                            }
-                        }
-                        break;
-                    case EV_ABS:
-                        if (msgbox_active) {
-                            break;
-                        }
-                        if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
-                                if (current_item_index == 0) {
-                                    current_item_index = UI_COUNT - 1;
-                                    nav_prev(ui_group, 1);
-                                    nav_prev(ui_group_value, 1);
-                                    nav_prev(ui_group_glyph, 1);
-                                    nav_prev(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
-                                                           current_item_index, ui_pnlContent);
-                                    nav_moved = 1;
-                                } else if (current_item_index > 0) {
-                                    list_nav_prev(1);
-                                }
-                                JOYUP_pressed = 1;
-                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
-                                nav_tick = mux_tick();
-                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
-                                if (current_item_index == UI_COUNT - 1) {
-                                    current_item_index = 0;
-                                    nav_next(ui_group, 1);
-                                    nav_next(ui_group_value, 1);
-                                    nav_next(ui_group_glyph, 1);
-                                    nav_next(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
-                                                           current_item_index, ui_pnlContent);
-                                    nav_moved = 1;
-                                } else if (current_item_index < UI_COUNT - 1) {
-                                    list_nav_next(1);
-                                }
-                                JOYDOWN_pressed = 1;
-                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
-                                nav_tick = mux_tick();
-                            } else {
-                                JOYUP_pressed = 0;
-                                JOYDOWN_pressed = 0;
-                            }
-                        }
-                        break;
-                    default:
-                        break;
-                }
-            }
-            refresh_screen();
-        }
-
-        // Handle menu acceleration.
-        if (mux_tick() - nav_tick >= nav_hold) {
-            if (JOYUP_pressed && current_item_index > 0) {
-                list_nav_prev(1);
-                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
-                nav_tick = mux_tick();
-            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
-                list_nav_next(1);
-                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
-                nav_tick = mux_tick();
-            }
-        }
-
-        if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {
-            if (ev.type == EV_KEY && ev.value == 1 &&
-                (ev.code == device.RAW_INPUT.BUTTON.VOLUME_DOWN || ev.code == device.RAW_INPUT.BUTTON.VOLUME_UP)) {
-                if (JOYHOTKEY_pressed) {
-                    progress_onscreen = 1;
-                    lv_obj_add_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
-                    lv_obj_clear_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
-                    lv_label_set_text(ui_icoProgressBrightness, "\uF185");
-                    lv_bar_set_value(ui_barProgressBrightness, atoi(read_text_from_file(BRIGHT_PERC)), LV_ANIM_OFF);
-                } else {
-                    progress_onscreen = 2;
-                    lv_obj_add_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
-                    lv_obj_clear_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
-                    int volume = atoi(read_text_from_file(VOLUME_PERC));
-                    switch (volume) {
-                        default:
-                        case 0:
-                            lv_label_set_text(ui_icoProgressVolume, "\uF6A9");
-                            break;
-                        case 1 ... 46:
-                            lv_label_set_text(ui_icoProgressVolume, "\uF026");
-                            break;
-                        case 47 ... 71:
-                            lv_label_set_text(ui_icoProgressVolume, "\uF027");
-                            break;
-                        case 72 ... 100:
-                            lv_label_set_text(ui_icoProgressVolume, "\uF028");
-                            break;
-                    }
-                    lv_bar_set_value(ui_barProgressVolume, volume, LV_ANIM_OFF);
-                }
-            }
-        }
-
-        if (file_exist("/tmp/hdmi_do_refresh")) {
-            if (atoi(read_text_from_file("/tmp/hdmi_do_refresh"))) {
-                remove("/tmp/hdmi_do_refresh");
-                lv_obj_invalidate(ui_pnlHeader);
-                lv_obj_invalidate(ui_pnlContent);
-                lv_obj_invalidate(ui_pnlFooter);
-            }
-        }
-
-        refresh_screen();
+    if (progress_onscreen == -1) {
+        play_sound("confirm", nav_sound, 1);
+        show_help(lv_group_get_focused(ui_group));
     }
+}
+
+void handle_up() {
+    if (msgbox_active) {
+        return;
+    }
+
+    if (current_item_index == 0) {
+        current_item_index = UI_COUNT - 1;
+        nav_prev(ui_group, 1);
+        nav_prev(ui_group_value, 1);
+        nav_prev(ui_group_glyph, 1);
+        nav_prev(ui_group_panel, 1);
+        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
+                               current_item_index, ui_pnlContent);
+        nav_moved = 1;
+    } else if (current_item_index > 0) {
+        list_nav_prev(1);
+    }
+}
+
+void handle_down() {
+    if (msgbox_active) {
+        return;
+    }
+
+    if (current_item_index == UI_COUNT - 1) {
+        current_item_index = 0;
+        nav_next(ui_group, 1);
+        nav_next(ui_group_value, 1);
+        nav_next(ui_group_glyph, 1);
+        nav_next(ui_group_panel, 1);
+        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
+                               current_item_index, ui_pnlContent);
+        nav_moved = 1;
+    } else if (current_item_index < UI_COUNT - 1) {
+        list_nav_next(1);
+    }
+}
+
+void handle_up_hold() {
+    if (msgbox_active) {
+        return;
+    }
+
+    if (current_item_index > 0) {
+        list_nav_prev(1);
+    }
+}
+
+void handle_down_hold() {
+    if (msgbox_active) {
+        return;
+    }
+
+    if (current_item_index < ui_count - 1) {
+        list_nav_next(1);
+    }
+}
+
+void handle_volume() {
+    if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {
+        if (mux_input_pressed(MUX_INPUT_MENU_LONG)) {
+            progress_onscreen = 1;
+            lv_obj_add_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_clear_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
+            lv_label_set_text(ui_icoProgressBrightness, "\uF185");
+            lv_bar_set_value(ui_barProgressBrightness, atoi(read_text_from_file(BRIGHT_PERC)), LV_ANIM_OFF);
+        } else {
+            progress_onscreen = 2;
+            lv_obj_add_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_clear_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
+            int volume = atoi(read_text_from_file(VOLUME_PERC));
+            switch (volume) {
+                default:
+                case 0:
+                    lv_label_set_text(ui_icoProgressVolume, "\uF6A9");
+                    break;
+                case 1 ... 46:
+                    lv_label_set_text(ui_icoProgressVolume, "\uF026");
+                    break;
+                case 47 ... 71:
+                    lv_label_set_text(ui_icoProgressVolume, "\uF027");
+                    break;
+                case 72 ... 100:
+                    lv_label_set_text(ui_icoProgressVolume, "\uF028");
+                    break;
+            }
+            lv_bar_set_value(ui_barProgressVolume, volume, LV_ANIM_OFF);
+        }
+    }
+}
+
+void handle_idle() {
+    if (file_exist("/tmp/hdmi_do_refresh")) {
+        if (atoi(read_text_from_file("/tmp/hdmi_do_refresh"))) {
+            remove("/tmp/hdmi_do_refresh");
+            lv_obj_invalidate(ui_pnlHeader);
+            lv_obj_invalidate(ui_pnlContent);
+            lv_obj_invalidate(ui_pnlFooter);
+        }
+    }
+
+    refresh_screen();
 }
 
 void init_elements() {
@@ -763,31 +693,6 @@ int main(int argc, char *argv[]) {
 
     lv_label_set_text(ui_lblDatetime, get_datetime());
 
-    switch (theme.MISC.NAVIGATION_TYPE) {
-        case 1:
-            NAV_DPAD_HOR = device.RAW_INPUT.DPAD.DOWN;
-            NAV_ANLG_HOR = device.RAW_INPUT.ANALOG.LEFT.DOWN;
-            NAV_DPAD_VER = device.RAW_INPUT.DPAD.RIGHT;
-            NAV_ANLG_VER = device.RAW_INPUT.ANALOG.LEFT.RIGHT;
-            break;
-        default:
-            NAV_DPAD_HOR = device.RAW_INPUT.DPAD.RIGHT;
-            NAV_ANLG_HOR = device.RAW_INPUT.ANALOG.LEFT.RIGHT;
-            NAV_DPAD_VER = device.RAW_INPUT.DPAD.DOWN;
-            NAV_ANLG_VER = device.RAW_INPUT.ANALOG.LEFT.DOWN;
-    }
-
-    switch (config.SETTINGS.ADVANCED.SWAP) {
-        case 1:
-            NAV_A = device.RAW_INPUT.BUTTON.B;
-            NAV_B = device.RAW_INPUT.BUTTON.A;
-            break;
-        default:
-            NAV_A = device.RAW_INPUT.BUTTON.A;
-            NAV_B = device.RAW_INPUT.BUTTON.B;
-            break;
-    }
-
     current_wall = load_wallpaper(ui_screen, NULL, theme.MISC.ANIMATED_BACKGROUND, theme.MISC.RANDOM_BACKGROUND);
     if (strlen(current_wall) > 3) {
         if (theme.MISC.RANDOM_BACKGROUND) {
@@ -879,7 +784,33 @@ int main(int argc, char *argv[]) {
     lv_timer_ready(ui_refresh_timer);
 
     refresh_screen();
-    joystick_task();
+
+    mux_input_options input_opts = {
+        .gamepad_fd = js_fd,
+        .system_fd = js_fd_sys,
+        .swap_nav = config.SETTINGS.ADVANCED.SWAP,
+        .swap_axis = (theme.MISC.NAVIGATION_TYPE == 1),
+        .press_handler = {
+            [MUX_INPUT_A] = handle_a,
+            [MUX_INPUT_L3] = handle_a,
+            [MUX_INPUT_B] = handle_b,
+            [MUX_INPUT_DPAD_UP] = handle_up,
+            [MUX_INPUT_LS_UP] = handle_up,
+            [MUX_INPUT_DPAD_DOWN] = handle_down,
+            [MUX_INPUT_LS_DOWN] = handle_down,
+            [MUX_INPUT_VOL_UP] = handle_volume,
+            [MUX_INPUT_VOL_DOWN] = handle_volume,
+            [MUX_INPUT_MENU_SHORT] = handle_menu,
+        },
+        .hold_handler = {
+            [MUX_INPUT_DPAD_UP] = handle_up_hold,
+            [MUX_INPUT_LS_UP] = handle_up_hold,
+            [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
+            [MUX_INPUT_LS_DOWN] = handle_down_hold,
+        },
+        .idle_handler = handle_idle,
+    };
+    mux_input_task(&input_opts);
 
     close(js_fd);
     close(js_fd_sys);


### PR DESCRIPTION
1. Sets analog stick detection threshold to 80% of the nominal max axis value. This should help with sticks (like the inconsistent Hall-effect ones) that can't quite reach the full axis value. Doesn't seem to introduce any sensitive issues on stock sticks.
2. Decouples gamepad event loop delay from menu acceleration delay. We can do this since we now track pending input hold times separately from the `epoll_wait` that controls the input loop. This fixes an interesting bug where the screen update rate is tied to acceleration rate. (The bug is easy to see in muxsysinfo. If you disable menu acceleration in settings, then the sysinfo stats don't update until you press a button.)
3. Ports a few more apps to the new input library so they can benefit from the above. :)