### PR TITLE
Implement input combos and a muhotkey program for scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MODULES := muxapp muxarchive muxassign muxcharge muxconfig muxcredits muxgov muxinfo \
            muxlanguage muxlaunch muxnetprofile muxnetscan muxnetwork muxoption muxpass \
            muxplore muxrtc muxsplash muxstart muxstorage muxsysinfo muxtask muxtester \
-           muxtheme muxtimezone muxtweakadv muxtweakgen muxvisual muxwebserv
+           muxtheme muxtimezone muxtweakadv muxtweakgen muxvisual muxwebserv muhotkey
 
 BUILD_TOTAL := $(words $(MODULES))
 BUILD_FILE := .build_count

--- a/common/common.h
+++ b/common/common.h
@@ -3,6 +3,8 @@
 #include "../lvgl/lvgl.h"
 #include "mini/mini.h"
 
+#define BIT(n) (UINT64_C(1) << (n))
+
 #define TS(str) translate_specific(str)
 #define TG(str) translate_generic(str)
 

--- a/common/input.c
+++ b/common/input.c
@@ -276,8 +276,14 @@ static void handle_combos(const mux_input_options *opts, uint32_t tick) {
             dispatch_combo(opts, active_combo, MUX_INPUT_RELEASE);
             active_combo = MUX_INPUT_COMBO_COUNT;
         }
-    } else if (pressed & ~held) {
+    }
+
+    if (active_combo == MUX_INPUT_COMBO_COUNT && (pressed & ~held)) {
         // No active combo, but a new input was pressed. Check if a combo should activate.
+        //
+        // Sometimes, a single evdev event can result in us registering both a release and a press
+        // (e.g., when transitioning from POWER_SHORT to POWER_LONG), so we have to check this even
+        // if a combo was previously active at the start of the function.
         for (int i = 0; i < MUX_INPUT_COMBO_COUNT; ++i) {
             uint64_t mask = opts->combo[i].type_mask;
 

--- a/common/input.h
+++ b/common/input.h
@@ -93,6 +93,10 @@ typedef struct {
     int gamepad_fd;
     int system_fd;
 
+    // If nonzero, the longest delay allowed without an input before the idle_handler is called.
+    // (The idle_handler may still be called more frequently at times.)
+    int max_idle_ms;
+
     // Whether to swap the A & B buttons.
     bool swap_btn;
 

--- a/common/ui_common.c
+++ b/common/ui_common.c
@@ -681,37 +681,43 @@ void ui_common_screen_init(struct theme_config *theme, struct mux_device *device
     lv_disp_load_scr(ui_screen);
 }
 
-void ui_common_handle_volume() {
-    if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) && !config.BOOT.FACTORY_RESET) {
-        if (mux_input_pressed(MUX_INPUT_MENU_LONG)) {
-            progress_onscreen = 1;
-            lv_obj_add_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
-            lv_obj_clear_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
-            lv_label_set_text(ui_icoProgressBrightness, "\uF185");
-            lv_bar_set_value(ui_barProgressBrightness, atoi(read_text_from_file(BRIGHT_PERC)), LV_ANIM_OFF);
-        } else {
-            progress_onscreen = 2;
-            lv_obj_add_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
-            lv_obj_clear_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
-            int volume = atoi(read_text_from_file(VOLUME_PERC));
-            switch (volume) {
-                default:
-                case 0:
-                    lv_label_set_text(ui_icoProgressVolume, "\uF6A9");
-                    break;
-                case 1 ... 46:
-                    lv_label_set_text(ui_icoProgressVolume, "\uF026");
-                    break;
-                case 47 ... 71:
-                    lv_label_set_text(ui_icoProgressVolume, "\uF027");
-                    break;
-                case 72 ... 100:
-                    lv_label_set_text(ui_icoProgressVolume, "\uF028");
-                    break;
-            }
-            lv_bar_set_value(ui_barProgressVolume, volume, LV_ANIM_OFF);
-        }
+void ui_common_handle_bright() {
+    if (atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.BOOT.FACTORY_RESET) {
+        return;
     }
+
+    progress_onscreen = 1;
+    lv_obj_add_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
+    lv_label_set_text(ui_icoProgressBrightness, "\uF185");
+    lv_bar_set_value(ui_barProgressBrightness, atoi(read_text_from_file(BRIGHT_PERC)), LV_ANIM_OFF);
+}
+
+void ui_common_handle_vol() {
+    if (atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.BOOT.FACTORY_RESET) {
+        return;
+    }
+
+    progress_onscreen = 2;
+    lv_obj_add_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
+    int volume = atoi(read_text_from_file(VOLUME_PERC));
+    switch (volume) {
+        default:
+        case 0:
+            lv_label_set_text(ui_icoProgressVolume, "\uF6A9");
+            break;
+        case 1 ... 46:
+            lv_label_set_text(ui_icoProgressVolume, "\uF026");
+            break;
+        case 47 ... 71:
+            lv_label_set_text(ui_icoProgressVolume, "\uF027");
+            break;
+        case 72 ... 100:
+            lv_label_set_text(ui_icoProgressVolume, "\uF028");
+            break;
+    }
+    lv_bar_set_value(ui_barProgressVolume, volume, LV_ANIM_OFF);
 }
 
 void ui_common_handle_idle() {

--- a/common/ui_common.h
+++ b/common/ui_common.h
@@ -2,7 +2,9 @@
 
 void ui_common_screen_init(struct theme_config *theme, struct mux_device *device, const char *title);
 
-void ui_common_handle_volume();
+void ui_common_handle_bright();
+
+void ui_common_handle_vol();
 
 void ui_common_handle_idle();
 

--- a/muhotkey/Makefile
+++ b/muhotkey/Makefile
@@ -1,0 +1,67 @@
+ifeq ($(DEVICE), RG35XX)
+	ARCH = -march=armv7-a \
+		-mtune=cortex-a9 \
+		-mfpu=neon-vfpv3 \
+		-mfloat-abi=softfp 
+else ifeq ($(DEVICE), RG35XXPLUS)
+	ARCH = -march=armv8-a+simd \
+		-mtune=cortex-a53
+else
+	$(error Unsupported Device: $(DEVICE))
+endif
+
+TARGET = ${shell basename $$(pwd)}
+
+CC = ccache $(CROSS_COMPILE)gcc -O3
+
+CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
+	-flto -finline-functions -Wall -Wno-format-zero-length \
+	-Wno-implicit-function-declaration
+
+LDFLAGS = $(CFLAGS) -Wl,--gc-sections -s
+
+EXTRA = $(LDFLAGS) -fno-exceptions -fno-stack-protector -fomit-frame-pointer \
+	-fno-unroll-loops -fmerge-all-constants -fno-ident \
+	-ffast-math -funroll-loops -falign-functions
+
+MAINSRC = ./main.c
+
+OBJEXT ?= .o
+
+AOBJS = $(ASRCS:.S=$(OBJEXT))
+COBJS = $(CSRCS:.c=$(OBJEXT))
+SOBJS = $(SSRCS:.c=$(OBJEXT))
+
+MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
+
+SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
+OBJS = $(AOBJS) $(COBJS) $(SOBJS)
+
+all: clean start compile move
+
+%.o: %.c
+	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
+
+clean:
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+
+start:
+	@date +%s > .start
+
+compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
+	@printf "Building: %s... " "$(TARGET)"
+	@START=$$(cat .start); \
+	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
+		../common/config.c \
+		../common/device.c \
+		../common/common.c \
+		../common/input.c \
+		$(EXTRA); \
+	END=$$(date +%s); \
+	ELAPSED_TIME=$$((END - START)); \
+	printf "DONE (%ds)\n" "$${ELAPSED_TIME}"
+
+move:
+	@mkdir -p ../bin
+	@mv $(TARGET) ../bin/
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start

--- a/muhotkey/main.c
+++ b/muhotkey/main.c
@@ -199,6 +199,7 @@ int main(int argc, char *argv[]) {
     mux_input_options input_opts = {
         .gamepad_fd = js_fd,
         .system_fd = js_fd_sys,
+        .max_idle_ms = 1000,
         .input_handler = handle_input,
         .combo_handler = handle_combo,
         .idle_handler = handle_idle,

--- a/muhotkey/main.c
+++ b/muhotkey/main.c
@@ -1,0 +1,241 @@
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "../common/common.h"
+#include "../common/config.h"
+#include "../common/device.h"
+#include "../common/input.h"
+
+struct mux_device device;
+struct mux_config config;
+
+static char *combo_name[MUX_INPUT_COMBO_COUNT] = {};
+
+static uint32_t last_input_tick;
+
+static bool idle_display = false;
+static bool idle_sleep = false;
+
+void idle_active() {
+    // Reset idle timer in response to activity.
+    if (idle_display || idle_sleep) {
+        printf("IDLE ACTIVE\n");
+    }
+
+    last_input_tick = mux_tick();
+    idle_display = false;
+    idle_sleep = false;
+}
+
+void handle_input(mux_input_type type, mux_input_action action) {
+    idle_active();
+}
+
+void handle_idle() {
+    // Allow the shell scripts to temporarily inhibit idle detection. (We could check those
+    // conditions here, but it's more flexible to leave that externally controllable.)
+    if (file_exist("/run/muos/system/idle_inhibit")) {
+        idle_active();
+        return;
+    }
+
+    // Detect idle display and/or sleep timeout.
+    uint32_t idle_ms = mux_tick() - last_input_tick;
+
+    uint32_t timeout_display_ms = config.SETTINGS.GENERAL.IDLE_DISPLAY * 1000;
+    if (timeout_display_ms && idle_ms >= timeout_display_ms && !idle_display) {
+        printf("IDLE DISPLAY\n");
+        idle_display = true;
+    }
+
+    uint32_t timeout_sleep_ms = config.SETTINGS.GENERAL.IDLE_SLEEP * 1000;
+    if (timeout_sleep_ms && idle_ms >= timeout_sleep_ms && !idle_sleep) {
+        printf("IDLE SLEEP\n");
+        idle_sleep = true;
+    }
+}
+
+void handle_combo(int num, mux_input_action action) {
+    const char *action_name;
+    switch (action) {
+        case MUX_INPUT_PRESS:
+            action_name = "PRESS";
+            break;
+        case MUX_INPUT_HOLD:
+            action_name = "HOLD";
+            break;
+        case MUX_INPUT_RELEASE:
+            action_name = "RELEASE";
+            break;
+    }
+    printf("%s %s\n", combo_name[num], action_name);
+}
+
+// Parse an input type specified by name on the command line.
+//
+// Returns MUX_INPUT_COUNT if the name is not valid.
+int parse_type(const char *type_name) {
+    const char *name[MUX_INPUT_COUNT] = {
+        // Gamepad buttons:
+        [MUX_INPUT_A] = "A",
+        [MUX_INPUT_B] = "B",
+        [MUX_INPUT_B] = "C",
+        [MUX_INPUT_X] = "X",
+        [MUX_INPUT_Y] = "Y",
+        [MUX_INPUT_Y] = "Z",
+        [MUX_INPUT_L1] = "L1",
+        [MUX_INPUT_L2] = "L2",
+        [MUX_INPUT_L3] = "L3",
+        [MUX_INPUT_R1] = "R1",
+        [MUX_INPUT_R2] = "R2",
+        [MUX_INPUT_R3] = "R3",
+        [MUX_INPUT_SELECT] = "SELECT",
+        [MUX_INPUT_START] = "START",
+
+        // D-pad:
+        [MUX_INPUT_DPAD_UP] = "DPAD_UP",
+        [MUX_INPUT_DPAD_DOWN] = "DPAD_DOWN",
+        [MUX_INPUT_DPAD_LEFT] = "DPAD_LEFT",
+        [MUX_INPUT_DPAD_RIGHT] = "DPAD_RIGHT",
+
+        // Left stick:
+        [MUX_INPUT_LS_UP] = "LS_UP",
+        [MUX_INPUT_LS_DOWN] = "LS_DOWN",
+        [MUX_INPUT_LS_LEFT] = "LS_LEFT",
+        [MUX_INPUT_LS_RIGHT] = "LS_RIGHT",
+
+        // Right stick:
+        [MUX_INPUT_RS_UP] = "RS_UP",
+        [MUX_INPUT_RS_DOWN] = "RS_DOWN",
+        [MUX_INPUT_RS_LEFT] = "RS_LEFT",
+        [MUX_INPUT_RS_RIGHT] = "RS_RIGHT",
+
+        // Volume buttons:
+        [MUX_INPUT_VOL_UP] = "VOL_UP",
+        [MUX_INPUT_VOL_DOWN] = "VOL_DOWN",
+
+        // Function buttons:
+        [MUX_INPUT_MENU_LONG] = "MENU_LONG",
+        [MUX_INPUT_MENU_SHORT] = "MENU_SHORT",
+
+        // System buttons:
+        [MUX_INPUT_POWER_LONG] = "POWER_LONG",
+        [MUX_INPUT_POWER_SHORT] = "POWER_SHORT",
+    };
+
+    int i;
+    for (i = 0; i < MUX_INPUT_COUNT; ++i) {
+        if (name[i] && strcmp(name[i], type_name) == 0) {
+            break;
+        }
+    }
+    return i;
+}
+
+// Parse command-line argument specifying a combo to listen for.
+//
+// Combo specs have the format `NAME=INPUT1+INPUT2+...`. For example, `OSF=POWER_SHORT+L1+L2+R1+R2`
+// is a valid combo that triggers when all five of those inputs are active.
+//
+// Combos are allowed to overlap, in which case the first combo that matches will trigger. For
+// example, consider combos `BRIGHT_UP=MENU_LONG+VOL_UP` and `VOL_UP=`VOL_UP`:
+//
+// * When Volume Up is pressed on its own, the VOL_UP combo will trigger.
+// * If Menu is held before Volume Up is pressed, then the BRIGHT_UP combo will trigger instead.
+void parse_combo(int combo_num, const char *combo_spec, mux_input_combo *combo) {
+    // Duplicate the argument so we can modify it without affecting the process command line.
+    char *s = strdup(combo_spec);
+    if (!s) {
+        fprintf(stderr, "muhotkey: couldn't allocate memory for combo\n");
+        exit(1);
+    }
+
+    // Parse NAME.
+    combo_name[combo_num] = strsep(&s, "=");
+    if (!s) {
+        fprintf(stderr, "muhotkey: combo must specify at least one input: %s\n", combo_spec);
+        exit(1);
+    }
+
+    do {
+        // Parse INPUT.
+        const char *type_name = strsep(&s, "+");
+
+        // Look up input type by name.
+        int type = parse_type(type_name);
+        if (type == MUX_INPUT_COUNT) {
+            fprintf(stderr, "muhotkey: combo specified invalid input name %s: %s\n", type_name,
+                    combo_spec);
+            exit(1);
+        }
+
+        // Update combo config accordingly.
+        combo->type_mask |= BIT(type);
+    } while (s);
+}
+
+int main(int argc, char *argv[]) {
+    load_device(&device);
+    load_config(&config);
+
+    int js_fd = open(device.INPUT.EV1, O_RDONLY);
+    if (js_fd < 0) {
+        perror("muhotkey: couldn't open joystick input device\n");
+        return 1;
+    }
+
+    int js_fd_sys = open(device.INPUT.EV0, O_RDONLY);
+    if (js_fd_sys < 0) {
+        perror("muhotkey: couldn't open system input device");
+        return 1;
+    }
+
+    mux_input_options input_opts = {
+        .gamepad_fd = js_fd,
+        .system_fd = js_fd_sys,
+        .input_handler = handle_input,
+        .combo_handler = handle_combo,
+        .idle_handler = handle_idle,
+    };
+
+    for (int i = 0; i < argc - 1; ++i) {
+        if (i >= MUX_INPUT_COMBO_COUNT) {
+            fprintf(stderr, "muhotkey: at most %d combos supported\n", MUX_INPUT_COMBO_COUNT);
+            return 1;
+        }
+
+        parse_combo(i, argv[i + 1], &input_opts.combo[i]);
+    }
+
+    setlinebuf(stdout);
+
+    last_input_tick = mux_tick();
+    mux_input_task(&input_opts);
+
+    for (int i = 0; i < MUX_INPUT_COMBO_COUNT; ++i) {
+        free(combo_name[i]);
+    }
+
+    close(js_fd);
+    close(js_fd_sys);
+
+    return 0;
+}
+
+uint32_t mux_tick(void) {
+    static uint64_t start_ms = 0;
+
+    struct timespec tv_now;
+    clock_gettime(CLOCK_REALTIME, &tv_now);
+
+    uint64_t now_ms = ((uint64_t) tv_now.tv_sec * 1000) + (tv_now.tv_nsec / 1000000);
+    start_ms = start_ms || now_ms;
+
+    return (uint32_t) (now_ms - start_ms);
+}

--- a/muhotkey/main.c
+++ b/muhotkey/main.c
@@ -12,10 +12,78 @@
 #include "../common/device.h"
 #include "../common/input.h"
 
+void handle_combo(int num, mux_input_action action);
+void handle_input(mux_input_type type, mux_input_action action);
+void handle_idle();
+
 struct mux_device device;
 struct mux_config config;
 
+static const char *input_name[MUX_INPUT_COUNT] = {
+    // Gamepad buttons:
+    [MUX_INPUT_A] = "A",
+    [MUX_INPUT_B] = "B",
+    [MUX_INPUT_C] = "C",
+    [MUX_INPUT_X] = "X",
+    [MUX_INPUT_Y] = "Y",
+    [MUX_INPUT_Z] = "Z",
+    [MUX_INPUT_L1] = "L1",
+    [MUX_INPUT_L2] = "L2",
+    [MUX_INPUT_L3] = "L3",
+    [MUX_INPUT_R1] = "R1",
+    [MUX_INPUT_R2] = "R2",
+    [MUX_INPUT_R3] = "R3",
+    [MUX_INPUT_SELECT] = "SELECT",
+    [MUX_INPUT_START] = "START",
+
+    // D-pad:
+    [MUX_INPUT_DPAD_UP] = "DPAD_UP",
+    [MUX_INPUT_DPAD_DOWN] = "DPAD_DOWN",
+    [MUX_INPUT_DPAD_LEFT] = "DPAD_LEFT",
+    [MUX_INPUT_DPAD_RIGHT] = "DPAD_RIGHT",
+
+    // Left stick:
+    [MUX_INPUT_LS_UP] = "LS_UP",
+    [MUX_INPUT_LS_DOWN] = "LS_DOWN",
+    [MUX_INPUT_LS_LEFT] = "LS_LEFT",
+    [MUX_INPUT_LS_RIGHT] = "LS_RIGHT",
+
+    // Right stick:
+    [MUX_INPUT_RS_UP] = "RS_UP",
+    [MUX_INPUT_RS_DOWN] = "RS_DOWN",
+    [MUX_INPUT_RS_LEFT] = "RS_LEFT",
+    [MUX_INPUT_RS_RIGHT] = "RS_RIGHT",
+
+    // Volume buttons:
+    [MUX_INPUT_VOL_UP] = "VOL_UP",
+    [MUX_INPUT_VOL_DOWN] = "VOL_DOWN",
+
+    // Function buttons:
+    [MUX_INPUT_MENU_LONG] = "MENU_LONG",
+    [MUX_INPUT_MENU_SHORT] = "MENU_SHORT",
+
+    // System buttons:
+    [MUX_INPUT_POWER_LONG] = "POWER_LONG",
+    [MUX_INPUT_POWER_SHORT] = "POWER_SHORT",
+};
+
+static const char *action_name[] = {
+    [MUX_INPUT_PRESS] = "PRESS",
+    [MUX_INPUT_HOLD] = "HOLD",
+    [MUX_INPUT_RELEASE] = "RELEASE",
+};
+
+static mux_input_options input_opts = {
+    .max_idle_ms = 1000,
+    .input_handler = handle_input,
+    .combo_handler = handle_combo,
+    .idle_handler = handle_idle,
+};
+
+static bool verbose = false;
+
 static char *combo_name[MUX_INPUT_COMBO_COUNT] = {};
+static bool combo_holdable[MUX_INPUT_COMBO_COUNT] = {};
 
 static uint32_t last_input_tick;
 
@@ -25,7 +93,7 @@ static bool idle_sleep = false;
 void idle_active() {
     // Reset idle timer in response to activity.
     if (idle_display || idle_sleep) {
-        printf("IDLE ACTIVE\n");
+        printf("IDLE_ACTIVE\n");
     }
 
     last_input_tick = mux_tick();
@@ -34,6 +102,9 @@ void idle_active() {
 }
 
 void handle_input(mux_input_type type, mux_input_action action) {
+    if (verbose) {
+        printf("[%s %s]\n", input_name[type], action_name[action]);
+    }
     idle_active();
 }
 
@@ -50,88 +121,51 @@ void handle_idle() {
 
     uint32_t timeout_display_ms = config.SETTINGS.GENERAL.IDLE_DISPLAY * 1000;
     if (timeout_display_ms && idle_ms >= timeout_display_ms && !idle_display) {
-        printf("IDLE DISPLAY\n");
+        printf("IDLE_DISPLAY\n");
         idle_display = true;
     }
 
     uint32_t timeout_sleep_ms = config.SETTINGS.GENERAL.IDLE_SLEEP * 1000;
     if (timeout_sleep_ms && idle_ms >= timeout_sleep_ms && !idle_sleep) {
-        printf("IDLE SLEEP\n");
+        printf("IDLE_SLEEP\n");
         idle_sleep = true;
     }
 }
 
 void handle_combo(int num, mux_input_action action) {
-    const char *action_name;
-    switch (action) {
-        case MUX_INPUT_PRESS:
-            action_name = "PRESS";
-            break;
-        case MUX_INPUT_HOLD:
-            action_name = "HOLD";
-            break;
-        case MUX_INPUT_RELEASE:
-            action_name = "RELEASE";
-            break;
+    if (input_opts.combo[num].type_mask == BIT(MUX_INPUT_POWER_SHORT)) {
+        // The power button behaves differently from every other button (including the menu button).
+        // We receive these events on a short press:
+        //
+        // 1. POWER_SHORT PRESS
+        // 2. POWER_SHORT RELEASE
+        //
+        // And these on a long press:
+        //
+        // 1. POWER_SHORT PRESS
+        // 2. POWER_SHORT RELEASE + POWER_LONG PRESS (simultaneous)
+        // 3. POWER_LONG RELEASE
+        //
+        // To support separate hotkeys for these two cases, we delay triggering of a POWER_SHORT
+        // combo till release (2) so we can tell if the short press turned into a long press or not.
+        if (action == MUX_INPUT_RELEASE && !mux_input_pressed(MUX_INPUT_POWER_LONG)) {
+            printf("%s\n", combo_name[num]);
+        }
+        return;
     }
-    printf("%s %s\n", combo_name[num], action_name);
+
+    if (action == MUX_INPUT_PRESS || (action == MUX_INPUT_HOLD && combo_holdable[num])) {
+        printf("%s\n", combo_name[num]);
+    }
 }
 
 // Parse an input type specified by name on the command line.
 //
 // Returns MUX_INPUT_COUNT if the name is not valid.
-int parse_type(const char *type_name) {
-    const char *name[MUX_INPUT_COUNT] = {
-        // Gamepad buttons:
-        [MUX_INPUT_A] = "A",
-        [MUX_INPUT_B] = "B",
-        [MUX_INPUT_B] = "C",
-        [MUX_INPUT_X] = "X",
-        [MUX_INPUT_Y] = "Y",
-        [MUX_INPUT_Y] = "Z",
-        [MUX_INPUT_L1] = "L1",
-        [MUX_INPUT_L2] = "L2",
-        [MUX_INPUT_L3] = "L3",
-        [MUX_INPUT_R1] = "R1",
-        [MUX_INPUT_R2] = "R2",
-        [MUX_INPUT_R3] = "R3",
-        [MUX_INPUT_SELECT] = "SELECT",
-        [MUX_INPUT_START] = "START",
-
-        // D-pad:
-        [MUX_INPUT_DPAD_UP] = "DPAD_UP",
-        [MUX_INPUT_DPAD_DOWN] = "DPAD_DOWN",
-        [MUX_INPUT_DPAD_LEFT] = "DPAD_LEFT",
-        [MUX_INPUT_DPAD_RIGHT] = "DPAD_RIGHT",
-
-        // Left stick:
-        [MUX_INPUT_LS_UP] = "LS_UP",
-        [MUX_INPUT_LS_DOWN] = "LS_DOWN",
-        [MUX_INPUT_LS_LEFT] = "LS_LEFT",
-        [MUX_INPUT_LS_RIGHT] = "LS_RIGHT",
-
-        // Right stick:
-        [MUX_INPUT_RS_UP] = "RS_UP",
-        [MUX_INPUT_RS_DOWN] = "RS_DOWN",
-        [MUX_INPUT_RS_LEFT] = "RS_LEFT",
-        [MUX_INPUT_RS_RIGHT] = "RS_RIGHT",
-
-        // Volume buttons:
-        [MUX_INPUT_VOL_UP] = "VOL_UP",
-        [MUX_INPUT_VOL_DOWN] = "VOL_DOWN",
-
-        // Function buttons:
-        [MUX_INPUT_MENU_LONG] = "MENU_LONG",
-        [MUX_INPUT_MENU_SHORT] = "MENU_SHORT",
-
-        // System buttons:
-        [MUX_INPUT_POWER_LONG] = "POWER_LONG",
-        [MUX_INPUT_POWER_SHORT] = "POWER_SHORT",
-    };
-
+int parse_type(const char *name) {
     int i;
     for (i = 0; i < MUX_INPUT_COUNT; ++i) {
-        if (name[i] && strcmp(name[i], type_name) == 0) {
+        if (input_name[i] && strcmp(input_name[i], name) == 0) {
             break;
         }
     }
@@ -148,7 +182,7 @@ int parse_type(const char *type_name) {
 //
 // * When Volume Up is pressed on its own, the VOL_UP combo will trigger.
 // * If Menu is held before Volume Up is pressed, then the BRIGHT_UP combo will trigger instead.
-void parse_combo(int combo_num, const char *combo_spec, mux_input_combo *combo) {
+void parse_combo(int combo_num, const char *combo_spec) {
     // Duplicate the argument so we can modify it without affecting the process command line.
     char *s = strdup(combo_spec);
     if (!s) {
@@ -165,53 +199,90 @@ void parse_combo(int combo_num, const char *combo_spec, mux_input_combo *combo) 
 
     do {
         // Parse INPUT.
-        const char *type_name = strsep(&s, "+");
+        const char *input_name = strsep(&s, "+");
 
         // Look up input type by name.
-        int type = parse_type(type_name);
+        int type = parse_type(input_name);
         if (type == MUX_INPUT_COUNT) {
-            fprintf(stderr, "muhotkey: combo specified invalid input name %s: %s\n", type_name,
+            fprintf(stderr, "muhotkey: combo specified invalid input name %s: %s\n", input_name,
                     combo_spec);
             exit(1);
         }
 
         // Update combo config accordingly.
-        combo->type_mask |= BIT(type);
+        input_opts.combo[combo_num].type_mask |= BIT(type);
     } while (s);
+}
+
+void usage(FILE *file) {
+    fprintf(file,
+            "Usage: muhotkey [-v] [-C|-H COMBO_SPEC]...\n"
+            "Usage: muhotkey -l\n"
+            "\n"
+            "Monitor input for a list of hotkey combos.\n"
+            "\n"
+            "  -C COMBO_SPEC combo that will receive events on press\n"
+            "  -H COMBO_SPEC combo that will receive events on press and hold\n"
+            "  -v            prints every input received (verbose mode)\n"
+            "  -l            lists valid input names for COMBO_SPEC\n"
+            "  -h            displays this usage message\n"
+            "\n"
+            "COMBO_SPEC has format `NAME=INPUT1+INPUT2+...`. Use -l to see valid INPUT values.\n"
+            );
 }
 
 int main(int argc, char *argv[]) {
     load_device(&device);
     load_config(&config);
 
-    int js_fd = open(device.INPUT.EV1, O_RDONLY);
-    if (js_fd < 0) {
+    input_opts.gamepad_fd = open(device.INPUT.EV1, O_RDONLY);
+    if (input_opts.gamepad_fd < 0) {
         perror("muhotkey: couldn't open joystick input device\n");
         return 1;
     }
 
-    int js_fd_sys = open(device.INPUT.EV0, O_RDONLY);
-    if (js_fd_sys < 0) {
+    input_opts.system_fd = open(device.INPUT.EV0, O_RDONLY);
+    if (input_opts.system_fd < 0) {
         perror("muhotkey: couldn't open system input device");
         return 1;
     }
 
-    mux_input_options input_opts = {
-        .gamepad_fd = js_fd,
-        .system_fd = js_fd_sys,
-        .max_idle_ms = 1000,
-        .input_handler = handle_input,
-        .combo_handler = handle_combo,
-        .idle_handler = handle_idle,
-    };
+    int opt, next_combo = 0;
+    while ((opt = getopt(argc, argv, "C:H:vlh")) != -1) {
+        switch (opt) {
+            case 'C':
+            case 'H':
+                if (next_combo >= MUX_INPUT_COMBO_COUNT) {
+                    fprintf(stderr, "muhotkey: at most %d combos supported\n",
+                            MUX_INPUT_COMBO_COUNT);
+                    return 1;
+                }
 
-    for (int i = 0; i < argc - 1; ++i) {
-        if (i >= MUX_INPUT_COMBO_COUNT) {
-            fprintf(stderr, "muhotkey: at most %d combos supported\n", MUX_INPUT_COMBO_COUNT);
-            return 1;
+                parse_combo(next_combo, optarg);
+                combo_holdable[next_combo] = (opt == 'H');
+                ++next_combo;
+                break;
+            case 'v':
+                verbose = true;
+                break;
+            case 'l':
+                for (int i = 0; i < MUX_INPUT_COUNT; ++i) {
+                    if (input_name[i]) {
+                        printf("%s\n", input_name[i]);
+                    }
+                }
+                return 0;
+            case 'h':
+                usage(stdout);
+                return 0;
+            default:
+                usage(stderr);
+                return 1;
         }
-
-        parse_combo(i, argv[i + 1], &input_opts.combo[i]);
+    }
+    if (optind < argc) {
+        usage(stderr);
+        return 1;
     }
 
     setlinebuf(stdout);
@@ -223,8 +294,8 @@ int main(int argc, char *argv[]) {
         free(combo_name[i]);
     }
 
-    close(js_fd);
-    close(js_fd_sys);
+    close(input_opts.gamepad_fd);
+    close(input_opts.system_fd);
 
     return 0;
 }

--- a/muxapp/main.c
+++ b/muxapp/main.c
@@ -670,6 +670,7 @@ int main(int argc, char *argv[]) {
     mux_input_options input_opts = {
         .gamepad_fd = js_fd,
         .system_fd = js_fd_sys,
+        .max_idle_ms = 16 /* ~60 FPS */,
         .swap_btn = config.SETTINGS.ADVANCED.SWAP,
         .swap_axis = (theme.MISC.NAVIGATION_TYPE == 1),
         .stick_nav = true,

--- a/muxapp/main.c
+++ b/muxapp/main.c
@@ -680,8 +680,6 @@ int main(int argc, char *argv[]) {
             [MUX_INPUT_R1] = handle_r1,
             [MUX_INPUT_DPAD_UP] = handle_up,
             [MUX_INPUT_DPAD_DOWN] = handle_down,
-            [MUX_INPUT_VOL_UP] = ui_common_handle_volume,
-            [MUX_INPUT_VOL_DOWN] = ui_common_handle_volume,
             [MUX_INPUT_MENU_SHORT] = handle_menu,
         },
         .hold_handler = {
@@ -689,6 +687,24 @@ int main(int argc, char *argv[]) {
             [MUX_INPUT_R1] = handle_r1,
             [MUX_INPUT_DPAD_UP] = handle_up_hold,
             [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
+        },
+        .combo = {
+            {
+                .type_mask = BIT(MUX_INPUT_MENU_LONG) | BIT(MUX_INPUT_VOL_UP),
+                .press_handler = ui_common_handle_bright,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_MENU_LONG) | BIT(MUX_INPUT_VOL_DOWN),
+                .press_handler = ui_common_handle_bright,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_VOL_UP),
+                .press_handler = ui_common_handle_vol,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_VOL_DOWN),
+                .press_handler = ui_common_handle_vol,
+            },
         },
         .idle_handler = ui_common_handle_idle,
     };

--- a/muxarchive/main.c
+++ b/muxarchive/main.c
@@ -660,6 +660,7 @@ int main(int argc, char *argv[]) {
     mux_input_options input_opts = {
         .gamepad_fd = js_fd,
         .system_fd = js_fd_sys,
+        .max_idle_ms = 16 /* ~60 FPS */,
         .swap_btn = config.SETTINGS.ADVANCED.SWAP,
         .swap_axis = (theme.MISC.NAVIGATION_TYPE == 1),
         .stick_nav = true,

--- a/muxarchive/main.c
+++ b/muxarchive/main.c
@@ -670,8 +670,6 @@ int main(int argc, char *argv[]) {
             [MUX_INPUT_R1] = handle_r1,
             [MUX_INPUT_DPAD_UP] = handle_up,
             [MUX_INPUT_DPAD_DOWN] = handle_down,
-            [MUX_INPUT_VOL_UP] = ui_common_handle_volume,
-            [MUX_INPUT_VOL_DOWN] = ui_common_handle_volume,
             [MUX_INPUT_MENU_SHORT] = handle_menu,
         },
         .hold_handler = {
@@ -679,6 +677,24 @@ int main(int argc, char *argv[]) {
             [MUX_INPUT_R1] = handle_r1,
             [MUX_INPUT_DPAD_UP] = handle_up_hold,
             [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
+        },
+        .combo = {
+            {
+                .type_mask = BIT(MUX_INPUT_MENU_LONG) | BIT(MUX_INPUT_VOL_UP),
+                .press_handler = ui_common_handle_bright,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_MENU_LONG) | BIT(MUX_INPUT_VOL_DOWN),
+                .press_handler = ui_common_handle_bright,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_VOL_UP),
+                .press_handler = ui_common_handle_vol,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_VOL_DOWN),
+                .press_handler = ui_common_handle_vol,
+            },
         },
         .idle_handler = ui_common_handle_idle,
     };

--- a/muxconfig/main.c
+++ b/muxconfig/main.c
@@ -615,13 +615,29 @@ int main(int argc, char *argv[]) {
             [MUX_INPUT_B] = handle_b,
             [MUX_INPUT_DPAD_UP] = handle_up,
             [MUX_INPUT_DPAD_DOWN] = handle_down,
-            [MUX_INPUT_VOL_UP] = ui_common_handle_volume,
-            [MUX_INPUT_VOL_DOWN] = ui_common_handle_volume,
             [MUX_INPUT_MENU_SHORT] = handle_menu,
         },
         .hold_handler = {
             [MUX_INPUT_DPAD_UP] = handle_up_hold,
             [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
+        },
+        .combo = {
+            {
+                .type_mask = BIT(MUX_INPUT_MENU_LONG) | BIT(MUX_INPUT_VOL_UP),
+                .press_handler = ui_common_handle_bright,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_MENU_LONG) | BIT(MUX_INPUT_VOL_DOWN),
+                .press_handler = ui_common_handle_bright,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_VOL_UP),
+                .press_handler = ui_common_handle_vol,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_VOL_DOWN),
+                .press_handler = ui_common_handle_vol,
+            },
         },
         .idle_handler = ui_common_handle_idle,
     };

--- a/muxconfig/main.c
+++ b/muxconfig/main.c
@@ -607,6 +607,7 @@ int main(int argc, char *argv[]) {
     mux_input_options input_opts = {
         .gamepad_fd = js_fd,
         .system_fd = js_fd_sys,
+        .max_idle_ms = 16 /* ~60 FPS */,
         .swap_btn = config.SETTINGS.ADVANCED.SWAP,
         .swap_axis = (theme.MISC.NAVIGATION_TYPE == 1),
         .stick_nav = true,

--- a/muxinfo/main.c
+++ b/muxinfo/main.c
@@ -571,6 +571,7 @@ int main(int argc, char *argv[]) {
     mux_input_options input_opts = {
         .gamepad_fd = js_fd,
         .system_fd = js_fd_sys,
+        .max_idle_ms = 16 /* ~60 FPS */,
         .swap_btn = config.SETTINGS.ADVANCED.SWAP,
         .swap_axis = (theme.MISC.NAVIGATION_TYPE == 1),
         .stick_nav = true,

--- a/muxinfo/main.c
+++ b/muxinfo/main.c
@@ -579,13 +579,29 @@ int main(int argc, char *argv[]) {
             [MUX_INPUT_B] = handle_b,
             [MUX_INPUT_DPAD_UP] = handle_up,
             [MUX_INPUT_DPAD_DOWN] = handle_down,
-            [MUX_INPUT_VOL_UP] = ui_common_handle_volume,
-            [MUX_INPUT_VOL_DOWN] = ui_common_handle_volume,
             [MUX_INPUT_MENU_SHORT] = handle_menu,
         },
         .hold_handler = {
             [MUX_INPUT_DPAD_UP] = handle_up_hold,
             [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
+        },
+        .combo = {
+            {
+                .type_mask = BIT(MUX_INPUT_MENU_LONG) | BIT(MUX_INPUT_VOL_UP),
+                .press_handler = ui_common_handle_bright,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_MENU_LONG) | BIT(MUX_INPUT_VOL_DOWN),
+                .press_handler = ui_common_handle_bright,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_VOL_UP),
+                .press_handler = ui_common_handle_vol,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_VOL_DOWN),
+                .press_handler = ui_common_handle_vol,
+            },
         },
         .idle_handler = ui_common_handle_idle,
     };

--- a/muxlaunch/main.c
+++ b/muxlaunch/main.c
@@ -663,6 +663,7 @@ int main(int argc, char *argv[]) {
     mux_input_options input_opts = {
         .gamepad_fd = js_fd,
         .system_fd = js_fd_sys,
+        .max_idle_ms = 16 /* ~60 FPS */,
         .swap_btn = config.SETTINGS.ADVANCED.SWAP,
         .swap_axis = (theme.MISC.NAVIGATION_TYPE >= 1 && theme.MISC.NAVIGATION_TYPE <= 5),
         .stick_nav = true,

--- a/muxlaunch/main.c
+++ b/muxlaunch/main.c
@@ -673,9 +673,25 @@ int main(int argc, char *argv[]) {
             [MUX_INPUT_DPAD_DOWN] = handle_down,
             [MUX_INPUT_DPAD_LEFT] = handle_left,
             [MUX_INPUT_DPAD_RIGHT] = handle_right,
-            [MUX_INPUT_VOL_UP] = ui_common_handle_volume,
-            [MUX_INPUT_VOL_DOWN] = ui_common_handle_volume,
             [MUX_INPUT_MENU_SHORT] = handle_menu,
+        },
+        .combo = {
+            {
+                .type_mask = BIT(MUX_INPUT_MENU_LONG) | BIT(MUX_INPUT_VOL_UP),
+                .press_handler = ui_common_handle_bright,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_MENU_LONG) | BIT(MUX_INPUT_VOL_DOWN),
+                .press_handler = ui_common_handle_bright,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_VOL_UP),
+                .press_handler = ui_common_handle_vol,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_VOL_DOWN),
+                .press_handler = ui_common_handle_vol,
+            },
         },
         .idle_handler = ui_common_handle_idle,
     };

--- a/muxplore/main.c
+++ b/muxplore/main.c
@@ -2235,6 +2235,7 @@ int main(int argc, char *argv[]) {
     mux_input_options input_opts = {
         .gamepad_fd = js_fd,
         .system_fd = js_fd_sys,
+        .max_idle_ms = 16 /* ~60 FPS */,
         .swap_btn = config.SETTINGS.ADVANCED.SWAP,
         .swap_axis = (theme.MISC.NAVIGATION_TYPE == 1),
         .stick_nav = true,

--- a/muxplore/main.c
+++ b/muxplore/main.c
@@ -2249,8 +2249,6 @@ int main(int argc, char *argv[]) {
             [MUX_INPUT_START] = handle_start,
             [MUX_INPUT_DPAD_UP] = handle_up,
             [MUX_INPUT_DPAD_DOWN] = handle_down,
-            [MUX_INPUT_VOL_UP] = ui_common_handle_volume,
-            [MUX_INPUT_VOL_DOWN] = ui_common_handle_volume,
             [MUX_INPUT_MENU_SHORT] = handle_menu,
         },
         .hold_handler = {
@@ -2258,6 +2256,24 @@ int main(int argc, char *argv[]) {
             [MUX_INPUT_R1] = handle_r1,
             [MUX_INPUT_DPAD_UP] = handle_up_hold,
             [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
+        },
+        .combo = {
+            {
+                .type_mask = BIT(MUX_INPUT_MENU_LONG) | BIT(MUX_INPUT_VOL_UP),
+                .press_handler = ui_common_handle_bright,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_MENU_LONG) | BIT(MUX_INPUT_VOL_DOWN),
+                .press_handler = ui_common_handle_bright,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_VOL_UP),
+                .press_handler = ui_common_handle_vol,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_VOL_DOWN),
+                .press_handler = ui_common_handle_vol,
+            },
         },
         .idle_handler = ui_common_handle_idle,
     };

--- a/muxrtc/main.c
+++ b/muxrtc/main.c
@@ -962,6 +962,7 @@ int main(int argc, char *argv[]) {
     mux_input_options input_opts = {
         .gamepad_fd = js_fd,
         .system_fd = js_fd_sys,
+        .max_idle_ms = 16 /* ~60 FPS */,
         .swap_btn = config.SETTINGS.ADVANCED.SWAP,
         .swap_axis = (theme.MISC.NAVIGATION_TYPE == 1),
         .stick_nav = true,

--- a/muxrtc/main.c
+++ b/muxrtc/main.c
@@ -972,8 +972,6 @@ int main(int argc, char *argv[]) {
             [MUX_INPUT_DPAD_DOWN] = handle_down,
             [MUX_INPUT_DPAD_LEFT] = handle_left,
             [MUX_INPUT_DPAD_RIGHT] = handle_right,
-            [MUX_INPUT_VOL_UP] = ui_common_handle_volume,
-            [MUX_INPUT_VOL_DOWN] = ui_common_handle_volume,
             [MUX_INPUT_MENU_SHORT] = handle_menu,
         },
         .hold_handler = {
@@ -981,6 +979,24 @@ int main(int argc, char *argv[]) {
             [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
             [MUX_INPUT_DPAD_LEFT] = handle_left,
             [MUX_INPUT_DPAD_RIGHT] = handle_right,
+        },
+        .combo = {
+            {
+                .type_mask = BIT(MUX_INPUT_MENU_LONG) | BIT(MUX_INPUT_VOL_UP),
+                .press_handler = ui_common_handle_bright,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_MENU_LONG) | BIT(MUX_INPUT_VOL_DOWN),
+                .press_handler = ui_common_handle_bright,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_VOL_UP),
+                .press_handler = ui_common_handle_vol,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_VOL_DOWN),
+                .press_handler = ui_common_handle_vol,
+            },
         },
         .idle_handler = ui_common_handle_idle,
     };

--- a/muxsysinfo/main.c
+++ b/muxsysinfo/main.c
@@ -750,13 +750,29 @@ int main(int argc, char *argv[]) {
             [MUX_INPUT_B] = handle_b,
             [MUX_INPUT_DPAD_UP] = handle_up,
             [MUX_INPUT_DPAD_DOWN] = handle_down,
-            [MUX_INPUT_VOL_UP] = ui_common_handle_volume,
-            [MUX_INPUT_VOL_DOWN] = ui_common_handle_volume,
             [MUX_INPUT_MENU_SHORT] = handle_menu,
         },
         .hold_handler = {
             [MUX_INPUT_DPAD_UP] = handle_up_hold,
             [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
+        },
+        .combo = {
+            {
+                .type_mask = BIT(MUX_INPUT_MENU_LONG) | BIT(MUX_INPUT_VOL_UP),
+                .press_handler = ui_common_handle_bright,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_MENU_LONG) | BIT(MUX_INPUT_VOL_DOWN),
+                .press_handler = ui_common_handle_bright,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_VOL_UP),
+                .press_handler = ui_common_handle_vol,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_VOL_DOWN),
+                .press_handler = ui_common_handle_vol,
+            },
         },
         .idle_handler = ui_common_handle_idle,
     };

--- a/muxsysinfo/main.c
+++ b/muxsysinfo/main.c
@@ -742,6 +742,7 @@ int main(int argc, char *argv[]) {
     mux_input_options input_opts = {
         .gamepad_fd = js_fd,
         .system_fd = js_fd_sys,
+        .max_idle_ms = 16 /* ~60 FPS */,
         .swap_btn = config.SETTINGS.ADVANCED.SWAP,
         .swap_axis = (theme.MISC.NAVIGATION_TYPE == 1),
         .stick_nav = true,

--- a/muxtester/main.c
+++ b/muxtester/main.c
@@ -263,6 +263,7 @@ int main(int argc, char *argv[]) {
     mux_input_options input_opts = {
         .gamepad_fd = js_fd,
         .system_fd = js_fd_sys,
+        .max_idle_ms = 16 /* ~60 FPS */,
         .press_handler = {
             [MUX_INPUT_POWER_SHORT] = handle_power,
         },

--- a/muxtimezone/main.c
+++ b/muxtimezone/main.c
@@ -528,6 +528,7 @@ int main(int argc, char *argv[]) {
     mux_input_options input_opts = {
         .gamepad_fd = js_fd,
         .system_fd = js_fd_sys,
+        .max_idle_ms = 16 /* ~60 FPS */,
         .swap_btn = config.SETTINGS.ADVANCED.SWAP,
         .swap_axis = (theme.MISC.NAVIGATION_TYPE == 1),
         .stick_nav = true,

--- a/muxtimezone/main.c
+++ b/muxtimezone/main.c
@@ -538,8 +538,6 @@ int main(int argc, char *argv[]) {
             [MUX_INPUT_R1] = handle_r1,
             [MUX_INPUT_DPAD_UP] = handle_up,
             [MUX_INPUT_DPAD_DOWN] = handle_down,
-            [MUX_INPUT_VOL_UP] = ui_common_handle_volume,
-            [MUX_INPUT_VOL_DOWN] = ui_common_handle_volume,
             [MUX_INPUT_MENU_SHORT] = handle_menu,
         },
         .hold_handler = {
@@ -547,6 +545,24 @@ int main(int argc, char *argv[]) {
             [MUX_INPUT_R1] = handle_r1,
             [MUX_INPUT_DPAD_UP] = handle_up_hold,
             [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
+        },
+        .combo = {
+            {
+                .type_mask = BIT(MUX_INPUT_MENU_LONG) | BIT(MUX_INPUT_VOL_UP),
+                .press_handler = ui_common_handle_bright,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_MENU_LONG) | BIT(MUX_INPUT_VOL_DOWN),
+                .press_handler = ui_common_handle_bright,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_VOL_UP),
+                .press_handler = ui_common_handle_vol,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_VOL_DOWN),
+                .press_handler = ui_common_handle_vol,
+            },
         },
         .idle_handler = ui_common_handle_idle,
     };


### PR DESCRIPTION
I wanted combo support when porting apps over to the new input library. It gives a more general way to handle things like the brightness keys, and is one of the last big things I wanted to call the library "complete".

I made some simplifying assumptions to help keep things sane. For example, only one combo can be active at a time, because combo press/hold/release behavior gets really confusing with multiple overlapping combos triggered at once.

To test this, I migrated the volume and brightness handlers of the muX apps using the new input library. But that's mostly just a precursor for the next thing....

---

I've written a `muhotkey` C program to listen for hotkeys from `input.sh` in the shell scripts. I have a soft spot for the `evtest` loop, but it has some disadvantages:

* It burns a lot of CPU due to printing _every_ input event and parsing it in the shell script. Spinning one of the sticks, `input.sh` + `evtest` take up about 17% of a core. By comparison, `input.sh` + `muhotkey` only uses about 0.7% of a core, which is a decent savings when some systems already push the CPU to its limits.
* Because `evtest` reports _every_ event, the tiny stick wobble from Hall effect sticks makes the new idle support falsely detect activity at random. (We could fix this in the script, but that's even more costly parsing.)
* The current setup requires a separate copy of the input mappings (`map.sh`) for every device, which duplicates what we already have in the config files.
* It's tricky to wire up holds in the current setup. (I wanted to make it possible to hold the brightness and volume hotkeys, but that gets really messy with `evtest`.)

See also the [companion PR](https://github.com/MustardOS/internal/pull/290) that uses the new daemon. For example, see this [new version of `input.sh` for the 35H](https://github.com/bcat/muos-internal/blob/muhotkey/device/rg35xx-h/input/input.sh) (or 40H/V) that seems to work well. It immediately dims on idle instead of fading out, but is otherwise working. Just drop in `muhotkey` and that `input.sh` if you want to test.

---

Here's what the command args and output looks like. Basically, you tell it what combos you want to listen for, and it reports those. It also tracks and reports input activity/idle (since it doesn't report every event to the calling script).

```
[~]# /opt/muos/extra/muhotkey -h
Usage: muhotkey [-v] [-C|-H COMBO_SPEC]...
Usage: muhotkey -l

Monitor input for a list of hotkey combos.

  -C COMBO_SPEC combo that will receive events on press
  -H COMBO_SPEC combo that will receive events on press and hold
  -v            prints every input received (verbose mode)
  -l            lists valid input names for COMBO_SPEC
  -h            displays this usage message

COMBO_SPEC has format `NAME=INPUT1+INPUT2+...`. Use -l to see valid INPUT values.

[~]# /opt/muos/extra/muhotkey \
> -C OSF=POWER_LONG+L1+L2+R1+R2 \
> -C SLEEP=POWER_LONG \
> -C SCREENSHOT=POWER_SHORT+MENU_LONG \
> -C DPAD_TOGGLE=POWER_SHORT \
> -H BRIGHT_UP=VOL_UP+MENU_LONG \
> -H VOL_UP=VOL_UP \
> -H BRIGHT_DOWN=VOL_DOWN+MENU_LONG \
> -H VOL_DOWN=VOL_DOWN \
> -C RETROWAIT_IGNORE=START \
> -C RETROWAIT_MENU=SELECT
VOL_UP
VOL_UP
VOL_UP
VOL_DOWN
VOL_DOWN
VOL_DOWN
BRIGHT_UP
BRIGHT_DOWN
DPAD_TOGGLE
SLEEP
IDLE_DISPLAY
IDLE_ACTIVE
SCREENSHOT
```