### PR TITLE
Swap X&Y when pref is set, not just A&B

### DIFF
--- a/common/input.c
+++ b/common/input.c
@@ -13,7 +13,7 @@
 #include "config.h"
 #include "device.h"
 
-extern uint32_t mux_tick();
+extern uint32_t mux_tick(void);
 
 // Whether to exit the input task before the next iteration of the event loop.
 static bool stop = false;
@@ -34,9 +34,9 @@ static void process_key(const mux_input_options *opts, const struct input_event 
     } else if (event->code == device.RAW_INPUT.BUTTON.C) {
         type = MUX_INPUT_C;
     } else if (event->code == device.RAW_INPUT.BUTTON.X) {
-        type = MUX_INPUT_X;
+        type = !opts->swap_btn ? MUX_INPUT_X : MUX_INPUT_Y;
     } else if (event->code == device.RAW_INPUT.BUTTON.Y) {
-        type = MUX_INPUT_Y;
+        type = !opts->swap_btn ? MUX_INPUT_Y : MUX_INPUT_X;
     } else if (event->code == device.RAW_INPUT.BUTTON.Z) {
         type = MUX_INPUT_Z;
     } else if (event->code == device.RAW_INPUT.BUTTON.L1) {
@@ -391,6 +391,6 @@ bool mux_input_pressed(mux_input_type type) {
     return pressed & BIT(type);
 }
 
-void mux_input_stop() {
+void mux_input_stop(void) {
     stop = true;
 }

--- a/common/input.h
+++ b/common/input.h
@@ -62,7 +62,7 @@ typedef enum {
 } mux_input_action;
 
 // Callback function invoked in response to a single specific input type and action.
-typedef void (*mux_input_handler)();
+typedef void (*mux_input_handler)(void);
 
 // Callback function invoked in response to any arbitrary input type and action.
 typedef void (*mux_input_catchall_handler)(mux_input_type, mux_input_action);
@@ -97,7 +97,8 @@ typedef struct {
     // (The idle_handler may still be called more frequently at times.)
     int max_idle_ms;
 
-    // Whether to swap the A & B buttons.
+    // Whether to swap the A/B/X/Y buttons. False is the Japanese layout (A on the right) and true
+    // is the Western layout (A on the bottom).
     bool swap_btn;
 
     // Whether to swap the up/down and left/right axes on the D-pad and sticks.
@@ -149,4 +150,4 @@ bool mux_input_pressed(mux_input_type type);
 
 // Causes the input task to exit at the start of the next iteration of the event loop (e.g., after
 // processing currently pressed or held inputs).
-void mux_input_stop();
+void mux_input_stop(void);


### PR DESCRIPTION
I think @antiKk is using this setting to swap ABXY in the SDL configs, so it seemed to make sense to swap the X&Y buttons for the muX apps too. WDYT?

I also added `void` to a couple of function prototypes because I keep forgetting this is C, not C++, and `()` is different from `(void)`....