### PR TITLE
Port apps with edge cases to new input library

### DIFF
--- a/muxapp/main.c
+++ b/muxapp/main.c
@@ -69,8 +69,6 @@ void list_nav_prev(int steps);
 
 void list_nav_next(int steps);
 
-void joystick_task();
-
 void init_elements();
 
 void update_footer_nav_elements();

--- a/muxcharge/Makefile
+++ b/muxcharge/Makefile
@@ -75,6 +75,7 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/device.c \
 		../common/common.c \
 		../common/theme.c \
+		../common/input.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \

--- a/muxcredits/Makefile
+++ b/muxcredits/Makefile
@@ -73,6 +73,7 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/device.c \
 		../common/common.c \
 		../common/theme.c \
+		../common/input.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \

--- a/muxcredits/main.c
+++ b/muxcredits/main.c
@@ -1,11 +1,13 @@
 #include "../lvgl/lvgl.h"
 #include "../lvgl/drivers/display/fbdev.h"
 #include "ui/ui.h"
+#include <fcntl.h>
 #include <string.h>
 #include <stdlib.h>
 #include "../common/common.h"
 #include "../common/config.h"
 #include "../common/device.h"
+#include "../common/input.h"
 
 int NAV_DPAD_HOR;
 int NAV_ANLG_HOR;
@@ -19,7 +21,6 @@ int msgbox_active = 0;
 int input_disable = 0;
 int SD2_found = 0;
 int nav_sound = 0;
-int safe_quit = 0;
 int bar_header = 0;
 int bar_footer = 0;
 char *osd_message;
@@ -29,9 +30,16 @@ struct mux_device device;
 
 lv_obj_t *msgbox_element = NULL;
 
+void timeout_task(lv_timer_t *timer) {
+    mux_input_stop();
+}
+
+void handle_quit(void) {
+    mux_input_stop();
+}
+
 int main() {
     load_device(&device);
-
 
     lv_init();
     fbdev_init(device.SCREEN.DEVICE);
@@ -64,15 +72,36 @@ int main() {
 
     if (!config.BOOT.FACTORY_RESET) write_text_to_file(MUOS_PDI_LOAD, "w", CHAR, "credit");
 
-    int hold = 0;
-    while (!safe_quit) {
-        hold++;
-        refresh_screen();
-        if (hold > 310000) {
-            safe_quit = 1;
-        }
-        //printf("%d\n", hold);
+    lv_timer_create(timeout_task, 70000, NULL);
+
+    int js_fd = open(device.INPUT.EV1, O_RDONLY);
+    if (js_fd < 0) {
+        perror("Failed to open joystick device");
+        return 1;
     }
+
+    int js_fd_sys = open(device.INPUT.EV0, O_RDONLY);
+    if (js_fd_sys < 0) {
+        perror("Failed to open joystick device");
+        return 1;
+    }
+
+    mux_input_options input_opts = {
+            .gamepad_fd = js_fd,
+            .system_fd = js_fd_sys,
+            .max_idle_ms = 16 /* ~60 FPS */,
+            .combo = {
+                    {
+                            .type_mask = BIT(MUX_INPUT_MENU_LONG) | BIT(MUX_INPUT_START),
+                            .press_handler = handle_quit,
+                    },
+            },
+            .idle_handler = refresh_screen,
+    };
+    mux_input_task(&input_opts);
+
+    close(js_fd);
+    close(js_fd_sys);
 
     return 0;
 }

--- a/muxnetwork/Makefile
+++ b/muxnetwork/Makefile
@@ -76,6 +76,8 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/common.c \
 		../common/ui_common.c \
 		../common/theme.c \
+		../common/input.c \
+		../common/input/list_nav.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \

--- a/muxpass/Makefile
+++ b/muxpass/Makefile
@@ -78,6 +78,7 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 		../common/ui_common.c \
 		../common/theme.c \
 		../common/passcode.c \
+		../common/input.c \
 		$(EXTRA); \
 	END=$$(date +%s); \
 	ELAPSED_TIME=$$((END - START)); \


### PR DESCRIPTION
Ports over a few apps some unusual input setups, mostly for completeness. Together with the @GrumpyGopher's #93, this is all of them. :D

`muxpass`: I also changed some error exit statuses from 1 (password check succeeded) to 2 (password check failed) so an error doesn't let someone through without a password. (Maybe it should just be 0 -> success and 1 -> failure to be more standard, but I didn't want to change the companion scripts right now.)

`muxnetwork`: Came out messier than I'd like due to the on-screen keyboard, but this seems to work for now, and the structure can always be improved later.

In particular, it should be possible to create APIs for swapping out the input handler configs when a modal dialog is shown (like the help message box or the on-screen keyboard). Just needs a little bit of thought on what the right balance between reusability and understandability. :)