### PR TITLE
Improve input/idle handling & fix a memory leak

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -447,6 +447,19 @@ char *read_line_from_file(const char *filename, size_t line_number) {
     return line;
 }
 
+int read_int_from_file(const char *filename) {
+    char buf[32] = {};
+
+    FILE *file = fopen(filename, "r");
+    if (!file) {
+        return 0;
+    }
+    fgets(buf, sizeof(buf), file);
+    fclose(file);
+
+    return atoi(buf);
+}
+
 const char *get_random_hex() {
     int red = rand() % UINT8_MAX;
     int green = rand() % UINT8_MAX;

--- a/common/common.h
+++ b/common/common.h
@@ -105,6 +105,8 @@ char *read_text_from_file(char *filename);
 
 char *read_line_from_file(const char *filename, size_t line_number);
 
+int read_int_from_file(const char *filename);
+
 const char *get_random_hex();
 
 uint32_t get_ini_hex(mini_t *ini_config, const char *section, const char *key);

--- a/common/input.h
+++ b/common/input.h
@@ -71,7 +71,7 @@ typedef void (*mux_input_catchall_handler)(mux_input_type, mux_input_action);
 typedef void (*mux_input_catchall_combo_handler)(int, mux_input_action);
 
 // Maximum number of combos allowed per input task.
-#define MUX_INPUT_COMBO_COUNT 16
+#define MUX_INPUT_COMBO_COUNT 32
 
 // Configuration for a multi-input combo.
 typedef struct {

--- a/common/ui_common.c
+++ b/common/ui_common.c
@@ -682,7 +682,7 @@ void ui_common_screen_init(struct theme_config *theme, struct mux_device *device
 }
 
 void ui_common_handle_bright() {
-    if (atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.BOOT.FACTORY_RESET) {
+    if (read_int_from_file("/tmp/hdmi_in_use") || config.BOOT.FACTORY_RESET) {
         return;
     }
 
@@ -694,7 +694,7 @@ void ui_common_handle_bright() {
 }
 
 void ui_common_handle_vol() {
-    if (atoi(read_line_from_file("/tmp/hdmi_in_use", 1)) || config.BOOT.FACTORY_RESET) {
+    if (read_int_from_file("/tmp/hdmi_in_use") || config.BOOT.FACTORY_RESET) {
         return;
     }
 

--- a/muxapp/main.c
+++ b/muxapp/main.c
@@ -490,7 +490,7 @@ int main(int argc, char *argv[]) {
 
     int ain_index = 0;
     if (file_exist(MUOS_AIN_LOAD)) {
-        ain_index = atoi(read_line_from_file(MUOS_AIN_LOAD, 1));
+        ain_index = read_int_from_file(MUOS_AIN_LOAD);
         printf("loading AIN at: %d\n", ain_index);
         remove(MUOS_AIN_LOAD);
     }

--- a/muxarchive/main.c
+++ b/muxarchive/main.c
@@ -506,7 +506,7 @@ int main(int argc, char *argv[]) {
 
     int sys_index = 0;
     if (file_exist(MUOS_IDX_LOAD)) {
-        sys_index = atoi(read_line_from_file(MUOS_IDX_LOAD, 1));
+        sys_index = read_int_from_file(MUOS_IDX_LOAD);
         remove(MUOS_IDX_LOAD);
     }
 

--- a/muxcharge/main.c
+++ b/muxcharge/main.c
@@ -45,7 +45,7 @@ lv_timer_t *battery_timer;
 
 void check_for_cable() {
     if (file_exist(device.BATTERY.CHARGER)) {
-        if (atoi(read_line_from_file(device.BATTERY.CHARGER, 1)) == 0) {
+        if (read_int_from_file(device.BATTERY.CHARGER) == 0) {
             exit_status = 1;
         }
     }

--- a/muxnetscan/main.c
+++ b/muxnetscan/main.c
@@ -76,7 +76,7 @@ void create_network_items() {
         return;
     }
 
-    if (strcmp(read_line_from_file(scan_file, 1), "0") == 0) {
+    if (read_int_from_file(scan_file) == 0) {
         lv_label_set_text(ui_lblScreenMessage, TS("No Wi-Fi Networks Found"));
         return;
     } else {

--- a/muxtask/main.c
+++ b/muxtask/main.c
@@ -504,7 +504,7 @@ int main(int argc, char *argv[]) {
 
     int tin_index = 0;
     if (file_exist(MUOS_TIN_LOAD)) {
-        tin_index = atoi(read_line_from_file(MUOS_TIN_LOAD, 1));
+        tin_index = read_int_from_file(MUOS_TIN_LOAD);
         printf("loading TIN at: %d\n", tin_index);
         remove(MUOS_TIN_LOAD);
     }

--- a/muxtheme/main.c
+++ b/muxtheme/main.c
@@ -467,7 +467,7 @@ int main(int argc, char *argv[]) {
 
     int sys_index = 0;
     if (file_exist(MUOS_IDX_LOAD)) {
-        sys_index = atoi(read_line_from_file(MUOS_IDX_LOAD, 1));
+        sys_index = read_int_from_file(MUOS_IDX_LOAD);
         remove(MUOS_IDX_LOAD);
     }
 


### PR DESCRIPTION
Requires companion PR to be merged at the same time: https://github.com/MustardOS/internal/pull/300

* Changes `/run/muos/system/idle_inhibit` to a normal "variable file" with values 0/1 instead of just checking file presence. Same effect, but is more consistent with other muOS flags in the filesystem.
* Updates `muhotkey` to only read the `idle_inhibit` file if it _didn't_ just process an input event. Otherwise, we end up reading the file uselessly in a tight loop and wasting CPU when receiving continuous inputs like stick movement.
* Adds a new `read_int_from_file(name)` function for the common pattern of `atoi(read_line_from_file(name, 1))`. It's a microscopic bit faster since it saves an allocation, but more importantly, it fixes a memory leak (since the apps currently use `read_line_from_file` to check the HDMI state on every frame, but never free the returned string).
* Ups the max combo count from 16 to 32, since we're already at 14 combos registered via `muhotkey` for some devices....