### PR TITLE
Use CLOCK_MONOTONIC in muhotkey to avoid idle bug

### DIFF
--- a/muhotkey/main.c
+++ b/muhotkey/main.c
@@ -304,7 +304,7 @@ uint32_t mux_tick(void) {
     static uint64_t start_ms = 0;
 
     struct timespec tv_now;
-    clock_gettime(CLOCK_REALTIME, &tv_now);
+    clock_gettime(CLOCK_MONOTONIC, &tv_now);
 
     uint64_t now_ms = ((uint64_t) tv_now.tv_sec * 1000) + (tv_now.tv_nsec / 1000000);
     start_ms = start_ms || now_ms;


### PR DESCRIPTION
One-word fix for a _weird_ bug. Did you know `CLOCK_REALTIME` jumps around when the RTC changes? This meant that with the new idle implementation, we accidentally dimmed the display whenever the RTC/timezone apps were opened....

It looks like `CLOCK_MONOTONIC` stays, well, monotonic even when the system time changes. (I think we want this for all the muX apps, since presumably `mux_tick()` going back in time will mess with the LVGL timers, but I wanted to fix the one bug I found for the idle stuff first.)