### PR TITLE
Factor out list nav handlers & port muxtweakgen to new input lib

### DIFF
--- a/common/input/list_nav.c
+++ b/common/input/list_nav.c
@@ -1,0 +1,74 @@
+#include "list_nav.h"
+
+#include <sys/param.h>
+
+#include "../common.h"
+#include "../theme.h"
+
+void list_nav_prev(int steps);
+void list_nav_next(int steps);
+
+extern int ui_count;
+extern int current_item_index;
+
+void handle_list_nav_up(void) {
+    if (msgbox_active || !ui_count) {
+        return;
+    }
+
+    list_nav_prev(1);
+}
+
+void handle_list_nav_down(void) {
+    if (msgbox_active || !ui_count) {
+        return;
+    }
+
+    list_nav_next(1);
+}
+
+void handle_list_nav_up_hold(void) {
+    if (msgbox_active || !ui_count) {
+        return;
+    }
+
+    // Don't wrap around when scrolling on hold.
+    if (current_item_index > 0) {
+        list_nav_prev(1);
+    }
+}
+
+void handle_list_nav_down_hold(void) {
+    if (msgbox_active || !ui_count) {
+        return;
+    }
+
+    // Don't wrap around when scrolling on hold.
+    if (current_item_index < ui_count - 1) {
+        list_nav_next(1);
+    }
+}
+
+void handle_list_nav_page_up(void) {
+    if (msgbox_active || !ui_count) {
+        return;
+    }
+
+    // Don't wrap around when scrolling by page.
+    int steps = MIN(theme.MUX.ITEM.COUNT, current_item_index);
+    if (steps > 0) {
+        list_nav_prev(steps);
+    }
+}
+
+void handle_list_nav_page_down(void) {
+    if (msgbox_active || !ui_count) {
+        return;
+    }
+
+    // Don't wrap around when scrolling by page.
+    int steps = MIN(theme.MUX.ITEM.COUNT, ui_count - current_item_index - 1);
+    if (steps > 0) {
+        list_nav_next(steps);
+    }
+}

--- a/common/input/list_nav.h
+++ b/common/input/list_nav.h
@@ -1,0 +1,10 @@
+#pragma once
+
+void handle_list_nav_up(void);
+void handle_list_nav_down(void);
+
+void handle_list_nav_up_hold(void);
+void handle_list_nav_down_hold(void);
+
+void handle_list_nav_page_up(void);
+void handle_list_nav_page_down(void);

--- a/muxapp/Makefile
+++ b/muxapp/Makefile
@@ -78,6 +78,7 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/ui_common.c \
 		../common/theme.c \
 		../common/input.c \
+		../common/input/list_nav.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \

--- a/muxapp/main.c
+++ b/muxapp/main.c
@@ -22,6 +22,7 @@
 #include "../common/config.h"
 #include "../common/device.h"
 #include "../common/input.h"
+#include "../common/input/list_nav.h"
 
 __thread uint64_t start_ms = 0;
 
@@ -203,12 +204,10 @@ void create_app_items() {
 void list_nav_prev(int steps) {
     play_sound("navigate", nav_sound, 0);
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index > 0) {
-            current_item_index--;
-            nav_prev(ui_group, 1);
-            nav_prev(ui_group_glyph, 1);
-            nav_prev(ui_group_panel, 1);
-        }
+        current_item_index = (current_item_index == 0) ? ui_count - 1 : current_item_index - 1;
+        nav_prev(ui_group, 1);
+        nav_prev(ui_group_glyph, 1);
+        nav_prev(ui_group_panel, 1);
     }
     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count, current_item_index, ui_pnlContent);
     nav_moved = 1;
@@ -221,12 +220,10 @@ void list_nav_next(int steps) {
         play_sound("navigate", nav_sound, 0);
     }
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index < (ui_count - 1)) {
-            current_item_index++;
-            nav_next(ui_group, 1);
-            nav_next(ui_group_glyph, 1);
-            nav_next(ui_group_panel, 1);
-        }
+        current_item_index = (current_item_index == ui_count - 1) ? 0 : current_item_index + 1;
+        nav_next(ui_group, 1);
+        nav_next(ui_group_glyph, 1);
+        nav_next(ui_group_panel, 1);
     }
     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count, current_item_index, ui_pnlContent);
     nav_moved = 1;
@@ -268,26 +265,6 @@ void handle_b() {
     mux_input_stop();
 }
 
-void handle_l1() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index >= 0 && current_item_index < ui_count) {
-        list_nav_prev(theme.MUX.ITEM.COUNT);
-    }
-}
-
-void handle_r1() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index >= 0 && current_item_index < ui_count) {
-        list_nav_next(theme.MUX.ITEM.COUNT);
-    }
-}
-
 void handle_menu() {
     if (msgbox_active) {
         return;
@@ -296,62 +273,6 @@ void handle_menu() {
     if (progress_onscreen == -1) {
         play_sound("confirm", nav_sound, 1);
         show_help();
-    }
-}
-
-void handle_up() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == 0) {
-        current_item_index = ui_count - 1;
-        nav_prev(ui_group, 1);
-        nav_prev(ui_group_glyph, 1);
-        nav_prev(ui_group_panel, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                               current_item_index, ui_pnlContent);
-        nav_moved = 1;
-    } else if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_up_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_down() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == ui_count - 1) {
-        current_item_index = 0;
-        nav_next(ui_group, 1);
-        nav_next(ui_group_glyph, 1);
-        nav_next(ui_group_panel, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                               current_item_index, ui_pnlContent);
-        nav_moved = 1;
-    } else if (current_item_index < ui_count - 1) {
-        list_nav_next(1);
-    }
-}
-
-void handle_down_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index < ui_count - 1) {
-        list_nav_next(1);
     }
 }
 
@@ -677,17 +598,19 @@ int main(int argc, char *argv[]) {
         .press_handler = {
             [MUX_INPUT_A] = handle_a,
             [MUX_INPUT_B] = handle_b,
-            [MUX_INPUT_L1] = handle_l1,
-            [MUX_INPUT_R1] = handle_r1,
-            [MUX_INPUT_DPAD_UP] = handle_up,
-            [MUX_INPUT_DPAD_DOWN] = handle_down,
             [MUX_INPUT_MENU_SHORT] = handle_menu,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .hold_handler = {
-            [MUX_INPUT_L1] = handle_l1,
-            [MUX_INPUT_R1] = handle_r1,
-            [MUX_INPUT_DPAD_UP] = handle_up_hold,
-            [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up_hold,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down_hold,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .combo = {
             {

--- a/muxarchive/Makefile
+++ b/muxarchive/Makefile
@@ -77,6 +77,7 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/ui_common.c \
 		../common/theme.c \
 		../common/input.c \
+		../common/input/list_nav.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \

--- a/muxarchive/main.c
+++ b/muxarchive/main.c
@@ -21,6 +21,7 @@
 #include "../common/config.h"
 #include "../common/device.h"
 #include "../common/input.h"
+#include "../common/input/list_nav.h"
 
 __thread uint64_t start_ms = 0;
 
@@ -194,14 +195,12 @@ void create_archive_items() {
 void list_nav_prev(int steps) {
     play_sound("navigate", nav_sound, 0);
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index > 0) {
-            current_item_index--;
-            nav_prev(ui_group, 1);
-            nav_prev(ui_group_glyph, 1);
-            nav_prev(ui_group_panel, 1);
-            nav_prev(ui_group_installed, 1);
-            nav_prev(ui_group_data, 1);
-        }
+        current_item_index = (current_item_index == 0) ? ui_count - 1 : current_item_index - 1;
+        nav_prev(ui_group, 1);
+        nav_prev(ui_group_glyph, 1);
+        nav_prev(ui_group_panel, 1);
+        nav_prev(ui_group_installed, 1);
+        nav_prev(ui_group_data, 1);
     }
     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count, current_item_index, ui_pnlContent);
     nav_moved = 1;
@@ -214,14 +213,12 @@ void list_nav_next(int steps) {
         play_sound("navigate", nav_sound, 0);
     }
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index < (ui_count - 1)) {
-            current_item_index++;
-            nav_next(ui_group, 1);
-            nav_next(ui_group_glyph, 1);
-            nav_next(ui_group_panel, 1);
-            nav_next(ui_group_installed, 1);
-            nav_next(ui_group_data, 1);
-        }
+        current_item_index = (current_item_index == ui_count - 1) ? 0 : current_item_index + 1;
+        nav_next(ui_group, 1);
+        nav_next(ui_group_glyph, 1);
+        nav_next(ui_group_panel, 1);
+        nav_next(ui_group_installed, 1);
+        nav_next(ui_group_data, 1);
     }
     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count, current_item_index, ui_pnlContent);
     nav_moved = 1;
@@ -266,26 +263,6 @@ void handle_b() {
     mux_input_stop();
 }
 
-void handle_l1() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index >= 0 && current_item_index < ui_count) {
-        list_nav_prev(theme.MUX.ITEM.COUNT);
-    }
-}
-
-void handle_r1() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index >= 0 && current_item_index < ui_count) {
-        list_nav_next(theme.MUX.ITEM.COUNT);
-    }
-}
-
 void handle_menu() {
     if (msgbox_active) {
         return;
@@ -294,64 +271,6 @@ void handle_menu() {
     if (progress_onscreen == -1) {
         play_sound("confirm", nav_sound, 1);
         show_help();
-    }
-}
-
-void handle_up() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == 0) {
-        current_item_index = ui_count - 1;
-        nav_prev(ui_group, 1);
-        nav_prev(ui_group_glyph, 1);
-        nav_prev(ui_group_panel, 1);
-        nav_prev(ui_group_installed, 1);
-        nav_prev(ui_group_data, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                               current_item_index, ui_pnlContent);
-    } else if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_up_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_down() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == ui_count - 1) {
-        current_item_index = 0;
-        nav_next(ui_group, 1);
-        nav_next(ui_group_glyph, 1);
-        nav_next(ui_group_panel, 1);
-        nav_next(ui_group_installed, 1);
-        nav_next(ui_group_data, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                               current_item_index, ui_pnlContent);
-    } else if (current_item_index < ui_count - 1) {
-        list_nav_next(1);
-    }
-}
-
-void handle_down_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index < ui_count - 1) {
-        list_nav_next(1);
     }
 }
 
@@ -667,17 +586,19 @@ int main(int argc, char *argv[]) {
         .press_handler = {
             [MUX_INPUT_A] = handle_a,
             [MUX_INPUT_B] = handle_b,
-            [MUX_INPUT_L1] = handle_l1,
-            [MUX_INPUT_R1] = handle_r1,
-            [MUX_INPUT_DPAD_UP] = handle_up,
-            [MUX_INPUT_DPAD_DOWN] = handle_down,
             [MUX_INPUT_MENU_SHORT] = handle_menu,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .hold_handler = {
-            [MUX_INPUT_L1] = handle_l1,
-            [MUX_INPUT_R1] = handle_r1,
-            [MUX_INPUT_DPAD_UP] = handle_up_hold,
-            [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up_hold,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down_hold,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .combo = {
             {

--- a/muxconfig/Makefile
+++ b/muxconfig/Makefile
@@ -77,6 +77,7 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/ui_common.c \
 		../common/theme.c \
 		../common/input.c \
+		../common/input/list_nav.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \

--- a/muxconfig/main.c
+++ b/muxconfig/main.c
@@ -21,6 +21,7 @@
 #include "../common/config.h"
 #include "../common/device.h"
 #include "../common/input.h"
+#include "../common/input/list_nav.h"
 
 __thread uint64_t start_ms = 0;
 
@@ -151,12 +152,10 @@ void init_navigation_groups() {
 void list_nav_prev(int steps) {
     play_sound("navigate", nav_sound, 0);
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index > 0) {
-            current_item_index--;
-            nav_prev(ui_group, 1);
-            nav_prev(ui_group_glyph, 1);
-            nav_prev(ui_group_panel, 1);
-        }
+        current_item_index = (current_item_index == 0) ? ui_count - 1 : current_item_index - 1;
+        nav_prev(ui_group, 1);
+        nav_prev(ui_group_glyph, 1);
+        nav_prev(ui_group_panel, 1);
     }
     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count, current_item_index, ui_pnlContent);
     nav_moved = 1;
@@ -165,12 +164,10 @@ void list_nav_prev(int steps) {
 void list_nav_next(int steps) {
     play_sound("navigate", nav_sound, 0);
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index < (ui_count)) {
-            current_item_index++;
-            nav_next(ui_group, 1);
-            nav_next(ui_group_glyph, 1);
-            nav_next(ui_group_panel, 1);
-        }
+        current_item_index = (current_item_index == ui_count - 1) ? 0 : current_item_index + 1;
+        nav_next(ui_group, 1);
+        nav_next(ui_group_glyph, 1);
+        nav_next(ui_group_panel, 1);
     }
     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count, current_item_index, ui_pnlContent);
     nav_moved = 1;
@@ -222,62 +219,6 @@ void handle_menu() {
     if (progress_onscreen == -1) {
         play_sound("confirm", nav_sound, 1);
         show_help(lv_group_get_focused(ui_group));
-    }
-}
-
-void handle_up() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == 0) {
-        current_item_index = ui_count - 1;
-        nav_prev(ui_group, 1);
-        nav_prev(ui_group_glyph, 1);
-        nav_prev(ui_group_panel, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                               current_item_index, ui_pnlContent);
-        nav_moved = 1;
-    } else if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_up_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_down() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == ui_count - 1) {
-        current_item_index = 0;
-        nav_next(ui_group, 1);
-        nav_next(ui_group_glyph, 1);
-        nav_next(ui_group_panel, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                               current_item_index, ui_pnlContent);
-        nav_moved = 1;
-    } else if (current_item_index < ui_count - 1) {
-        list_nav_next(1);
-    }
-}
-
-void handle_down_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index < ui_count - 1) {
-        list_nav_next(1);
     }
 }
 
@@ -614,13 +555,19 @@ int main(int argc, char *argv[]) {
         .press_handler = {
             [MUX_INPUT_A] = handle_a,
             [MUX_INPUT_B] = handle_b,
-            [MUX_INPUT_DPAD_UP] = handle_up,
-            [MUX_INPUT_DPAD_DOWN] = handle_down,
             [MUX_INPUT_MENU_SHORT] = handle_menu,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .hold_handler = {
-            [MUX_INPUT_DPAD_UP] = handle_up_hold,
-            [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up_hold,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down_hold,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .combo = {
             {

--- a/muxinfo/Makefile
+++ b/muxinfo/Makefile
@@ -77,6 +77,7 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/ui_common.c \
 		../common/theme.c \
 		../common/input.c \
+		../common/input/list_nav.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \

--- a/muxinfo/main.c
+++ b/muxinfo/main.c
@@ -21,6 +21,7 @@
 #include "../common/config.h"
 #include "../common/device.h"
 #include "../common/input.h"
+#include "../common/input/list_nav.h"
 
 __thread uint64_t start_ms = 0;
 
@@ -134,7 +135,7 @@ void init_navigation_groups() {
 void list_nav_prev(int steps) {
     play_sound("navigate", nav_sound, 0);
     for (int step = 0; step < steps; ++step) {
-        current_item_index = (current_item_index == 0) ? UI_COUNT - 1 : current_item_index - 1;
+        current_item_index = (current_item_index == 0) ? ui_count - 1 : current_item_index - 1;
         nav_prev(ui_group, 1);
         nav_prev(ui_group_glyph, 1);
         nav_prev(ui_group_panel, 1);
@@ -146,7 +147,7 @@ void list_nav_prev(int steps) {
 void list_nav_next(int steps) {
     play_sound("navigate", nav_sound, 0);
     for (int step = 0; step < steps; ++step) {
-        current_item_index = (current_item_index == UI_COUNT - 1) ? 0 : current_item_index + 1;
+        current_item_index = (current_item_index == ui_count - 1) ? 0 : current_item_index + 1;
         nav_next(ui_group, 1);
         nav_next(ui_group_glyph, 1);
         nav_next(ui_group_panel, 1);
@@ -196,62 +197,6 @@ void handle_menu() {
     if (progress_onscreen == -1) {
         play_sound("confirm", nav_sound, 1);
         show_help(lv_group_get_focused(ui_group));
-    }
-}
-
-void handle_up() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == 0) {
-        current_item_index = UI_COUNT - 1;
-        nav_prev(ui_group, 1);
-        nav_prev(ui_group_glyph, 1);
-        nav_prev(ui_group_panel, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
-                               current_item_index, ui_pnlContent);
-        nav_moved = 1;
-    } else if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_down() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == UI_COUNT - 1) {
-        current_item_index = 0;
-        nav_next(ui_group, 1);
-        nav_next(ui_group_glyph, 1);
-        nav_next(ui_group_panel, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
-                               current_item_index, ui_pnlContent);
-        nav_moved = 1;
-    } else if (current_item_index < UI_COUNT - 1) {
-        list_nav_next(1);
-    }
-}
-
-void handle_up_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_down_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index < ui_count - 1) {
-        list_nav_next(1);
     }
 }
 
@@ -578,13 +523,19 @@ int main(int argc, char *argv[]) {
         .press_handler = {
             [MUX_INPUT_A] = handle_a,
             [MUX_INPUT_B] = handle_b,
-            [MUX_INPUT_DPAD_UP] = handle_up,
-            [MUX_INPUT_DPAD_DOWN] = handle_down,
             [MUX_INPUT_MENU_SHORT] = handle_menu,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .hold_handler = {
-            [MUX_INPUT_DPAD_UP] = handle_up_hold,
-            [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up_hold,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down_hold,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .combo = {
             {

--- a/muxplore/Makefile
+++ b/muxplore/Makefile
@@ -78,6 +78,7 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/ui_common.c \
 		../common/theme.c \
 		../common/input.c \
+		../common/input/list_nav.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \

--- a/muxplore/main.c
+++ b/muxplore/main.c
@@ -23,6 +23,7 @@
 #include "../common/collection.h"
 #include "../common/json/json.h"
 #include "../common/input.h"
+#include "../common/input/list_nav.h"
 
 __thread uint64_t start_ms = 0;
 
@@ -1190,12 +1191,10 @@ void list_nav_prev(int steps) {
     play_sound("navigate", nav_sound, 0);
     for (int step = 0; step < steps; ++step) {
         reset_label_long_mode();
-        if (current_item_index > 0) {
-            current_item_index--;
-            nav_prev(ui_group, 1);
-            nav_prev(ui_group_glyph, 1);
-            nav_prev(ui_group_panel, 1);
-        }
+        current_item_index = (current_item_index == 0) ? ui_count - 1 : current_item_index - 1;
+        nav_prev(ui_group, 1);
+        nav_prev(ui_group_glyph, 1);
+        nav_prev(ui_group_panel, 1);
     }
     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
                            current_item_index, ui_pnlContent);
@@ -1212,12 +1211,10 @@ void list_nav_next(int steps) {
     }
     for (int step = 0; step < steps; ++step) {
         reset_label_long_mode();
-        if (current_item_index < (ui_count - 1)) {
-            current_item_index++;
-            nav_next(ui_group, 1);
-            nav_next(ui_group_glyph, 1);
-            nav_next(ui_group_panel, 1);
-        }
+        current_item_index = (current_item_index == ui_count - 1) ? 0 : current_item_index + 1;
+        nav_next(ui_group, 1);
+        nav_next(ui_group_glyph, 1);
+        nav_next(ui_group_panel, 1);
     }
     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
                            current_item_index, ui_pnlContent);
@@ -1589,26 +1586,6 @@ void handle_select() {
     }
 }
 
-void handle_l1() {
-    if (msgbox_active || ui_count == 0) {
-        return;
-    }
-
-    if (current_item_index != 0 && current_item_index < ui_count) {
-        list_nav_prev(theme.MUX.ITEM.COUNT);
-    }
-}
-
-void handle_r1() {
-    if (msgbox_active || ui_count == 0) {
-        return;
-    }
-
-    if (current_item_index >= 0 && current_item_index != ui_count - 1) {
-        list_nav_next(theme.MUX.ITEM.COUNT);
-    }
-}
-
 void handle_menu() {
     if (msgbox_active || progress_onscreen != -1 || ui_count == 0) {
         return;
@@ -1634,70 +1611,6 @@ void handle_menu() {
                   ui_lblHelpContent,
                   items[current_item_index].display_name,
                   load_content_description());
-}
-
-void handle_up() {
-    if (msgbox_active || ui_count == 0) {
-        return;
-    }
-
-    if (current_item_index == 0) {
-        reset_label_long_mode();
-        current_item_index = ui_count - 1;
-        nav_prev(ui_group, 1);
-        nav_prev(ui_group_glyph, 1);
-        nav_prev(ui_group_panel, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                               current_item_index, ui_pnlContent);
-        nav_moved = 1;
-        image_refresh("box");
-        set_label_long_mode();
-        update_file_counter();
-    } else if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_up_hold() {
-    if (msgbox_active || ui_count == 0) {
-        return;
-    }
-
-    if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_down() {
-    if (msgbox_active || ui_count == 0) {
-        return;
-    }
-
-    if (current_item_index == ui_count - 1) {
-        reset_label_long_mode();
-        current_item_index = 0;
-        nav_next(ui_group, 1);
-        nav_next(ui_group_glyph, 1);
-        nav_next(ui_group_panel, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                               current_item_index, ui_pnlContent);
-        nav_moved = 1;
-        image_refresh("box");
-        set_label_long_mode();
-        update_file_counter();
-    } else if (current_item_index < ui_count - 1) {
-        list_nav_next(1);
-    }
-}
-
-void handle_down_hold() {
-    if (msgbox_active || ui_count == 0) {
-        return;
-    }
-
-    if (current_item_index < ui_count - 1) {
-        list_nav_next(1);
-    }
 }
 
 void set_nav_text(const char *nav_a, const char *nav_b, const char *nav_x, const char *nav_y, const char *nav_menu) {
@@ -2291,19 +2204,21 @@ int main(int argc, char *argv[]) {
             [MUX_INPUT_B] = handle_b,
             [MUX_INPUT_X] = handle_x,
             [MUX_INPUT_Y] = handle_y,
-            [MUX_INPUT_L1] = handle_l1,
-            [MUX_INPUT_R1] = handle_r1,
             [MUX_INPUT_SELECT] = handle_select,
             [MUX_INPUT_START] = handle_start,
-            [MUX_INPUT_DPAD_UP] = handle_up,
-            [MUX_INPUT_DPAD_DOWN] = handle_down,
             [MUX_INPUT_MENU_SHORT] = handle_menu,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .hold_handler = {
-            [MUX_INPUT_L1] = handle_l1,
-            [MUX_INPUT_R1] = handle_r1,
-            [MUX_INPUT_DPAD_UP] = handle_up_hold,
-            [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up_hold,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down_hold,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .combo = {
             {

--- a/muxrtc/Makefile
+++ b/muxrtc/Makefile
@@ -77,6 +77,7 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/ui_common.c \
 		../common/theme.c \
 		../common/input.c \
+		../common/input/list_nav.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \

--- a/muxrtc/main.c
+++ b/muxrtc/main.c
@@ -20,6 +20,7 @@
 #include "../common/config.h"
 #include "../common/device.h"
 #include "../common/input.h"
+#include "../common/input/list_nav.h"
 
 __thread uint64_t start_ms = 0;
 
@@ -303,13 +304,11 @@ void init_navigation_groups() {
 void list_nav_prev(int steps) {
     play_sound("navigate", nav_sound, 0);
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index > 0) {
-            current_item_index--;
-            nav_prev(ui_group, 1);
-            nav_prev(ui_group_value, 1);
-            nav_prev(ui_group_glyph, 1);
-            nav_prev(ui_group_panel, 1);
-        }
+        current_item_index = (current_item_index == 0) ? ui_count - 1 : current_item_index - 1;
+        nav_prev(ui_group, 1);
+        nav_prev(ui_group_value, 1);
+        nav_prev(ui_group_glyph, 1);
+        nav_prev(ui_group_panel, 1);
     }
     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT, current_item_index, ui_pnlContent);
     nav_moved = 1;
@@ -318,13 +317,11 @@ void list_nav_prev(int steps) {
 void list_nav_next(int steps) {
     play_sound("navigate", nav_sound, 0);
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index < (UI_COUNT - 1)) {
-            current_item_index++;
-            nav_next(ui_group, 1);
-            nav_next(ui_group_value, 1);
-            nav_next(ui_group_glyph, 1);
-            nav_next(ui_group_panel, 1);
-        }
+        current_item_index = (current_item_index == ui_count - 1) ? 0 : current_item_index + 1;
+        nav_next(ui_group, 1);
+        nav_next(ui_group_value, 1);
+        nav_next(ui_group_glyph, 1);
+        nav_next(ui_group_panel, 1);
     }
     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT, current_item_index, ui_pnlContent);
     nav_moved = 1;
@@ -431,64 +428,6 @@ void handle_b() {
     write_text_to_file("/run/muos/global/boot/clock_setup", "w", INT, 0);
     write_text_to_file(MUOS_PDI_LOAD, "w", CHAR, "clock");
     mux_input_stop();
-}
-
-void handle_up() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == 0) {
-        current_item_index = UI_COUNT - 1;
-        nav_prev(ui_group, 1);
-        nav_prev(ui_group_value, 1);
-        nav_prev(ui_group_glyph, 1);
-        nav_prev(ui_group_panel, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
-                               current_item_index, ui_pnlContent);
-        nav_moved = 1;
-    } else if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_up_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_down() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == ui_count - 1) {
-        current_item_index = 0;
-        nav_next(ui_group, 1);
-        nav_next(ui_group_value, 1);
-        nav_next(ui_group_glyph, 1);
-        nav_next(ui_group_panel, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
-                               current_item_index, ui_pnlContent);
-        nav_moved = 1;
-    } else if (current_item_index < ui_count) {
-        list_nav_next(1);
-    }
-}
-
-void handle_down_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index < ui_count - 1) {
-        list_nav_next(1);
-    }
 }
 
 void handle_left() {
@@ -969,17 +908,23 @@ int main(int argc, char *argv[]) {
         .press_handler = {
             [MUX_INPUT_A] = handle_a,
             [MUX_INPUT_B] = handle_b,
-            [MUX_INPUT_DPAD_UP] = handle_up,
-            [MUX_INPUT_DPAD_DOWN] = handle_down,
             [MUX_INPUT_DPAD_LEFT] = handle_left,
             [MUX_INPUT_DPAD_RIGHT] = handle_right,
             [MUX_INPUT_MENU_SHORT] = handle_menu,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .hold_handler = {
-            [MUX_INPUT_DPAD_UP] = handle_up_hold,
-            [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
             [MUX_INPUT_DPAD_LEFT] = handle_left,
             [MUX_INPUT_DPAD_RIGHT] = handle_right,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up_hold,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down_hold,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .combo = {
             {

--- a/muxsysinfo/Makefile
+++ b/muxsysinfo/Makefile
@@ -77,6 +77,7 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/ui_common.c \
 		../common/theme.c \
 		../common/input.c \
+		../common/input/list_nav.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \

--- a/muxsysinfo/main.c
+++ b/muxsysinfo/main.c
@@ -21,6 +21,7 @@
 #include "../common/config.h"
 #include "../common/device.h"
 #include "../common/input.h"
+#include "../common/input/list_nav.h"
 
 __thread uint64_t start_ms = 0;
 
@@ -312,13 +313,11 @@ void init_navigation_groups() {
 void list_nav_prev(int steps) {
     play_sound("navigate", nav_sound, 0);
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index > 0) {
-            current_item_index--;
-            nav_prev(ui_group, 1);
-            nav_prev(ui_group_value, 1);
-            nav_prev(ui_group_glyph, 1);
-            nav_prev(ui_group_panel, 1);
-        }
+        current_item_index = (current_item_index == 0) ? ui_count - 1 : current_item_index - 1;
+        nav_prev(ui_group, 1);
+        nav_prev(ui_group_value, 1);
+        nav_prev(ui_group_glyph, 1);
+        nav_prev(ui_group_panel, 1);
     }
     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT, current_item_index, ui_pnlContent);
     nav_moved = 1;
@@ -327,13 +326,11 @@ void list_nav_prev(int steps) {
 void list_nav_next(int steps) {
     play_sound("navigate", nav_sound, 0);
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index < (UI_COUNT - 1)) {
-            current_item_index++;
-            nav_next(ui_group, 1);
-            nav_next(ui_group_value, 1);
-            nav_next(ui_group_glyph, 1);
-            nav_next(ui_group_panel, 1);
-        }
+        current_item_index = (current_item_index == ui_count - 1) ? 0 : current_item_index + 1;
+        nav_next(ui_group, 1);
+        nav_next(ui_group_value, 1);
+        nav_next(ui_group_glyph, 1);
+        nav_next(ui_group_panel, 1);
     }
     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT, current_item_index, ui_pnlContent);
     nav_moved = 1;
@@ -374,64 +371,6 @@ void handle_menu() {
     if (progress_onscreen == -1) {
         play_sound("confirm", nav_sound, 1);
         show_help(lv_group_get_focused(ui_group));
-    }
-}
-
-void handle_up() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == 0) {
-        current_item_index = UI_COUNT - 1;
-        nav_prev(ui_group, 1);
-        nav_prev(ui_group_value, 1);
-        nav_prev(ui_group_glyph, 1);
-        nav_prev(ui_group_panel, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
-                               current_item_index, ui_pnlContent);
-        nav_moved = 1;
-    } else if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_down() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == UI_COUNT - 1) {
-        current_item_index = 0;
-        nav_next(ui_group, 1);
-        nav_next(ui_group_value, 1);
-        nav_next(ui_group_glyph, 1);
-        nav_next(ui_group_panel, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, UI_COUNT,
-                               current_item_index, ui_pnlContent);
-        nav_moved = 1;
-    } else if (current_item_index < UI_COUNT - 1) {
-        list_nav_next(1);
-    }
-}
-
-void handle_up_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_down_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index < ui_count - 1) {
-        list_nav_next(1);
     }
 }
 
@@ -749,13 +688,19 @@ int main(int argc, char *argv[]) {
         .press_handler = {
             [MUX_INPUT_A] = handle_a,
             [MUX_INPUT_B] = handle_b,
-            [MUX_INPUT_DPAD_UP] = handle_up,
-            [MUX_INPUT_DPAD_DOWN] = handle_down,
             [MUX_INPUT_MENU_SHORT] = handle_menu,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .hold_handler = {
-            [MUX_INPUT_DPAD_UP] = handle_up_hold,
-            [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up_hold,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down_hold,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .combo = {
             {

--- a/muxtimezone/Makefile
+++ b/muxtimezone/Makefile
@@ -77,6 +77,7 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/ui_common.c \
 		../common/theme.c \
 		../common/input.c \
+		../common/input/list_nav.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \

--- a/muxtimezone/main.c
+++ b/muxtimezone/main.c
@@ -21,6 +21,7 @@
 #include "../common/config.h"
 #include "../common/device.h"
 #include "../common/input.h"
+#include "../common/input/list_nav.h"
 
 __thread uint64_t start_ms = 0;
 
@@ -92,12 +93,10 @@ void create_timezone_items() {
 void list_nav_prev(int steps) {
     play_sound("navigate", nav_sound, 0);
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index > 0) {
-            current_item_index--;
-            nav_prev(ui_group, 1);
-            nav_prev(ui_group_glyph, 1);
-            nav_prev(ui_group_panel, 1);
-        }
+        current_item_index = (current_item_index == 0) ? ui_count - 1 : current_item_index - 1;
+        nav_prev(ui_group, 1);
+        nav_prev(ui_group_glyph, 1);
+        nav_prev(ui_group_panel, 1);
     }
     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count, current_item_index, ui_pnlContent);
     nav_moved = 1;
@@ -110,12 +109,10 @@ void list_nav_next(int steps) {
         play_sound("navigate", nav_sound, 0);
     }
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index < (ui_count - 1)) {
-            current_item_index++;
-            nav_next(ui_group, 1);
-            nav_next(ui_group_glyph, 1);
-            nav_next(ui_group_panel, 1);
-        }
+        current_item_index = (current_item_index == ui_count - 1) ? 0 : current_item_index + 1;
+        nav_next(ui_group, 1);
+        nav_next(ui_group_glyph, 1);
+        nav_next(ui_group_panel, 1);
     }
     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count, current_item_index, ui_pnlContent);
     nav_moved = 1;
@@ -151,72 +148,6 @@ void handle_b() {
 
     play_sound("back", nav_sound, 1);
     mux_input_stop();
-}
-
-void handle_l1() {
-    if (current_item_index >= 0 && current_item_index < ui_count) {
-        list_nav_prev(theme.MUX.ITEM.COUNT);
-    }
-}
-
-void handle_r1() {
-    if (current_item_index >= 0 && current_item_index < ui_count) {
-        list_nav_next(theme.MUX.ITEM.COUNT);
-    }
-}
-
-void handle_up() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == 0) {
-        current_item_index = ui_count - 1;
-        nav_prev(ui_group, 1);
-        nav_prev(ui_group_glyph, 1);
-        nav_prev(ui_group_panel, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                               current_item_index, ui_pnlContent);
-    } else if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_up_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index > 0) {
-        list_nav_prev(1);
-    }
-}
-
-void handle_down() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index == ui_count - 1) {
-        current_item_index = 0;
-        nav_next(ui_group, 1);
-        nav_next(ui_group_glyph, 1);
-        nav_next(ui_group_panel, 1);
-        update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                               current_item_index, ui_pnlContent);
-    } else if (current_item_index < ui_count) {
-        list_nav_next(1);
-    }
-}
-
-void handle_down_hold() {
-    if (msgbox_active) {
-        return;
-    }
-
-    if (current_item_index < ui_count - 1) {
-        list_nav_next(1);
-    }
 }
 
 void handle_menu() {
@@ -535,17 +466,19 @@ int main(int argc, char *argv[]) {
         .press_handler = {
             [MUX_INPUT_A] = handle_a,
             [MUX_INPUT_B] = handle_b,
-            [MUX_INPUT_L1] = handle_l1,
-            [MUX_INPUT_R1] = handle_r1,
-            [MUX_INPUT_DPAD_UP] = handle_up,
-            [MUX_INPUT_DPAD_DOWN] = handle_down,
             [MUX_INPUT_MENU_SHORT] = handle_menu,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .hold_handler = {
-            [MUX_INPUT_L1] = handle_l1,
-            [MUX_INPUT_R1] = handle_r1,
-            [MUX_INPUT_DPAD_UP] = handle_up_hold,
-            [MUX_INPUT_DPAD_DOWN] = handle_down_hold,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up_hold,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down_hold,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
         },
         .combo = {
             {

--- a/muxtweakgen/Makefile
+++ b/muxtweakgen/Makefile
@@ -76,6 +76,8 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/common.c \
 		../common/ui_common.c \
 		../common/theme.c \
+		../common/input.c \
+		../common/input/list_nav.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \

--- a/muxtweakgen/main.c
+++ b/muxtweakgen/main.c
@@ -20,19 +20,14 @@
 #include "../common/ui_common.h"
 #include "../common/config.h"
 #include "../common/device.h"
+#include "../common/input.h"
+#include "../common/input/list_nav.h"
 
 __thread uint64_t start_ms = 0;
 
 char *mux_prog;
 static int js_fd;
 static int js_fd_sys;
-
-int NAV_DPAD_HOR;
-int NAV_ANLG_HOR;
-int NAV_DPAD_VER;
-int NAV_ANLG_VER;
-int NAV_A;
-int NAV_B;
 
 int turbo_mode = 0;
 int msgbox_active = 0;
@@ -939,13 +934,11 @@ void init_navigation_groups() {
 void list_nav_prev(int steps) {
     play_sound("navigate", nav_sound, 0);
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index > 0) {
-            current_item_index--;
-            nav_prev(ui_group, 1);
-            nav_prev(ui_group_value, 1);
-            nav_prev(ui_group_glyph, 1);
-            nav_prev(ui_group_panel, 1);
-        }
+        current_item_index = (current_item_index == 0) ? ui_count - 1 : current_item_index - 1;
+        nav_prev(ui_group, 1);
+        nav_prev(ui_group_value, 1);
+        nav_prev(ui_group_glyph, 1);
+        nav_prev(ui_group_panel, 1);
     }
     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count, current_item_index, ui_pnlContent);
     nav_moved = 1;
@@ -954,390 +947,176 @@ void list_nav_prev(int steps) {
 void list_nav_next(int steps) {
     play_sound("navigate", nav_sound, 0);
     for (int step = 0; step < steps; ++step) {
-        if (current_item_index < (ui_count)) {
-            current_item_index++;
-            nav_next(ui_group, 1);
-            nav_next(ui_group_value, 1);
-            nav_next(ui_group_glyph, 1);
-            nav_next(ui_group_panel, 1);
-        }
+        current_item_index = (current_item_index == ui_count - 1) ? 0 : current_item_index + 1;
+        nav_next(ui_group, 1);
+        nav_next(ui_group_value, 1);
+        nav_next(ui_group_glyph, 1);
+        nav_next(ui_group_panel, 1);
     }
     update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count, current_item_index, ui_pnlContent);
     nav_moved = 1;
 }
 
-void joystick_task() {
-    struct input_event ev;
-    int epoll_fd;
-    struct epoll_event event, events[device.DEVICE.EVENT];
-
-    int JOYUP_pressed = 0;
-    int JOYDOWN_pressed = 0;
-    int JOYHOTKEY_pressed = 0;
-    int JOYHOTKEY_screenshot = 0;
-
-    uint32_t nav_hold = 0; // Delay (millis) before scrolling again when up/down is held.
-    uint32_t nav_tick = 0; // Clock tick (millis) when the navigation list was last scrolled.
-
-    epoll_fd = epoll_create1(0);
-    if (epoll_fd == -1) {
-        perror("Error creating EPOLL instance");
+void handle_option_prev(void) {
+    if (msgbox_active) {
         return;
     }
 
-    event.events = EPOLLIN;
-    event.data.fd = js_fd;
-    if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, js_fd, &event) == -1) {
-        perror("Error with EPOLL controller");
+    play_sound("navigate", nav_sound, 0);
+    struct _lv_obj_t *element_focused = lv_group_get_focused(ui_group);
+    if (element_focused == ui_lblHidden) {
+        decrease_option_value(ui_droHidden,
+                              &hidden_current,
+                              hidden_total);
+    } else if (element_focused == ui_lblBGM) {
+        decrease_option_value(ui_droBGM,
+                              &bgm_current,
+                              bgm_total);
+    } else if (element_focused == ui_lblSound) {
+        decrease_option_value(ui_droSound,
+                              &sound_current,
+                              sound_total);
+    } else if (element_focused == ui_lblStartup) {
+        decrease_option_value(ui_droStartup,
+                              &startup_current,
+                              startup_total);
+    } else if (element_focused == ui_lblColour) {
+        decrease_option_value(ui_droColour,
+                              &colour_current,
+                              colour_total);
+    } else if (element_focused == ui_lblBrightness) {
+        decrease_option_value(ui_droBrightness,
+                              &brightness_current,
+                              brightness_total);
+    } else if (element_focused == ui_lblHDMI) {
+        decrease_option_value(ui_droHDMI,
+                              &hdmi_current,
+                              hdmi_total);
+    } else if (element_focused == ui_lblShutdown) {
+        decrease_option_value(ui_droShutdown,
+                              &shutdown_current,
+                              shutdown_total);
+    } else if (element_focused == ui_lblBattery) {
+        decrease_option_value(ui_droBattery,
+                              &battery_current,
+                              battery_total);
+    } else if (element_focused == ui_lblIdleDisplay) {
+        decrease_option_value(ui_droIdleDisplay,
+                              &idle_display_current,
+                              idle_display_total);
+    } else if (element_focused == ui_lblIdleSleep) {
+        decrease_option_value(ui_droIdleSleep,
+                              &idle_sleep_current,
+                              idle_sleep_total);
+    }
+}
+
+void handle_option_next(void) {
+    if (msgbox_active) {
         return;
     }
 
-    event.data.fd = js_fd_sys;
-    if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, js_fd_sys, &event) == -1) {
-        perror("Error with EPOLL controller");
+    play_sound("navigate", nav_sound, 0);
+    struct _lv_obj_t *element_focused = lv_group_get_focused(ui_group);
+    if (element_focused == ui_lblHidden) {
+        decrease_option_value(ui_droHidden,
+                              &hidden_current,
+                              hidden_total);
+    } else if (element_focused == ui_lblBGM) {
+        increase_option_value(ui_droBGM,
+                              &bgm_current,
+                              bgm_total);
+    } else if (element_focused == ui_lblSound) {
+        increase_option_value(ui_droSound,
+                              &sound_current,
+                              sound_total);
+    } else if (element_focused == ui_lblStartup) {
+        increase_option_value(ui_droStartup,
+                              &startup_current,
+                              startup_total);
+    } else if (element_focused == ui_lblColour) {
+        increase_option_value(ui_droColour,
+                              &colour_current,
+                              colour_total);
+    } else if (element_focused == ui_lblBrightness) {
+        increase_option_value(ui_droBrightness,
+                              &brightness_current,
+                              brightness_total);
+    } else if (element_focused == ui_lblHDMI) {
+        increase_option_value(ui_droHDMI,
+                              &hdmi_current,
+                              hdmi_total);
+    } else if (element_focused == ui_lblShutdown) {
+        increase_option_value(ui_droShutdown,
+                              &shutdown_current,
+                              shutdown_total);
+    } else if (element_focused == ui_lblBattery) {
+        increase_option_value(ui_droBattery,
+                              &battery_current,
+                              battery_total);
+    } else if (element_focused == ui_lblIdleDisplay) {
+        increase_option_value(ui_droIdleDisplay,
+                              &idle_display_current,
+                              idle_display_total);
+    } else if (element_focused == ui_lblIdleSleep) {
+        increase_option_value(ui_droIdleSleep,
+                              &idle_sleep_current,
+                              idle_sleep_total);
+    }
+}
+
+void handle_confirm(void) {
+    if (msgbox_active) {
         return;
     }
 
-    while (1) {
-        int num_events = epoll_wait(epoll_fd, events, device.DEVICE.EVENT, config.SETTINGS.ADVANCED.ACCELERATE);
-        if (num_events == -1) {
-            perror("Error with EPOLL wait event timer");
-            continue;
-        }
+    struct _lv_obj_t *element_focused = lv_group_get_focused(ui_group);
+    if (element_focused == ui_lblInterface) {
+        play_sound("confirm", nav_sound, 1);
+        save_tweak_options();
 
-        for (int i = 0; i < num_events; i++) {
-            if (events[i].data.fd == js_fd_sys) {
-                ssize_t ret = read(js_fd_sys, &ev, sizeof(struct input_event));
-                if (ret == -1) {
-                    perror("Error reading input");
-                    continue;
-                }
-                if (JOYHOTKEY_pressed == 1 && ev.type == EV_KEY && ev.value == 1 &&
-                    (ev.code == device.RAW_INPUT.BUTTON.POWER_SHORT || ev.code == device.RAW_INPUT.BUTTON.POWER_LONG)) {
-                    JOYHOTKEY_screenshot = 1;
-                }
-            } else if (events[i].data.fd == js_fd) {
-                ssize_t ret = read(js_fd, &ev, sizeof(struct input_event));
-                if (ret == -1) {
-                    perror("Error reading input");
-                    continue;
-                }
+        load_mux("visual");
+        mux_input_stop();
+    } else if (element_focused == ui_lblAdvanced) {
+        play_sound("confirm", nav_sound, 1);
+        save_tweak_options();
 
-                struct _lv_obj_t *element_focused = lv_group_get_focused(ui_group);
-                switch (ev.type) {
-                    case EV_KEY:
-                        if (ev.value == 1) {
-                            if (msgbox_active) {
-                                if (ev.code == NAV_B) {
-                                    play_sound("confirm", nav_sound, 1);
-                                    msgbox_active = 0;
-                                    progress_onscreen = 0;
-                                    lv_obj_add_flag(msgbox_element, LV_OBJ_FLAG_HIDDEN);
-                                }
-                            } else {
-                                if (ev.code == device.RAW_INPUT.BUTTON.MENU_LONG) {
-                                    JOYHOTKEY_pressed = 1;
-                                    JOYHOTKEY_screenshot = 0;
-                                } else if (ev.code == NAV_A || ev.code == device.RAW_INPUT.ANALOG.LEFT.CLICK) {
-                                    play_sound("confirm", nav_sound, 1);
-                                    if (element_focused == ui_lblHidden) {
-                                        increase_option_value(ui_droHidden,
-                                                              &hidden_current,
-                                                              hidden_total);
-                                    } else if (element_focused == ui_lblBGM) {
-                                        increase_option_value(ui_droBGM,
-                                                              &bgm_current,
-                                                              bgm_total);
-                                    } else if (element_focused == ui_lblSound) {
-                                        increase_option_value(ui_droSound,
-                                                              &sound_current,
-                                                              sound_total);
-                                    } else if (element_focused == ui_lblStartup) {
-                                        increase_option_value(ui_droStartup,
-                                                              &startup_current,
-                                                              startup_total);
-                                    } else if (element_focused == ui_lblColour) {
-                                        increase_option_value(ui_droColour,
-                                                              &colour_current,
-                                                              colour_total);
-                                    } else if (element_focused == ui_lblBrightness) {
-                                        increase_option_value(ui_droBrightness,
-                                                              &brightness_current,
-                                                              brightness_total);
-                                    } else if (element_focused == ui_lblHDMI) {
-                                        increase_option_value(ui_droHDMI,
-                                                              &hdmi_current,
-                                                              hdmi_total);
-                                    } else if (element_focused == ui_lblShutdown) {
-                                        increase_option_value(ui_droShutdown,
-                                                              &shutdown_current,
-                                                              shutdown_total);
-                                    } else if (element_focused == ui_lblBattery) {
-                                        increase_option_value(ui_droBattery,
-                                                              &battery_current,
-                                                              battery_total);
-                                    } else if (element_focused == ui_lblIdleDisplay) {
-                                        increase_option_value(ui_droIdleDisplay,
-                                                              &idle_display_current,
-                                                              idle_display_total);
-                                    } else if (element_focused == ui_lblIdleSleep) {
-                                        increase_option_value(ui_droIdleSleep,
-                                                              &idle_sleep_current,
-                                                              idle_sleep_total);
-                                    } else if (element_focused == ui_lblInterface) {
-                                        save_tweak_options();
+        load_mux("tweakadv");
+        mux_input_stop();
+    } else {
+        handle_option_next();
+    }
+}
 
-                                        load_mux("visual");
-                                        return;
-                                    } else if (element_focused == ui_lblAdvanced) {
-                                        save_tweak_options();
+void handle_back(void) {
+    if (msgbox_active) {
+        play_sound("confirm", nav_sound, 1);
+        msgbox_active = 0;
+        progress_onscreen = 0;
+        lv_obj_add_flag(msgbox_element, LV_OBJ_FLAG_HIDDEN);
+        return;
+    }
 
-                                        load_mux("tweakadv");
-                                        return;
-                                    }
-                                } else if (ev.code == NAV_B) {
-                                    play_sound("back", nav_sound, 1);
-                                    input_disable = 1;
+    play_sound("back", nav_sound, 1);
+    input_disable = 1;
 
-                                    lv_label_set_text(ui_lblMessage, TG("Saving Changes"));
-                                    lv_obj_clear_flag(ui_pnlMessage, LV_OBJ_FLAG_HIDDEN);
+    lv_label_set_text(ui_lblMessage, TG("Saving Changes"));
+    lv_obj_clear_flag(ui_pnlMessage, LV_OBJ_FLAG_HIDDEN);
 
-                                    save_tweak_options();
+    save_tweak_options();
 
-                                    write_text_to_file(MUOS_PDI_LOAD, "w", CHAR, "general");
-                                    return;
-                                } else if (ev.code == device.RAW_INPUT.BUTTON.L1) {
-                                    if (element_focused == ui_lblBrightness) {
-                                        for (i = 1; i <= 10; i++) {
-                                            decrease_option_value(ui_droBrightness,
-                                                                  &brightness_current,
-                                                                  brightness_total);
-                                        }
-                                    }
-                                } else if (ev.code == device.RAW_INPUT.BUTTON.R1) {
-                                    if (element_focused == ui_lblBrightness) {
-                                        for (i = 1; i <= 10; i++) {
-                                            increase_option_value(ui_droBrightness,
-                                                                  &brightness_current,
-                                                                  brightness_total);
-                                        }
-                                    }
-                                }
-                            }
-                        } else {
-                            if ((ev.code == device.RAW_INPUT.BUTTON.MENU_SHORT ||
-                                 ev.code == device.RAW_INPUT.BUTTON.MENU_LONG) && !JOYHOTKEY_screenshot) {
-                                JOYHOTKEY_pressed = 0;
-                                if (progress_onscreen == -1) {
-                                    play_sound("confirm", nav_sound, 1);
-                                    show_help(element_focused);
-                                }
-                            }
-                        }
-                        break;
-                    case EV_ABS:
-                        if (msgbox_active) {
-                            break;
-                        }
-                        if (ev.code == NAV_DPAD_VER || ev.code == NAV_ANLG_VER) {
-                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
-                                if (current_item_index == 0) {
-                                    current_item_index = ui_count - 1;
-                                    nav_prev(ui_group, 1);
-                                    nav_prev(ui_group_value, 1);
-                                    nav_prev(ui_group_glyph, 1);
-                                    nav_prev(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                    nav_moved = 1;
-                                } else if (current_item_index > 0) {
-                                    list_nav_prev(1);
-                                }
-                                JOYUP_pressed = 1;
-                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
-                                nav_tick = mux_tick();
-                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
-                                if (current_item_index == ui_count - 1) {
-                                    current_item_index = 0;
-                                    nav_next(ui_group, 1);
-                                    nav_next(ui_group_value, 1);
-                                    nav_next(ui_group_glyph, 1);
-                                    nav_next(ui_group_panel, 1);
-                                    update_scroll_position(theme.MUX.ITEM.COUNT, theme.MUX.ITEM.PANEL, ui_count,
-                                                           current_item_index, ui_pnlContent);
-                                    nav_moved = 1;
-                                } else if (current_item_index < ui_count - 1) {
-                                    list_nav_next(1);
-                                }
-                                JOYDOWN_pressed = 1;
-                                nav_hold = 2 * config.SETTINGS.ADVANCED.ACCELERATE;
-                                nav_tick = mux_tick();
-                            } else {
-                                JOYUP_pressed = 0;
-                                JOYDOWN_pressed = 0;
-                            }
-                        } else if (ev.code == NAV_DPAD_HOR || ev.code == NAV_ANLG_HOR) {
-                            if (ev.value == -device.INPUT.AXIS || ev.value == -1) {
-                                play_sound("navigate", nav_sound, 0);
-                                if (element_focused == ui_lblHidden) {
-                                    decrease_option_value(ui_droHidden,
-                                                          &hidden_current,
-                                                          hidden_total);
-                                } else if (element_focused == ui_lblBGM) {
-                                    decrease_option_value(ui_droBGM,
-                                                          &bgm_current,
-                                                          bgm_total);
-                                } else if (element_focused == ui_lblSound) {
-                                    decrease_option_value(ui_droSound,
-                                                          &sound_current,
-                                                          sound_total);
-                                } else if (element_focused == ui_lblStartup) {
-                                    decrease_option_value(ui_droStartup,
-                                                          &startup_current,
-                                                          startup_total);
-                                } else if (element_focused == ui_lblColour) {
-                                    decrease_option_value(ui_droColour,
-                                                          &colour_current,
-                                                          colour_total);
-                                } else if (element_focused == ui_lblBrightness) {
-                                    decrease_option_value(ui_droBrightness,
-                                                          &brightness_current,
-                                                          brightness_total);
-                                } else if (element_focused == ui_lblHDMI) {
-                                    decrease_option_value(ui_droHDMI,
-                                                          &hdmi_current,
-                                                          hdmi_total);
-                                } else if (element_focused == ui_lblShutdown) {
-                                    decrease_option_value(ui_droShutdown,
-                                                          &shutdown_current,
-                                                          shutdown_total);
-                                } else if (element_focused == ui_lblBattery) {
-                                    decrease_option_value(ui_droBattery,
-                                                          &battery_current,
-                                                          battery_total);
-                                } else if (element_focused == ui_lblIdleDisplay) {
-                                    decrease_option_value(ui_droIdleDisplay,
-                                                          &idle_display_current,
-                                                          idle_display_total);
-                                } else if (element_focused == ui_lblIdleSleep) {
-                                    decrease_option_value(ui_droIdleSleep,
-                                                          &idle_sleep_current,
-                                                          idle_sleep_total);
-                                }
-                            } else if (ev.value == device.INPUT.AXIS || ev.value == 1) {
-                                play_sound("navigate", nav_sound, 0);
-                                if (element_focused == ui_lblHidden) {
-                                    decrease_option_value(ui_droHidden,
-                                                          &hidden_current,
-                                                          hidden_total);
-                                } else if (element_focused == ui_lblBGM) {
-                                    increase_option_value(ui_droBGM,
-                                                          &bgm_current,
-                                                          bgm_total);
-                                } else if (element_focused == ui_lblSound) {
-                                    increase_option_value(ui_droSound,
-                                                          &sound_current,
-                                                          sound_total);
-                                } else if (element_focused == ui_lblStartup) {
-                                    increase_option_value(ui_droStartup,
-                                                          &startup_current,
-                                                          startup_total);
-                                } else if (element_focused == ui_lblColour) {
-                                    increase_option_value(ui_droColour,
-                                                          &colour_current,
-                                                          colour_total);
-                                } else if (element_focused == ui_lblBrightness) {
-                                    increase_option_value(ui_droBrightness,
-                                                          &brightness_current,
-                                                          brightness_total);
-                                } else if (element_focused == ui_lblHDMI) {
-                                    increase_option_value(ui_droHDMI,
-                                                          &hdmi_current,
-                                                          hdmi_total);
-                                } else if (element_focused == ui_lblShutdown) {
-                                    increase_option_value(ui_droShutdown,
-                                                          &shutdown_current,
-                                                          shutdown_total);
-                                } else if (element_focused == ui_lblBattery) {
-                                    increase_option_value(ui_droBattery,
-                                                          &battery_current,
-                                                          battery_total);
-                                } else if (element_focused == ui_lblIdleDisplay) {
-                                    increase_option_value(ui_droIdleDisplay,
-                                                          &idle_display_current,
-                                                          idle_display_total);
-                                } else if (element_focused == ui_lblIdleSleep) {
-                                    increase_option_value(ui_droIdleSleep,
-                                                          &idle_sleep_current,
-                                                          idle_sleep_total);
-                                }
-                            }
-                        }
-                        break;
-                    default:
-                        break;
-                }
-            }
-            refresh_screen();
-        }
+    write_text_to_file(MUOS_PDI_LOAD, "w", CHAR, "general");
+    mux_input_stop();
+}
 
-        // Handle menu acceleration.
-        if (mux_tick() - nav_tick >= nav_hold) {
-            if (JOYUP_pressed && current_item_index > 0) {
-                list_nav_prev(1);
-                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
-                nav_tick = mux_tick();
-            } else if (JOYDOWN_pressed && current_item_index < ui_count - 1) {
-                list_nav_next(1);
-                nav_hold = config.SETTINGS.ADVANCED.ACCELERATE;
-                nav_tick = mux_tick();
-            }
-        }
+void handle_help(void) {
+    if (msgbox_active) {
+        return;
+    }
 
-        if (!atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.SETTINGS.ADVANCED.HDMIOUTPUT) {
-            if (ev.type == EV_KEY && ev.value == 1 &&
-                (ev.code == device.RAW_INPUT.BUTTON.VOLUME_DOWN || ev.code == device.RAW_INPUT.BUTTON.VOLUME_UP)) {
-                if (JOYHOTKEY_pressed) {
-                    progress_onscreen = 1;
-                    lv_obj_add_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
-                    lv_obj_clear_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
-                    lv_label_set_text(ui_icoProgressBrightness, "\uF185");
-                    lv_bar_set_value(ui_barProgressBrightness, atoi(read_text_from_file(BRIGHT_PERC)), LV_ANIM_OFF);
-                } else {
-                    progress_onscreen = 2;
-                    lv_obj_add_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
-                    lv_obj_clear_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
-                    int volume = atoi(read_text_from_file(VOLUME_PERC));
-                    switch (volume) {
-                        default:
-                        case 0:
-                            lv_label_set_text(ui_icoProgressVolume, "\uF6A9");
-                            break;
-                        case 1 ... 46:
-                            lv_label_set_text(ui_icoProgressVolume, "\uF026");
-                            break;
-                        case 47 ... 71:
-                            lv_label_set_text(ui_icoProgressVolume, "\uF027");
-                            break;
-                        case 72 ... 100:
-                            lv_label_set_text(ui_icoProgressVolume, "\uF028");
-                            break;
-                    }
-                    lv_bar_set_value(ui_barProgressVolume, volume, LV_ANIM_OFF);
-                }
-            }
-        }
-
-        if (file_exist("/tmp/hdmi_do_refresh")) {
-            if (atoi(read_text_from_file("/tmp/hdmi_do_refresh"))) {
-                remove("/tmp/hdmi_do_refresh");
-                lv_obj_invalidate(ui_pnlHeader);
-                lv_obj_invalidate(ui_pnlContent);
-                lv_obj_invalidate(ui_pnlFooter);
-            }
-        }
-
-        refresh_screen();
+    if (progress_onscreen == -1) {
+        play_sound("confirm", nav_sound, 1);
+        show_help(lv_group_get_focused(ui_group));
     }
 }
 
@@ -1581,31 +1360,6 @@ int main(int argc, char *argv[]) {
 
     lv_label_set_text(ui_lblDatetime, get_datetime());
 
-    switch (theme.MISC.NAVIGATION_TYPE) {
-        case 1:
-            NAV_DPAD_HOR = device.RAW_INPUT.DPAD.DOWN;
-            NAV_ANLG_HOR = device.RAW_INPUT.ANALOG.LEFT.DOWN;
-            NAV_DPAD_VER = device.RAW_INPUT.DPAD.RIGHT;
-            NAV_ANLG_VER = device.RAW_INPUT.ANALOG.LEFT.RIGHT;
-            break;
-        default:
-            NAV_DPAD_HOR = device.RAW_INPUT.DPAD.RIGHT;
-            NAV_ANLG_HOR = device.RAW_INPUT.ANALOG.LEFT.RIGHT;
-            NAV_DPAD_VER = device.RAW_INPUT.DPAD.DOWN;
-            NAV_ANLG_VER = device.RAW_INPUT.ANALOG.LEFT.DOWN;
-    }
-
-    switch (config.SETTINGS.ADVANCED.SWAP) {
-        case 1:
-            NAV_A = device.RAW_INPUT.BUTTON.B;
-            NAV_B = device.RAW_INPUT.BUTTON.A;
-            break;
-        default:
-            NAV_A = device.RAW_INPUT.BUTTON.A;
-            NAV_B = device.RAW_INPUT.BUTTON.B;
-            break;
-    }
-
     current_wall = load_wallpaper(ui_screen, NULL, theme.MISC.ANIMATED_BACKGROUND, theme.MISC.RANDOM_BACKGROUND);
     if (strlen(current_wall) > 3) {
         if (theme.MISC.RANDOM_BACKGROUND) {
@@ -1698,7 +1452,56 @@ int main(int argc, char *argv[]) {
     direct_to_previous();
 
     refresh_screen();
-    joystick_task();
+
+    mux_input_options input_opts = {
+        .gamepad_fd = js_fd,
+        .system_fd = js_fd_sys,
+        .max_idle_ms = 16 /* ~60 FPS */,
+        .swap_btn = config.SETTINGS.ADVANCED.SWAP,
+        .swap_axis = (theme.MISC.NAVIGATION_TYPE == 1),
+        .stick_nav = true,
+        .press_handler = {
+            [MUX_INPUT_A] = handle_confirm,
+            [MUX_INPUT_B] = handle_back,
+            [MUX_INPUT_DPAD_LEFT] = handle_option_prev,
+            [MUX_INPUT_DPAD_RIGHT] = handle_option_next,
+            [MUX_INPUT_MENU_SHORT] = handle_help,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
+        },
+        .hold_handler = {
+            [MUX_INPUT_DPAD_LEFT] = handle_option_prev,
+            [MUX_INPUT_DPAD_RIGHT] = handle_option_next,
+            // List navigation:
+            [MUX_INPUT_DPAD_UP] = handle_list_nav_up_hold,
+            [MUX_INPUT_DPAD_DOWN] = handle_list_nav_down_hold,
+            [MUX_INPUT_L1] = handle_list_nav_page_up,
+            [MUX_INPUT_R1] = handle_list_nav_page_down,
+        },
+        .combo = {
+            {
+                .type_mask = BIT(MUX_INPUT_MENU_LONG) | BIT(MUX_INPUT_VOL_UP),
+                .press_handler = ui_common_handle_bright,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_MENU_LONG) | BIT(MUX_INPUT_VOL_DOWN),
+                .press_handler = ui_common_handle_bright,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_VOL_UP),
+                .press_handler = ui_common_handle_vol,
+            },
+            {
+                .type_mask = BIT(MUX_INPUT_VOL_DOWN),
+                .press_handler = ui_common_handle_vol,
+            },
+        },
+        .idle_handler = ui_common_handle_idle,
+    };
+    mux_input_task(&input_opts);
 
     close(js_fd);
     close(js_fd_sys);


### PR DESCRIPTION
This is a second attempt at #88, without the cleanups bogging it down, as well as an implementation requiring less changes to the existing apps (and less code overall!). This PR is the last step to make it easy to port all the remaining apps over (with minimal risk of introducing new scrolling bugs in the process).

The `list_nav.h` input handlers standardize on the following behavior:

* Up/Down (press): Scroll one item at a time, wrapping around at the start/end.
* Up/Down (hold): Scroll one item at a time, but stop scrolling at the start/end.
* L1/R1 (press/hold): Scroll one page of items at a time, stopping at the start/end.

@GrumpyGopher The only significant app change required to use these handlers is making `list_nav_prev`/`list_nav_next` wrap around at the end like the underlying LVGL functions do. Some of the muX apps already do this, but some require modifications like [this one for `muxapp`](https://github.com/MustardOS/frontend/pull/89/files#diff-831dee9e6f00f45c0e157d66bac5fb6b46498dc8f0c44dc80b15839e2f9b4e43). (I'll put together a PR showing a clean example of porting an app entirely from the old `joystick_task` to the new input library later this evening.)

---

I also ported over `muxtweakgen` to the new input library as a clean example of how to migrate over a muX app that's currently using the old pattern (custom input handling reimplemented in each app).

The migration process various a bit from app to app, but generally looks [something like this](https://github.com/MustardOS/frontend/pull/89/commits/b5d7441e309ad40af1b0f6d55954814eab1763d3?diff=split&w=0):

1. Delete the entire `joystick_task` function, as well as [the `NAV_*` variables](https://github.com/MustardOS/frontend/pull/89/commits/b5d7441e309ad40af1b0f6d55954814eab1763d3?diff=split&w=0#diff-7bf2636c808f333a1bfae40574ea30d576dee8ffa7d302c777c62eee9db9feafL30-L36) and [related code](https://github.com/MustardOS/frontend/pull/89/commits/b5d7441e309ad40af1b0f6d55954814eab1763d3?diff=split&w=0#diff-7bf2636c808f333a1bfae40574ea30d576dee8ffa7d302c777c62eee9db9feafL1584-L1608). Most of this stuff won't need to come back. (In particular, apps now longer need to duplicate the event loop, evdev key translation, menu acceleration, brightness/volume hotkeys, screen refresh, and HDMI switch detection. They will also get the new, Hall-friendly stick handling and generalized key repeat/combo support. 😄)
2. Check if `list_nav_prev` and `list_nav_next` already wrap around at the ends of the list. If they don't, [update them to wrap around](https://github.com/MustardOS/frontend/pull/89/commits/b5d7441e309ad40af1b0f6d55954814eab1763d3?diff=split&w=0#diff-7bf2636c808f333a1bfae40574ea30d576dee8ffa7d302c777c62eee9db9feafL942-R954).
3. **The interesting part:** Write "handler" functions for the per-app behavior that was lurking inside `joystick_task`.
    * The logic you're looking to move over exists in the various cases of the `switch (ev.task)` statements.
    * You can ignore any cases that just update the `JOYPAD*` variables.
    * You can ignore the handlers for Up, Down, L1, R1, and Volume keys, as reusable handlers for these now exist elsewhere.
    * You can call the handlers whatever you like. The apps I ported previously just name them after the buttons (like `handle_a`), but I've come started thinking it's clearer to name them after what they do.
    * This app has ends up with these custom handlers:
      * [`handle_option_prev`](https://github.com/MustardOS/frontend/blob/b5d7441e309ad40af1b0f6d55954814eab1763d3/muxtweakgen/main.c#L960-L1012) (Left)
      * [`handle_option_next`](https://github.com/MustardOS/frontend/blob/b5d7441e309ad40af1b0f6d55954814eab1763d3/muxtweakgen/main.c#L1014-L1066) (Right)
      * [`handle_confirm`](https://github.com/MustardOS/frontend/blob/b5d7441e309ad40af1b0f6d55954814eab1763d3/muxtweakgen/main.c#L1068-L1089) (A)
      * [`handle_back`](https://github.com/MustardOS/frontend/blob/b5d7441e309ad40af1b0f6d55954814eab1763d3/muxtweakgen/main.c#L1091-L1110) (B)
      * [`handle_help`](https://github.com/MustardOS/frontend/blob/b5d7441e309ad40af1b0f6d55954814eab1763d3/muxtweakgen/main.c#L1112-L1121) (Menu)
    * Things to be aware of:
      * There's currently only one set of handlers, so they all have the same boilerplate to do nothing when a message box is open. (Maybe post-Banana, we could allow switching the handler set when a message box activates? IDK, something to consider.)
      * Sometimes the `joystick_task` code uses a `return` statement to exit the event loop (and thus let the app terminate). Returning from one of the new input handlers just ends that particular handler. Instead, `return` in the old code translates to `mux_input_stop();` in the new code.
      * The settings apps tend to duplicate some of the logic for the A button vs. the right button. It's not identical since A can also open submenus, so they can't share the same handler, but you can at have the "confirm" handler call the "next option" one to eliminate the redundant bit.
5. Update the `main` function to [set up a `mux_input_options` struct and call `mux_input_task`](https://github.com/MustardOS/frontend/pull/89/commits/b5d7441e309ad40af1b0f6d55954814eab1763d3?diff=split&w=0#diff-7bf2636c808f333a1bfae40574ea30d576dee8ffa7d302c777c62eee9db9feafR1456-R1504) where it used to call `joystick_task`. (The input options are documented in [the struct definition](https://github.com/MustardOS/frontend/blob/1de96a3c395335b8e8b7b44f7b8884eb481a105a/common/input.h#L90-L142), but hopefully should be pretty self explanatory.)
6. Update the Makefile to [depend on the common input code](https://github.com/MustardOS/frontend/pull/89/commits/b5d7441e309ad40af1b0f6d55954814eab1763d3?diff=split&w=0#diff-cffd60c59dfb9d4e1fde8edf2a819e8591cbe96dfcbfc2b5718f8b84679522a1R79-R80).