### PR TITLE
fix .start missing error when compiling

### DIFF
--- a/muhotkey/Makefile
+++ b/muhotkey/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -37,20 +39,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/config.c \
 		../common/device.c \
@@ -64,4 +63,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxapp/Makefile
+++ b/muxapp/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -53,20 +55,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -87,4 +86,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxarchive/Makefile
+++ b/muxarchive/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -53,20 +55,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -86,4 +85,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxassign/Makefile
+++ b/muxassign/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -53,20 +55,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -86,4 +85,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxcharge/Makefile
+++ b/muxcharge/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -53,20 +55,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -84,4 +83,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxconfig/Makefile
+++ b/muxconfig/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -53,20 +55,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -86,4 +85,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxcredits/Makefile
+++ b/muxcredits/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -50,20 +52,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/kofi.c \
 		../common/img/nothing.c \
@@ -82,4 +81,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxgov/Makefile
+++ b/muxgov/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -53,20 +55,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -86,4 +85,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxinfo/Makefile
+++ b/muxinfo/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -53,20 +55,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -86,4 +85,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxlanguage/Makefile
+++ b/muxlanguage/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -53,20 +55,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -87,4 +86,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxlaunch/Makefile
+++ b/muxlaunch/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -53,20 +55,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -85,4 +84,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxnetprofile/Makefile
+++ b/muxnetprofile/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -53,20 +55,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -87,4 +86,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxnetscan/Makefile
+++ b/muxnetscan/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -53,20 +55,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -86,4 +85,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxnetwork/Makefile
+++ b/muxnetwork/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -53,20 +55,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -86,4 +85,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxoption/Makefile
+++ b/muxoption/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -53,20 +55,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -86,4 +85,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxpass/Makefile
+++ b/muxpass/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -54,20 +56,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -87,4 +86,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxplore/Makefile
+++ b/muxplore/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -53,20 +55,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -87,4 +86,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxpower/Makefile
+++ b/muxpower/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -53,20 +55,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -86,4 +85,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxrtc/Makefile
+++ b/muxrtc/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -53,20 +55,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -86,4 +85,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxsplash/Makefile
+++ b/muxsplash/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -44,20 +46,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/mini/mini.c \
@@ -71,4 +70,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxstart/Makefile
+++ b/muxstart/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -53,20 +55,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -83,4 +82,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxstorage/Makefile
+++ b/muxstorage/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -53,20 +55,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -86,4 +85,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxsysinfo/Makefile
+++ b/muxsysinfo/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -53,20 +55,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -86,4 +85,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxtask/Makefile
+++ b/muxtask/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -53,20 +55,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -87,4 +86,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxtester/Makefile
+++ b/muxtester/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -54,20 +56,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -86,4 +85,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxtheme/Makefile
+++ b/muxtheme/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -53,20 +55,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -87,4 +86,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxtimezone/Makefile
+++ b/muxtimezone/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -53,20 +55,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -86,4 +85,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxtweakadv/Makefile
+++ b/muxtweakadv/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -53,20 +55,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -86,4 +85,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxtweakgen/Makefile
+++ b/muxtweakgen/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -53,20 +55,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -86,4 +85,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxvisual/Makefile
+++ b/muxvisual/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -53,20 +55,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -86,4 +85,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)

--- a/muxwebserv/Makefile
+++ b/muxwebserv/Makefile
@@ -1,3 +1,5 @@
+START_TIME := $(shell date +%s)
+
 ifeq ($(DEVICE), RG35XX)
 	ARCH = -march=armv7-a \
 		-mtune=cortex-a9 \
@@ -53,20 +55,17 @@ MAINOBJ = $(MAINSRC:.c=$(OBJEXT))
 SRCS = $(ASRCS) $(CSRCS) $(SSRCS) $(MAINSRC)
 OBJS = $(AOBJS) $(COBJS) $(SOBJS)
 
-all: clean start compile move
+all: clean compile move
 
 %.o: %.c
 	@$(CC) -D$(DEVICE) $(CFLAGS) -c $< -o $@ $(EXTRA)
 
 clean:
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
-
-start:
-	@date +%s > .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)
 
 compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
-	@START=$$(cat .start); \
+	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
 		../common/img/nothing.c \
 		../common/json/json.c \
@@ -86,4 +85,4 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 move: compile
 	@mkdir -p ../bin
 	@mv $(TARGET) ../bin/
-	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET) .start
+	@rm -f $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) $(TARGET)


### PR DESCRIPTION
updated make files to use a global variable to store the start time to avoid error when attempting to create .start file.  Building now reports compile time accurately