### PR TITLE
Factor list navigation handlers (Up/Down/L1/R1) to a reusable file

### DIFF
--- a/common/input.c
+++ b/common/input.c
@@ -13,7 +13,7 @@
 #include "config.h"
 #include "device.h"
 
-extern uint32_t mux_tick();
+extern uint32_t mux_tick(void);
 
 // Whether to exit the input task before the next iteration of the event loop.
 static bool stop = false;
@@ -391,6 +391,6 @@ bool mux_input_pressed(mux_input_type type) {
     return pressed & BIT(type);
 }
 
-void mux_input_stop() {
+void mux_input_stop(void) {
     stop = true;
 }

--- a/common/input.c
+++ b/common/input.c
@@ -1,5 +1,6 @@
 #include "input.h"
 
+#include <errno.h>
 #include <linux/input.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -349,7 +350,9 @@ void mux_input_task(const mux_input_options *opts) {
         int num_events = epoll_wait(epoll_fd, epoll_event, device.DEVICE.EVENT,
                                     held ? timeout_hold : timeout);
         if (num_events == -1) {
-            perror("mux_input_task: epoll_wait");
+            if (errno != EINTR) {
+                perror("mux_input_task: epoll_wait");
+            }
             continue;
         }
 

--- a/common/input.h
+++ b/common/input.h
@@ -62,7 +62,7 @@ typedef enum {
 } mux_input_action;
 
 // Callback function invoked in response to a single specific input type and action.
-typedef void (*mux_input_handler)();
+typedef void (*mux_input_handler)(void);
 
 // Callback function invoked in response to any arbitrary input type and action.
 typedef void (*mux_input_catchall_handler)(mux_input_type, mux_input_action);
@@ -149,4 +149,4 @@ bool mux_input_pressed(mux_input_type type);
 
 // Causes the input task to exit at the start of the next iteration of the event loop (e.g., after
 // processing currently pressed or held inputs).
-void mux_input_stop();
+void mux_input_stop(void);

--- a/common/input/list_nav.c
+++ b/common/input/list_nav.c
@@ -1,0 +1,77 @@
+#include "list_nav.h"
+
+#include "../common.h"
+#include "../theme.h"
+
+void list_nav_prev(int steps);
+void list_nav_next(int steps);
+
+void list_nav_first(void);
+void list_nav_last(void);
+
+extern int ui_count;
+extern int current_item_index;
+
+void handle_list_nav_up(void) {
+    if (msgbox_active || !ui_count) {
+        return;
+    }
+
+    if (current_item_index > 0) {
+        list_nav_prev(1);
+    } else {
+        list_nav_last();
+    }
+}
+
+void handle_list_nav_down(void) {
+    if (msgbox_active || !ui_count) {
+        return;
+    }
+
+    if (current_item_index < ui_count - 1) {
+        list_nav_next(1);
+    } else {
+        list_nav_first();
+    }
+}
+
+void handle_list_nav_up_hold(void) {
+    if (msgbox_active || !ui_count) {
+        return;
+    }
+
+    if (current_item_index > 0) {
+        list_nav_prev(1);
+    }
+}
+
+void handle_list_nav_down_hold(void) {
+    if (msgbox_active || !ui_count) {
+        return;
+    }
+
+    if (current_item_index < ui_count - 1) {
+        list_nav_next(1);
+    }
+}
+
+void handle_list_nav_page_up(void) {
+    if (msgbox_active || !ui_count) {
+        return;
+    }
+
+    if (current_item_index > 0) {
+        list_nav_prev(theme.MUX.ITEM.COUNT);
+    }
+}
+
+void handle_list_nav_page_down(void) {
+    if (msgbox_active || !ui_count) {
+        return;
+    }
+
+    if (current_item_index < ui_count - 1) {
+        list_nav_next(theme.MUX.ITEM.COUNT);
+    }
+}

--- a/common/input/list_nav.h
+++ b/common/input/list_nav.h
@@ -1,0 +1,10 @@
+#pragma once
+
+void handle_list_nav_up(void);
+void handle_list_nav_down(void);
+
+void handle_list_nav_up_hold(void);
+void handle_list_nav_down_hold(void);
+
+void handle_list_nav_page_up(void);
+void handle_list_nav_page_down(void);

--- a/common/ui_common.c
+++ b/common/ui_common.c
@@ -1,3 +1,5 @@
+#include <stdlib.h>
+
 #include "font/awesome_small.h"
 #include "font/gamepad_nav.h"
 #include "font/notosans.h"

--- a/muhotkey/Makefile
+++ b/muhotkey/Makefile
@@ -15,8 +15,7 @@ TARGET = ${shell basename $$(pwd)}
 CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
-	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration
+	-flto -finline-functions -Wall -Wno-format-zero-length
 
 LDFLAGS = $(CFLAGS) -Wl,--gc-sections -s
 

--- a/muxapp/Makefile
+++ b/muxapp/Makefile
@@ -78,6 +78,7 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/ui_common.c \
 		../common/theme.c \
 		../common/input.c \
+		../common/input/list_nav.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \

--- a/muxapp/Makefile
+++ b/muxapp/Makefile
@@ -16,7 +16,7 @@ CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
 	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration -I../common/font
+	-I../common/font
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \

--- a/muxapp/main.c
+++ b/muxapp/main.c
@@ -22,6 +22,7 @@
 #include "../common/config.h"
 #include "../common/device.h"
 #include "../common/input.h"
+#include "../common/input/list_nav.h"
 
 __thread uint64_t start_ms = 0;
 
@@ -232,6 +233,26 @@ void list_nav_next(int steps) {
     nav_moved = 1;
 }
 
+void list_nav_first(void) {
+    current_item_index = 0;
+    nav_next(ui_group, 1);
+    nav_next(ui_group_glyph, 1);
+    nav_next(ui_group_panel, 1);
+    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                           current_item_index, ui_pnlContent);
+    nav_moved = 1;
+}
+
+void list_nav_last(void) {
+    current_item_index = ui_count - 1;
+    nav_prev(ui_group, 1);
+    nav_prev(ui_group_glyph, 1);
+    nav_prev(ui_group_panel, 1);
+    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                           current_item_index, ui_pnlContent);
+    nav_moved = 1;
+}
+
 void handle_a() {
     if (msgbox_active) {
         return;
@@ -268,26 +289,6 @@ void handle_b() {
     mux_input_stop();
 }
 
-void handle_l1() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index >= 0 && current_item_index < ui_count) {
-        list_nav_prev(theme.MUX.ITEM.COUNT);
-    }
-}
-
-void handle_r1() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index >= 0 && current_item_index < ui_count) {
-        list_nav_next(theme.MUX.ITEM.COUNT);
-    }
-}
-
 void handle_menu() {
     if (msgbox_active) {
         return;
@@ -296,62 +297,6 @@ void handle_menu() {
     if (progress_onscreen == -1) {
         play_sound("confirm", nav_sound, 1);
         show_help();
-    }
-}
-
-void handle_up() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == 0) {
-        current_item_index = ui_count - 1;
-        nav_prev(ui_group, 1);
-        nav_prev(ui_group_glyph, 1);
-        nav_prev(ui_group_panel, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                               current_item_index, ui_pnlContent);
-        nav_moved = 1;
-    } else if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_up_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_down() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == ui_count - 1) {
-        current_item_index = 0;
-        nav_next(ui_group, 1);
-        nav_next(ui_group_glyph, 1);
-        nav_next(ui_group_panel, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                               current_item_index, ui_pnlContent);
-        nav_moved = 1;
-    } else if (current_item_index < ui_count - 1) {
-        list_nav_next(1);
-    }
-}
-
-void handle_down_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index < ui_count - 1) {
-        list_nav_next(1);
     }
 }
 
@@ -677,17 +622,19 @@ int main(int argc, char *argv[]) {
         .press_handler = {
             [MUX_INPUT_A] = handle_a,
             [MUX_INPUT_B] = handle_b,
-            [MUX_INPUT_L1] = handle_l1,
-            [MUX_INPUT_R1] = handle_r1,
-            [MUX_INPUT_DPAD_UP] = handle_up,
-            [MUX_INPUT_DPAD_DOWN] = handle_down,
             [MUX_INPUT_MENU_SHORT] = handle_menu,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .hold_handler = {
-            [MUX_INPUT_L1] = handle_l1,
-            [MUX_INPUT_R1] = handle_r1,
-            [MUX_INPUT_DPAD_UP] = handle_up_hold,
-            [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up_hold,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down_hold,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .combo = {
             {

--- a/muxarchive/Makefile
+++ b/muxarchive/Makefile
@@ -16,7 +16,7 @@ CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
 	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration -I../common/font
+	-I../common/font
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \

--- a/muxarchive/Makefile
+++ b/muxarchive/Makefile
@@ -77,6 +77,7 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/ui_common.c \
 		../common/theme.c \
 		../common/input.c \
+		../common/input/list_nav.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \

--- a/muxarchive/main.c
+++ b/muxarchive/main.c
@@ -21,6 +21,7 @@
 #include "../common/config.h"
 #include "../common/device.h"
 #include "../common/input.h"
+#include "../common/input/list_nav.h"
 
 __thread uint64_t start_ms = 0;
 
@@ -227,6 +228,28 @@ void list_nav_next(int steps) {
     nav_moved = 1;
 }
 
+void list_nav_first(void) {
+    current_item_index = 0;
+    nav_next(ui_group, 1);
+    nav_next(ui_group_glyph, 1);
+    nav_next(ui_group_panel, 1);
+    nav_next(ui_group_installed, 1);
+    nav_next(ui_group_data, 1);
+    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                           current_item_index, ui_pnlContent);
+}
+
+void list_nav_last(void) {
+    current_item_index = ui_count - 1;
+    nav_prev(ui_group, 1);
+    nav_prev(ui_group_glyph, 1);
+    nav_prev(ui_group_panel, 1);
+    nav_prev(ui_group_installed, 1);
+    nav_prev(ui_group_data, 1);
+    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                           current_item_index, ui_pnlContent);
+}
+
 void handle_a() {
     if (msgbox_active) {
         return;
@@ -266,26 +289,6 @@ void handle_b() {
     mux_input_stop();
 }
 
-void handle_l1() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index >= 0 && current_item_index < ui_count) {
-        list_nav_prev(theme.MUX.ITEM.COUNT);
-    }
-}
-
-void handle_r1() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index >= 0 && current_item_index < ui_count) {
-        list_nav_next(theme.MUX.ITEM.COUNT);
-    }
-}
-
 void handle_menu() {
     if (msgbox_active) {
         return;
@@ -294,64 +297,6 @@ void handle_menu() {
     if (progress_onscreen == -1) {
         play_sound("confirm", nav_sound, 1);
         show_help();
-    }
-}
-
-void handle_up() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == 0) {
-        current_item_index = ui_count - 1;
-        nav_prev(ui_group, 1);
-        nav_prev(ui_group_glyph, 1);
-        nav_prev(ui_group_panel, 1);
-        nav_prev(ui_group_installed, 1);
-        nav_prev(ui_group_data, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                               current_item_index, ui_pnlContent);
-    } else if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_up_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_down() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == ui_count - 1) {
-        current_item_index = 0;
-        nav_next(ui_group, 1);
-        nav_next(ui_group_glyph, 1);
-        nav_next(ui_group_panel, 1);
-        nav_next(ui_group_installed, 1);
-        nav_next(ui_group_data, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                               current_item_index, ui_pnlContent);
-    } else if (current_item_index < ui_count - 1) {
-        list_nav_next(1);
-    }
-}
-
-void handle_down_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index < ui_count - 1) {
-        list_nav_next(1);
     }
 }
 
@@ -667,17 +612,19 @@ int main(int argc, char *argv[]) {
         .press_handler = {
             [MUX_INPUT_A] = handle_a,
             [MUX_INPUT_B] = handle_b,
-            [MUX_INPUT_L1] = handle_l1,
-            [MUX_INPUT_R1] = handle_r1,
-            [MUX_INPUT_DPAD_UP] = handle_up,
-            [MUX_INPUT_DPAD_DOWN] = handle_down,
             [MUX_INPUT_MENU_SHORT] = handle_menu,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .hold_handler = {
-            [MUX_INPUT_L1] = handle_l1,
-            [MUX_INPUT_R1] = handle_r1,
-            [MUX_INPUT_DPAD_UP] = handle_up_hold,
-            [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up_hold,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down_hold,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .combo = {
             {

--- a/muxassign/Makefile
+++ b/muxassign/Makefile
@@ -16,7 +16,7 @@ CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
 	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration -I../common/font
+	-I../common/font
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \

--- a/muxcharge/Makefile
+++ b/muxcharge/Makefile
@@ -16,7 +16,7 @@ CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
 	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration -I../common/font
+	-I../common/font
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \

--- a/muxconfig/Makefile
+++ b/muxconfig/Makefile
@@ -77,6 +77,7 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/ui_common.c \
 		../common/theme.c \
 		../common/input.c \
+		../common/input/list_nav.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \

--- a/muxconfig/Makefile
+++ b/muxconfig/Makefile
@@ -16,7 +16,7 @@ CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
 	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration -I../common/font
+	-I../common/font
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \

--- a/muxconfig/main.c
+++ b/muxconfig/main.c
@@ -21,6 +21,7 @@
 #include "../common/config.h"
 #include "../common/device.h"
 #include "../common/input.h"
+#include "../common/input/list_nav.h"
 
 __thread uint64_t start_ms = 0;
 
@@ -165,7 +166,7 @@ void list_nav_prev(int steps) {
 void list_nav_next(int steps) {
     play_sound("navigate", nav_sound, 0);
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index < (ui_count)) {
+        if (current_item_index < (ui_count - 1)) {
             current_item_index++;
             nav_next(ui_group, 1);
             nav_next(ui_group_glyph, 1);
@@ -173,6 +174,26 @@ void list_nav_next(int steps) {
         }
     }
     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count, current_item_index, ui_pnlContent);
+    nav_moved = 1;
+}
+
+void list_nav_first(void) {
+    current_item_index = 0;
+    nav_next(ui_group, 1);
+    nav_next(ui_group_glyph, 1);
+    nav_next(ui_group_panel, 1);
+    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                           current_item_index, ui_pnlContent);
+    nav_moved = 1;
+}
+
+void list_nav_last(void) {
+    current_item_index = ui_count - 1;
+    nav_prev(ui_group, 1);
+    nav_prev(ui_group_glyph, 1);
+    nav_prev(ui_group_panel, 1);
+    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                           current_item_index, ui_pnlContent);
     nav_moved = 1;
 }
 
@@ -222,62 +243,6 @@ void handle_menu() {
     if (progress_onscreen == -1) {
         play_sound("confirm", nav_sound, 1);
         show_help(lv_group_get_focused(ui_group));
-    }
-}
-
-void handle_up() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == 0) {
-        current_item_index = ui_count - 1;
-        nav_prev(ui_group, 1);
-        nav_prev(ui_group_glyph, 1);
-        nav_prev(ui_group_panel, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                               current_item_index, ui_pnlContent);
-        nav_moved = 1;
-    } else if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_up_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_down() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == ui_count - 1) {
-        current_item_index = 0;
-        nav_next(ui_group, 1);
-        nav_next(ui_group_glyph, 1);
-        nav_next(ui_group_panel, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                               current_item_index, ui_pnlContent);
-        nav_moved = 1;
-    } else if (current_item_index < ui_count - 1) {
-        list_nav_next(1);
-    }
-}
-
-void handle_down_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index < ui_count - 1) {
-        list_nav_next(1);
     }
 }
 
@@ -614,13 +579,19 @@ int main(int argc, char *argv[]) {
         .press_handler = {
             [MUX_INPUT_A] = handle_a,
             [MUX_INPUT_B] = handle_b,
-            [MUX_INPUT_DPAD_UP] = handle_up,
-            [MUX_INPUT_DPAD_DOWN] = handle_down,
             [MUX_INPUT_MENU_SHORT] = handle_menu,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .hold_handler = {
-            [MUX_INPUT_DPAD_UP] = handle_up_hold,
-            [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up_hold,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down_hold,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .combo = {
             {

--- a/muxcredits/Makefile
+++ b/muxcredits/Makefile
@@ -15,8 +15,7 @@ TARGET = ${shell basename $$(pwd)}
 CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
-	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration
+	-flto -finline-functions -Wall -Wno-format-zero-length
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \

--- a/muxgov/Makefile
+++ b/muxgov/Makefile
@@ -16,7 +16,7 @@ CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
 	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration -I../common/font
+	-I../common/font
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \

--- a/muxinfo/Makefile
+++ b/muxinfo/Makefile
@@ -16,7 +16,7 @@ CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
 	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration -I../common/font
+	-I../common/font
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \

--- a/muxinfo/Makefile
+++ b/muxinfo/Makefile
@@ -77,6 +77,7 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/ui_common.c \
 		../common/theme.c \
 		../common/input.c \
+		../common/input/list_nav.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \

--- a/muxinfo/main.c
+++ b/muxinfo/main.c
@@ -21,6 +21,7 @@
 #include "../common/config.h"
 #include "../common/device.h"
 #include "../common/input.h"
+#include "../common/input/list_nav.h"
 
 __thread uint64_t start_ms = 0;
 
@@ -134,10 +135,12 @@ void init_navigation_groups() {
 void list_nav_prev(int steps) {
     play_sound("navigate", nav_sound, 0);
     for (int step = 0; step < steps; ++step) {
-        current_item_index = (current_item_index == 0) ? UI_COUNT - 1 : current_item_index - 1;
-        nav_prev(ui_group, 1);
-        nav_prev(ui_group_glyph, 1);
-        nav_prev(ui_group_panel, 1);
+        if (current_item_index > 0) {
+            current_item_index--;
+            nav_prev(ui_group, 1);
+            nav_prev(ui_group_glyph, 1);
+            nav_prev(ui_group_panel, 1);
+        }
     }
     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT, current_item_index, ui_pnlContent);
     nav_moved = 1;
@@ -146,12 +149,34 @@ void list_nav_prev(int steps) {
 void list_nav_next(int steps) {
     play_sound("navigate", nav_sound, 0);
     for (int step = 0; step < steps; ++step) {
-        current_item_index = (current_item_index == UI_COUNT - 1) ? 0 : current_item_index + 1;
-        nav_next(ui_group, 1);
-        nav_next(ui_group_glyph, 1);
-        nav_next(ui_group_panel, 1);
+        if (current_item_index < ui_count - 1) {
+            current_item_index++;
+            nav_next(ui_group, 1);
+            nav_next(ui_group_glyph, 1);
+            nav_next(ui_group_panel, 1);
+        }
     }
     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT, current_item_index, ui_pnlContent);
+    nav_moved = 1;
+}
+
+void list_nav_first(void) {
+    current_item_index = 0;
+    nav_next(ui_group, 1);
+    nav_next(ui_group_glyph, 1);
+    nav_next(ui_group_panel, 1);
+    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
+                           current_item_index, ui_pnlContent);
+    nav_moved = 1;
+}
+
+void list_nav_last(void) {
+    current_item_index = UI_COUNT - 1;
+    nav_prev(ui_group, 1);
+    nav_prev(ui_group_glyph, 1);
+    nav_prev(ui_group_panel, 1);
+    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
+                           current_item_index, ui_pnlContent);
     nav_moved = 1;
 }
 
@@ -196,62 +221,6 @@ void handle_menu() {
     if (progress_onscreen == -1) {
         play_sound("confirm", nav_sound, 1);
         show_help(lv_group_get_focused(ui_group));
-    }
-}
-
-void handle_up() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == 0) {
-        current_item_index = UI_COUNT - 1;
-        nav_prev(ui_group, 1);
-        nav_prev(ui_group_glyph, 1);
-        nav_prev(ui_group_panel, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
-                               current_item_index, ui_pnlContent);
-        nav_moved = 1;
-    } else if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_down() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == UI_COUNT - 1) {
-        current_item_index = 0;
-        nav_next(ui_group, 1);
-        nav_next(ui_group_glyph, 1);
-        nav_next(ui_group_panel, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
-                               current_item_index, ui_pnlContent);
-        nav_moved = 1;
-    } else if (current_item_index < UI_COUNT - 1) {
-        list_nav_next(1);
-    }
-}
-
-void handle_up_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_down_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index < ui_count - 1) {
-        list_nav_next(1);
     }
 }
 
@@ -578,13 +547,19 @@ int main(int argc, char *argv[]) {
         .press_handler = {
             [MUX_INPUT_A] = handle_a,
             [MUX_INPUT_B] = handle_b,
-            [MUX_INPUT_DPAD_UP] = handle_up,
-            [MUX_INPUT_DPAD_DOWN] = handle_down,
             [MUX_INPUT_MENU_SHORT] = handle_menu,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .hold_handler = {
-            [MUX_INPUT_DPAD_UP] = handle_up_hold,
-            [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up_hold,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down_hold,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .combo = {
             {

--- a/muxlanguage/Makefile
+++ b/muxlanguage/Makefile
@@ -16,7 +16,7 @@ CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
 	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration -I../common/font
+	-I../common/font
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \

--- a/muxlaunch/Makefile
+++ b/muxlaunch/Makefile
@@ -16,7 +16,7 @@ CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
 	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration -I../common/font
+	-I../common/font
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \

--- a/muxnetprofile/Makefile
+++ b/muxnetprofile/Makefile
@@ -16,7 +16,7 @@ CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
 	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration -I../common/font
+	-I../common/font
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \

--- a/muxnetscan/Makefile
+++ b/muxnetscan/Makefile
@@ -16,7 +16,7 @@ CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
 	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration -I../common/font
+	-I../common/font
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \

--- a/muxnetscan/main.c
+++ b/muxnetscan/main.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include "../lvgl/lvgl.h"
 #include "../lvgl/drivers/display/fbdev.h"
 #include "../lvgl/drivers/indev/evdev.h"

--- a/muxnetwork/Makefile
+++ b/muxnetwork/Makefile
@@ -16,7 +16,7 @@ CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
 	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration -I../common/font
+	-I../common/font
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \

--- a/muxoption/Makefile
+++ b/muxoption/Makefile
@@ -16,7 +16,7 @@ CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
 	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration -I../common/font
+	-I../common/font
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \

--- a/muxpass/Makefile
+++ b/muxpass/Makefile
@@ -16,7 +16,7 @@ CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
 	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration -I../common/font
+	-I../common/font
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \

--- a/muxplore/Makefile
+++ b/muxplore/Makefile
@@ -78,6 +78,7 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/ui_common.c \
 		../common/theme.c \
 		../common/input.c \
+		../common/input/list_nav.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \

--- a/muxplore/Makefile
+++ b/muxplore/Makefile
@@ -16,7 +16,7 @@ CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
 	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration -I../common/font
+	-I../common/font
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \

--- a/muxrtc/Makefile
+++ b/muxrtc/Makefile
@@ -16,7 +16,7 @@ CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
 	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration -I../common/font
+	-I../common/font
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \

--- a/muxrtc/Makefile
+++ b/muxrtc/Makefile
@@ -77,6 +77,7 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/ui_common.c \
 		../common/theme.c \
 		../common/input.c \
+		../common/input/list_nav.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \

--- a/muxrtc/main.c
+++ b/muxrtc/main.c
@@ -20,6 +20,7 @@
 #include "../common/config.h"
 #include "../common/device.h"
 #include "../common/input.h"
+#include "../common/input/list_nav.h"
 
 __thread uint64_t start_ms = 0;
 
@@ -330,6 +331,28 @@ void list_nav_next(int steps) {
     nav_moved = 1;
 }
 
+void list_nav_first(void) {
+    current_item_index = 0;
+    nav_next(ui_group, 1);
+    nav_next(ui_group_value, 1);
+    nav_next(ui_group_glyph, 1);
+    nav_next(ui_group_panel, 1);
+    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
+                           current_item_index, ui_pnlContent);
+    nav_moved = 1;
+}
+
+void list_nav_last(void) {
+    current_item_index = UI_COUNT - 1;
+    nav_prev(ui_group, 1);
+    nav_prev(ui_group_value, 1);
+    nav_prev(ui_group_glyph, 1);
+    nav_prev(ui_group_panel, 1);
+    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
+                           current_item_index, ui_pnlContent);
+    nav_moved = 1;
+}
+
 void handle_a() {
     if (msgbox_active) {
         return;
@@ -431,64 +454,6 @@ void handle_b() {
     write_text_to_file("/run/muos/global/boot/clock_setup", "w", INT, 0);
     write_text_to_file(MUOS_PDI_LOAD, "w", CHAR, "clock");
     mux_input_stop();
-}
-
-void handle_up() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == 0) {
-        current_item_index = UI_COUNT - 1;
-        nav_prev(ui_group, 1);
-        nav_prev(ui_group_value, 1);
-        nav_prev(ui_group_glyph, 1);
-        nav_prev(ui_group_panel, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
-                               current_item_index, ui_pnlContent);
-        nav_moved = 1;
-    } else if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_up_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_down() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == ui_count - 1) {
-        current_item_index = 0;
-        nav_next(ui_group, 1);
-        nav_next(ui_group_value, 1);
-        nav_next(ui_group_glyph, 1);
-        nav_next(ui_group_panel, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
-                               current_item_index, ui_pnlContent);
-        nav_moved = 1;
-    } else if (current_item_index < ui_count) {
-        list_nav_next(1);
-    }
-}
-
-void handle_down_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index < ui_count - 1) {
-        list_nav_next(1);
-    }
 }
 
 void handle_left() {
@@ -969,17 +934,23 @@ int main(int argc, char *argv[]) {
         .press_handler = {
             [MUX_INPUT_A] = handle_a,
             [MUX_INPUT_B] = handle_b,
-            [MUX_INPUT_DPAD_UP] = handle_up,
-            [MUX_INPUT_DPAD_DOWN] = handle_down,
             [MUX_INPUT_DPAD_LEFT] = handle_left,
             [MUX_INPUT_DPAD_RIGHT] = handle_right,
             [MUX_INPUT_MENU_SHORT] = handle_menu,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .hold_handler = {
-            [MUX_INPUT_DPAD_UP] = handle_up_hold,
-            [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
             [MUX_INPUT_DPAD_LEFT] = handle_left,
             [MUX_INPUT_DPAD_RIGHT] = handle_right,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up_hold,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down_hold,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .combo = {
             {

--- a/muxsplash/Makefile
+++ b/muxsplash/Makefile
@@ -15,8 +15,7 @@ TARGET = ${shell basename $$(pwd)}
 CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
-	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration
+	-flto -finline-functions -Wall -Wno-format-zero-length
 
 LDFLAGS = $(CFLAGS) -lSDL2 -lSDL2_mixer -lpthread -Wl,--gc-sections -s
 

--- a/muxstart/Makefile
+++ b/muxstart/Makefile
@@ -16,7 +16,7 @@ CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
 	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration -I../common/font
+	-I../common/font
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \

--- a/muxstorage/Makefile
+++ b/muxstorage/Makefile
@@ -16,7 +16,7 @@ CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
 	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration -I../common/font
+	-I../common/font
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \

--- a/muxsysinfo/Makefile
+++ b/muxsysinfo/Makefile
@@ -16,7 +16,7 @@ CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
 	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration -I../common/font
+	-I../common/font
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \

--- a/muxsysinfo/Makefile
+++ b/muxsysinfo/Makefile
@@ -77,6 +77,7 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/ui_common.c \
 		../common/theme.c \
 		../common/input.c \
+		../common/input/list_nav.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \

--- a/muxsysinfo/main.c
+++ b/muxsysinfo/main.c
@@ -21,6 +21,7 @@
 #include "../common/config.h"
 #include "../common/device.h"
 #include "../common/input.h"
+#include "../common/input/list_nav.h"
 
 __thread uint64_t start_ms = 0;
 
@@ -339,6 +340,28 @@ void list_nav_next(int steps) {
     nav_moved = 1;
 }
 
+void list_nav_first(void) {
+    current_item_index = 0;
+    nav_next(ui_group, 1);
+    nav_next(ui_group_value, 1);
+    nav_next(ui_group_glyph, 1);
+    nav_next(ui_group_panel, 1);
+    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
+                           current_item_index, ui_pnlContent);
+    nav_moved = 1;
+}
+
+void list_nav_last(void) {
+    current_item_index = UI_COUNT - 1;
+    nav_prev(ui_group, 1);
+    nav_prev(ui_group_value, 1);
+    nav_prev(ui_group_glyph, 1);
+    nav_prev(ui_group_panel, 1);
+    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
+                           current_item_index, ui_pnlContent);
+    nav_moved = 1;
+}
+
 void handle_a() {
     if (msgbox_active) {
         return;
@@ -374,64 +397,6 @@ void handle_menu() {
     if (progress_onscreen == -1) {
         play_sound("confirm", nav_sound, 1);
         show_help(lv_group_get_focused(ui_group));
-    }
-}
-
-void handle_up() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == 0) {
-        current_item_index = UI_COUNT - 1;
-        nav_prev(ui_group, 1);
-        nav_prev(ui_group_value, 1);
-        nav_prev(ui_group_glyph, 1);
-        nav_prev(ui_group_panel, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
-                               current_item_index, ui_pnlContent);
-        nav_moved = 1;
-    } else if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_down() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == UI_COUNT - 1) {
-        current_item_index = 0;
-        nav_next(ui_group, 1);
-        nav_next(ui_group_value, 1);
-        nav_next(ui_group_glyph, 1);
-        nav_next(ui_group_panel, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
-                               current_item_index, ui_pnlContent);
-        nav_moved = 1;
-    } else if (current_item_index < UI_COUNT - 1) {
-        list_nav_next(1);
-    }
-}
-
-void handle_up_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_down_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index < ui_count - 1) {
-        list_nav_next(1);
     }
 }
 
@@ -749,13 +714,19 @@ int main(int argc, char *argv[]) {
         .press_handler = {
             [MUX_INPUT_A] = handle_a,
             [MUX_INPUT_B] = handle_b,
-            [MUX_INPUT_DPAD_UP] = handle_up,
-            [MUX_INPUT_DPAD_DOWN] = handle_down,
             [MUX_INPUT_MENU_SHORT] = handle_menu,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .hold_handler = {
-            [MUX_INPUT_DPAD_UP] = handle_up_hold,
-            [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up_hold,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down_hold,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .combo = {
             {

--- a/muxtask/Makefile
+++ b/muxtask/Makefile
@@ -16,7 +16,7 @@ CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
 	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration -I../common/font
+	-I../common/font
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \

--- a/muxtester/Makefile
+++ b/muxtester/Makefile
@@ -16,7 +16,7 @@ CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
 	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration -I../common/font
+	-I../common/font
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \

--- a/muxtheme/Makefile
+++ b/muxtheme/Makefile
@@ -16,7 +16,7 @@ CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
 	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration -I../common/font
+	-I../common/font
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \

--- a/muxtimezone/Makefile
+++ b/muxtimezone/Makefile
@@ -16,7 +16,7 @@ CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
 	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration -I../common/font
+	-I../common/font
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \

--- a/muxtimezone/Makefile
+++ b/muxtimezone/Makefile
@@ -77,6 +77,7 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/ui_common.c \
 		../common/theme.c \
 		../common/input.c \
+		../common/input/list_nav.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \

--- a/muxtimezone/main.c
+++ b/muxtimezone/main.c
@@ -21,6 +21,7 @@
 #include "../common/config.h"
 #include "../common/device.h"
 #include "../common/input.h"
+#include "../common/input/list_nav.h"
 
 __thread uint64_t start_ms = 0;
 
@@ -121,6 +122,24 @@ void list_nav_next(int steps) {
     nav_moved = 1;
 }
 
+void list_nav_first(void) {
+    current_item_index = 0;
+    nav_next(ui_group, 1);
+    nav_next(ui_group_glyph, 1);
+    nav_next(ui_group_panel, 1);
+    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                           current_item_index, ui_pnlContent);
+}
+
+void list_nav_last(void) {
+    current_item_index = ui_count - 1;
+    nav_prev(ui_group, 1);
+    nav_prev(ui_group_glyph, 1);
+    nav_prev(ui_group_panel, 1);
+    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
+                           current_item_index, ui_pnlContent);
+}
+
 void handle_a() {
     if (msgbox_active) {
         return;
@@ -151,72 +170,6 @@ void handle_b() {
 
     play_sound("back", nav_sound, 1);
     mux_input_stop();
-}
-
-void handle_l1() {
-    if (current_item_index >= 0 && current_item_index < ui_count) {
-        list_nav_prev(theme.MUX.ITEM.COUNT);
-    }
-}
-
-void handle_r1() {
-    if (current_item_index >= 0 && current_item_index < ui_count) {
-        list_nav_next(theme.MUX.ITEM.COUNT);
-    }
-}
-
-void handle_up() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == 0) {
-        current_item_index = ui_count - 1;
-        nav_prev(ui_group, 1);
-        nav_prev(ui_group_glyph, 1);
-        nav_prev(ui_group_panel, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                               current_item_index, ui_pnlContent);
-    } else if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_up_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_down() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == ui_count - 1) {
-        current_item_index = 0;
-        nav_next(ui_group, 1);
-        nav_next(ui_group_glyph, 1);
-        nav_next(ui_group_panel, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                               current_item_index, ui_pnlContent);
-    } else if (current_item_index < ui_count) {
-        list_nav_next(1);
-    }
-}
-
-void handle_down_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index < ui_count - 1) {
-        list_nav_next(1);
-    }
 }
 
 void handle_menu() {
@@ -535,17 +488,19 @@ int main(int argc, char *argv[]) {
         .press_handler = {
             [MUX_INPUT_A] = handle_a,
             [MUX_INPUT_B] = handle_b,
-            [MUX_INPUT_L1] = handle_l1,
-            [MUX_INPUT_R1] = handle_r1,
-            [MUX_INPUT_DPAD_UP] = handle_up,
-            [MUX_INPUT_DPAD_DOWN] = handle_down,
             [MUX_INPUT_MENU_SHORT] = handle_menu,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .hold_handler = {
-            [MUX_INPUT_L1] = handle_l1,
-            [MUX_INPUT_R1] = handle_r1,
-            [MUX_INPUT_DPAD_UP] = handle_up_hold,
-            [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up_hold,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down_hold,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .combo = {
             {

--- a/muxtweakadv/Makefile
+++ b/muxtweakadv/Makefile
@@ -16,7 +16,7 @@ CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
 	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration -I../common/font
+	-I../common/font
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \

--- a/muxtweakgen/Makefile
+++ b/muxtweakgen/Makefile
@@ -16,7 +16,7 @@ CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
 	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration -I../common/font
+	-I../common/font
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \

--- a/muxvisual/Makefile
+++ b/muxvisual/Makefile
@@ -16,7 +16,7 @@ CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
 	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration -I../common/font
+	-I../common/font
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \

--- a/muxwebserv/Makefile
+++ b/muxwebserv/Makefile
@@ -16,7 +16,7 @@ CC = ccache $(CROSS_COMPILE)gcc -O3
 
 CFLAGS  = $(ARCH) -flto=auto -ffunction-sections -fdata-sections \
 	-flto -finline-functions -Wall -Wno-format-zero-length \
-	-Wno-implicit-function-declaration -I../common/font
+	-I../common/font
 
 CFONTS = -L../bin/lib \
 	-lawesome_small \


### PR DESCRIPTION
This change sets up to port all the remaining list-based muX apps to the new input library without duplicating as much of the navigation code. It also makes it easy to make the apps more consistent (e.g., supporting L1/L2 in each one).

There's still some more overlap that can probably be removed in the future with the list logic itself (e.g., many of the `list_nav_first/prev/next/last` implementations are identical), but that feels like a post-Banana problem. For now, I'd rather get the remaining apps onto the new input stuff (hopefully this weekend?).

I also made a couple other minor cleanups to the new input code, and I reenabled the `no-implicit-function-declaration` compiler warning since I keep accidentally calling functions without declaring them. :)