### PR TITLE
fix issue with overlay being applied twice

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -1040,7 +1040,7 @@ char *load_static_image(lv_obj_t *ui_screen, lv_group_t *ui_group) {
     return "";
 }
 
-char *load_overlay_image() {
+void load_overlay_image(lv_obj_t *ui_screen, int16_t image_overlay_enabled) {
     static char static_image_path[MAX_BUFFER_SIZE];
     static char static_image_embed[MAX_BUFFER_SIZE];
 
@@ -1049,10 +1049,13 @@ char *load_overlay_image() {
         file_exist(static_image_path)) {
         snprintf(static_image_embed, sizeof(static_image_embed), "M:%s/theme/active/image/overlay.png",
                  STORAGE_PATH);
-        return static_image_embed;
-    }
 
-    return "";
+        if (image_overlay_enabled) {
+            lv_obj_t *overlay_img = lv_img_create(ui_screen);
+            lv_img_set_src(overlay_img, static_image_embed);
+            lv_obj_move_foreground(overlay_img);
+        }
+    }
 }
 
 static void image_anim_cb(void *var, int32_t img_idx) {

--- a/common/common.h
+++ b/common/common.h
@@ -165,7 +165,7 @@ char *load_wallpaper(lv_obj_t *ui_screen, lv_group_t *ui_group, int animated, in
 
 char *load_static_image(lv_obj_t *ui_screen, lv_group_t *ui_group);
 
-char *load_overlay_image();
+void load_overlay_image(lv_obj_t *ui_screen, int16_t image_overlay_enabled);
 
 void load_image_random(lv_obj_t *ui_imgWall, char *base_image_path);
 

--- a/muxapp/main.c
+++ b/muxapp/main.c
@@ -313,13 +313,6 @@ void init_elements() {
         lv_obj_add_flag(nav_hide[i], LV_OBJ_FLAG_FLOATING);
     }
 
-    char *overlay = load_overlay_image();
-    if (strlen(overlay) > 0 && theme.MISC.IMAGE_OVERLAY) {
-        lv_obj_t *overlay_img = lv_img_create(ui_screen);
-        lv_img_set_src(overlay_img, overlay);
-        lv_obj_move_foreground(overlay_img);
-    }
-
     if (TEST_IMAGE) display_testing_message(ui_screen);
 }
 
@@ -475,6 +468,7 @@ int main(int argc, char *argv[]) {
 
     ui_common_screen_init(&theme, &device, TS("APPLICATIONS"));
     init_elements();
+    load_overlay_image(ui_screen, theme.MISC.IMAGE_OVERLAY);
 
     lv_obj_set_user_data(ui_screen, basename(argv[0]));
 

--- a/muxarchive/main.c
+++ b/muxarchive/main.c
@@ -325,13 +325,6 @@ void init_elements() {
         lv_obj_clear_flag(ui_lblNavAGlyph, LV_OBJ_FLAG_FLOATING);
     }
 
-    char *overlay = load_overlay_image();
-    if (strlen(overlay) > 0 && theme.MISC.IMAGE_OVERLAY) {
-        lv_obj_t *overlay_img = lv_img_create(ui_screen);
-        lv_img_set_src(overlay_img, overlay);
-        lv_obj_move_foreground(overlay_img);
-    }
-
     if (TEST_IMAGE) display_testing_message(ui_screen);
 }
 
@@ -470,6 +463,7 @@ int main(int argc, char *argv[]) {
 
     ui_common_screen_init(&theme, &device, TS("ARCHIVE MANAGER"));
     init_elements();
+    load_overlay_image(ui_screen, theme.MISC.IMAGE_OVERLAY);
 
     lv_obj_set_user_data(ui_screen, basename(argv[0]));
 

--- a/muxassign/main.c
+++ b/muxassign/main.c
@@ -684,13 +684,6 @@ void init_elements() {
         lv_obj_move_foreground(ui_lblNavY);
     }
 
-    char *overlay = load_overlay_image();
-    if (strlen(overlay) > 0 && theme.MISC.IMAGE_OVERLAY) {
-        lv_obj_t *overlay_img = lv_img_create(ui_screen);
-        lv_img_set_src(overlay_img, overlay);
-        lv_obj_move_foreground(overlay_img);
-    }
-
     if (TEST_IMAGE) display_testing_message(ui_screen);
 }
 
@@ -940,6 +933,7 @@ int main(int argc, char *argv[]) {
 
     ui_common_screen_init(&theme, &device, "");
     init_elements();
+    load_overlay_image(ui_screen, theme.MISC.IMAGE_OVERLAY);
 
     lv_obj_set_user_data(ui_screen, basename(argv[0]));
 

--- a/muxconfig/main.c
+++ b/muxconfig/main.c
@@ -276,13 +276,6 @@ void init_elements() {
         ui_count -= 2;
     }
 
-    char *overlay = load_overlay_image();
-    if (strlen(overlay) > 0 && theme.MISC.IMAGE_OVERLAY) {
-        lv_obj_t *overlay_img = lv_img_create(ui_screen);
-        lv_img_set_src(overlay_img, overlay);
-        lv_obj_move_foreground(overlay_img);
-    }
-
     if (TEST_IMAGE) display_testing_message(ui_screen);
 }
 
@@ -443,6 +436,7 @@ int main(int argc, char *argv[]) {
     ui_common_screen_init(&theme, &device, TS("CONFIGURATION"));
     ui_init(ui_pnlContent);
     init_elements();
+    load_overlay_image(ui_screen, theme.MISC.IMAGE_OVERLAY);
 
     lv_obj_set_user_data(ui_screen, basename(argv[0]));
 

--- a/muxgov/main.c
+++ b/muxgov/main.c
@@ -408,13 +408,6 @@ void init_elements() {
     lv_obj_move_foreground(ui_lblNavYGlyph);
     lv_obj_move_foreground(ui_lblNavY);
 
-    char *overlay = load_overlay_image();
-    if (strlen(overlay) > 0 && theme.MISC.IMAGE_OVERLAY) {
-        lv_obj_t *overlay_img = lv_img_create(ui_screen);
-        lv_img_set_src(overlay_img, overlay);
-        lv_obj_move_foreground(overlay_img);
-    }
-
     if (TEST_IMAGE) display_testing_message(ui_screen);
 }
 
@@ -655,6 +648,7 @@ int main(int argc, char *argv[]) {
 
     ui_common_screen_init(&theme, &device, "");
     init_elements();
+    load_overlay_image(ui_screen, theme.MISC.IMAGE_OVERLAY);
 
     lv_obj_set_user_data(ui_screen, basename(argv[0]));
 

--- a/muxinfo/main.c
+++ b/muxinfo/main.c
@@ -244,13 +244,6 @@ void init_elements() {
     lv_obj_set_user_data(ui_lblSystem, "system");
     lv_obj_set_user_data(ui_lblCredits, "credit");
 
-    char *overlay = load_overlay_image();
-    if (strlen(overlay) > 0 && theme.MISC.IMAGE_OVERLAY) {
-        lv_obj_t *overlay_img = lv_img_create(ui_screen);
-        lv_img_set_src(overlay_img, overlay);
-        lv_obj_move_foreground(overlay_img);
-    }
-
     if (TEST_IMAGE) display_testing_message(ui_screen);
 }
 
@@ -411,6 +404,7 @@ int main(int argc, char *argv[]) {
     ui_common_screen_init(&theme, &device, TS("INFORMATION"));
     ui_init(ui_pnlContent);
     init_elements();
+    load_overlay_image(ui_screen, theme.MISC.IMAGE_OVERLAY);
 
     lv_obj_set_user_data(ui_screen, basename(argv[0]));
 

--- a/muxlanguage/main.c
+++ b/muxlanguage/main.c
@@ -232,13 +232,6 @@ void init_elements() {
         lv_obj_add_flag(nav_hide[i], LV_OBJ_FLAG_FLOATING);
     }
 
-    char *overlay = load_overlay_image();
-    if (strlen(overlay) > 0 && theme.MISC.IMAGE_OVERLAY) {
-        lv_obj_t *overlay_img = lv_img_create(ui_screen);
-        lv_img_set_src(overlay_img, overlay);
-        lv_obj_move_foreground(overlay_img);
-    }
-
     if (TEST_IMAGE) display_testing_message(ui_screen);
 }
 
@@ -383,6 +376,7 @@ int main(int argc, char *argv[]) {
 
     ui_common_screen_init(&theme, &device, TS("LANGUAGES"));
     init_elements();
+    load_overlay_image(ui_screen, theme.MISC.IMAGE_OVERLAY);
 
     lv_obj_set_user_data(ui_screen, basename(argv[0]));
 

--- a/muxlaunch/main.c
+++ b/muxlaunch/main.c
@@ -421,13 +421,6 @@ void init_elements() {
     lv_obj_set_user_data(ui_lblReboot, "reboot");
     lv_obj_set_user_data(ui_lblShutdown, "shutdown");
 
-    char *overlay = load_overlay_image();
-    if (strlen(overlay) > 0 && theme.MISC.IMAGE_OVERLAY) {
-        lv_obj_t *overlay_img = lv_img_create(ui_screen);
-        lv_img_set_src(overlay_img, overlay);
-        lv_obj_move_foreground(overlay_img);
-    }
-
     if (TEST_IMAGE) display_testing_message(ui_screen);
 }
 
@@ -588,6 +581,7 @@ int main(int argc, char *argv[]) {
     ui_common_screen_init(&theme, &device, TS("MAIN MENU"));
     ui_init(ui_pnlContent);
     init_elements();
+    load_overlay_image(ui_screen, theme.MISC.IMAGE_OVERLAY);
 
     lv_obj_set_user_data(ui_screen, basename(argv[0]));
 

--- a/muxnetprofile/main.c
+++ b/muxnetprofile/main.c
@@ -427,13 +427,6 @@ void init_elements() {
         lv_obj_add_flag(ui_lblNavYGlyph, LV_OBJ_FLAG_FLOATING);
     }
 
-    char *overlay = load_overlay_image();
-    if (strlen(overlay) > 0 && theme.MISC.IMAGE_OVERLAY) {
-        lv_obj_t *overlay_img = lv_img_create(ui_screen);
-        lv_img_set_src(overlay_img, overlay);
-        lv_obj_move_foreground(overlay_img);
-    }
-
     if (TEST_IMAGE) display_testing_message(ui_screen);
 }
 
@@ -574,6 +567,7 @@ int main(int argc, char *argv[]) {
 
     ui_common_screen_init(&theme, &device, TS("NETWORK PROFILE"));
     init_elements();
+    load_overlay_image(ui_screen, theme.MISC.IMAGE_OVERLAY);
     lv_label_set_text(ui_lblScreenMessage, TS("Loading Network Profiles..."));
     lv_obj_clear_flag(ui_lblScreenMessage, LV_OBJ_FLAG_HIDDEN);
 

--- a/muxnetscan/main.c
+++ b/muxnetscan/main.c
@@ -229,13 +229,6 @@ void init_elements() {
         lv_obj_add_flag(nav_hide[i], LV_OBJ_FLAG_FLOATING);
     }
 
-    char *overlay = load_overlay_image();
-    if (strlen(overlay) > 0 && theme.MISC.IMAGE_OVERLAY) {
-        lv_obj_t *overlay_img = lv_img_create(ui_screen);
-        lv_img_set_src(overlay_img, overlay);
-        lv_obj_move_foreground(overlay_img);
-    }
-
     if (TEST_IMAGE) display_testing_message(ui_screen);
 }
 
@@ -376,6 +369,7 @@ int main(int argc, char *argv[]) {
 
     ui_common_screen_init(&theme, &device, TS("NETWORK SCAN"));
     init_elements();
+    load_overlay_image(ui_screen, theme.MISC.IMAGE_OVERLAY);
     lv_label_set_text(ui_lblScreenMessage, TS("Scanning for Wi-Fi Networks..."));
     lv_obj_clear_flag(ui_lblScreenMessage, LV_OBJ_FLAG_HIDDEN);
 

--- a/muxnetwork/main.c
+++ b/muxnetwork/main.c
@@ -1059,13 +1059,6 @@ void init_elements() {
     lv_obj_set_user_data(ui_lblStatus, "status");
     lv_obj_set_user_data(ui_lblConnect, "connect");
 
-    char *overlay = load_overlay_image();
-    if (strlen(overlay) > 0 && theme.MISC.IMAGE_OVERLAY) {
-        lv_obj_t *overlay_img = lv_img_create(ui_screen);
-        lv_img_set_src(overlay_img, overlay);
-        lv_obj_move_foreground(overlay_img);
-    }
-
     if (strcasecmp(lv_label_get_text(ui_lblEnableValue), enabled_false) == 0) {
         lv_obj_add_flag(ui_pnlIdentifier, LV_OBJ_FLAG_HIDDEN);
         lv_obj_add_flag(ui_pnlPassword, LV_OBJ_FLAG_HIDDEN);
@@ -1398,6 +1391,7 @@ int main(int argc, char *argv[]) {
     ui_common_screen_init(&theme, &device, TS("WI-FI NETWORK"));
     ui_init(ui_screen, ui_pnlContent, &theme);
     init_elements();
+    load_overlay_image(ui_screen, theme.MISC.IMAGE_OVERLAY);
 
     lv_obj_set_user_data(ui_screen, basename(argv[0]));
 

--- a/muxoption/main.c
+++ b/muxoption/main.c
@@ -231,13 +231,6 @@ void init_elements() {
     lv_obj_set_user_data(ui_lblCore, "core");
     lv_obj_set_user_data(ui_lblGovernor, "governor");
 
-    char *overlay = load_overlay_image();
-    if (strlen(overlay) > 0 && theme.MISC.IMAGE_OVERLAY) {
-        lv_obj_t *overlay_img = lv_img_create(ui_screen);
-        lv_img_set_src(overlay_img, overlay);
-        lv_obj_move_foreground(overlay_img);
-    }
-
     if (TEST_IMAGE) display_testing_message(ui_screen);
 }
 
@@ -398,6 +391,7 @@ int main(int argc, char *argv[]) {
     ui_common_screen_init(&theme, &device, TS("CONTENT OPTION"));
     ui_init(ui_pnlContent);
     init_elements();
+    load_overlay_image(ui_screen, theme.MISC.IMAGE_OVERLAY);
 
     lv_obj_set_user_data(ui_screen, basename(argv[0]));
 

--- a/muxpass/main.c
+++ b/muxpass/main.c
@@ -157,13 +157,6 @@ void init_elements() {
         lv_obj_add_flag(nav_hide[i], LV_OBJ_FLAG_FLOATING);
     }
 
-    char *overlay = load_overlay_image();
-    if (strlen(overlay) > 0 && theme.MISC.IMAGE_OVERLAY) {
-        lv_obj_t *overlay_img = lv_img_create(ui_screen);
-        lv_img_set_src(overlay_img, overlay);
-        lv_obj_move_foreground(overlay_img);
-    }
-
     if (TEST_IMAGE) display_testing_message(ui_screen);
 }
 
@@ -247,6 +240,7 @@ int main(int argc, char *argv[]) {
     ui_common_screen_init(&theme, &device, TS("PASSCODE"));
     ui_init(ui_pnlContent);
     init_elements();
+    load_overlay_image(ui_screen, theme.MISC.IMAGE_OVERLAY);
 
     if (strlen(p_msg) > 1) {
         lv_label_set_text(ui_lblMessage, p_msg);

--- a/muxplore/main.c
+++ b/muxplore/main.c
@@ -1666,13 +1666,6 @@ void init_elements() {
     process_visual_element(NETWORK, ui_staNetwork);
     process_visual_element(BATTERY, ui_staCapacity);
 
-    char *overlay = load_overlay_image();
-    if (strlen(overlay) > 0 && theme.MISC.IMAGE_OVERLAY) {
-        lv_obj_t *overlay_img = lv_img_create(ui_screen);
-        lv_img_set_src(overlay_img, overlay);
-        lv_obj_move_foreground(overlay_img);
-    }
-
     if (TEST_IMAGE) display_testing_message(ui_screen);
 }
 
@@ -2014,6 +2007,7 @@ int main(int argc, char *argv[]) {
     lv_timer_ready(ui_refresh_timer);
 
     init_elements();
+    load_overlay_image(ui_screen, theme.MISC.IMAGE_OVERLAY);
 
     current_wall = load_wallpaper(ui_screen, NULL, theme.MISC.ANIMATED_BACKGROUND, theme.MISC.RANDOM_BACKGROUND);
     if (strlen(current_wall) > 3) {

--- a/muxpower/main.c
+++ b/muxpower/main.c
@@ -453,13 +453,6 @@ void init_elements() {
     lv_obj_set_user_data(ui_lblIdleDisplay, "idle_display");
     lv_obj_set_user_data(ui_lblIdleSleep, "idle_sleep");
 
-    char *overlay = load_overlay_image();
-    if (strlen(overlay) > 0 && theme.MISC.IMAGE_OVERLAY) {
-        lv_obj_t *overlay_img = lv_img_create(ui_screen);
-        lv_img_set_src(overlay_img, overlay);
-        lv_obj_move_foreground(overlay_img);
-    }
-
     if (TEST_IMAGE) display_testing_message(ui_screen);
 }
 
@@ -620,6 +613,7 @@ int main(int argc, char *argv[]) {
     ui_common_screen_init(&theme, &device, TS("POWER SETTINGS"));
     ui_init(ui_pnlContent);
     init_elements();
+    load_overlay_image(ui_screen, theme.MISC.IMAGE_OVERLAY);
 
     lv_obj_set_user_data(ui_screen, basename(argv[0]));
 

--- a/muxrtc/main.c
+++ b/muxrtc/main.c
@@ -618,13 +618,6 @@ void init_elements() {
     lv_obj_set_user_data(ui_lblNotation, "notation");
     lv_obj_set_user_data(ui_lblTimezone, "timezone");
 
-    char *overlay = load_overlay_image();
-    if (strlen(overlay) > 0 && theme.MISC.IMAGE_OVERLAY) {
-        lv_obj_t *overlay_img = lv_img_create(ui_screen);
-        lv_img_set_src(overlay_img, overlay);
-        lv_obj_move_foreground(overlay_img);
-    }
-
     if (TEST_IMAGE) display_testing_message(ui_screen);
 }
 
@@ -792,6 +785,7 @@ int main(int argc, char *argv[]) {
     ui_common_screen_init(&theme, &device, TS("DATE AND TIME"));
     ui_init(ui_pnlContent);
     init_elements();
+    load_overlay_image(ui_screen, theme.MISC.IMAGE_OVERLAY);
 
     lv_obj_set_user_data(ui_screen, basename(argv[0]));
 

--- a/muxstorage/main.c
+++ b/muxstorage/main.c
@@ -576,13 +576,6 @@ void init_elements() {
     lv_obj_set_user_data(ui_lblLanguage, "language");
     lv_obj_set_user_data(ui_lblNetwork, "network");
 
-    char *overlay = load_overlay_image();
-    if (strlen(overlay) > 0 && theme.MISC.IMAGE_OVERLAY) {
-        lv_obj_t *overlay_img = lv_img_create(ui_screen);
-        lv_img_set_src(overlay_img, overlay);
-        lv_obj_move_foreground(overlay_img);
-    }
-
     if (TEST_IMAGE) display_testing_message(ui_screen);
 }
 
@@ -723,6 +716,7 @@ int main(int argc, char *argv[]) {
     ui_common_screen_init(&theme, &device, TS("STORAGE PREFERENCE"));
     ui_init(ui_pnlContent);
     init_elements();
+    load_overlay_image(ui_screen, theme.MISC.IMAGE_OVERLAY);
 
     lv_obj_set_user_data(ui_screen, basename(argv[0]));
 

--- a/muxsysinfo/main.c
+++ b/muxsysinfo/main.c
@@ -427,13 +427,6 @@ void init_elements() {
     lv_obj_set_user_data(ui_lblBatteryCap, "capacity");
     lv_obj_set_user_data(ui_lblVoltage, "voltage");
 
-    char *overlay = load_overlay_image();
-    if (strlen(overlay) > 0 && theme.MISC.IMAGE_OVERLAY) {
-        lv_obj_t *overlay_img = lv_img_create(ui_screen);
-        lv_img_set_src(overlay_img, overlay);
-        lv_obj_move_foreground(overlay_img);
-    }
-
     if (TEST_IMAGE) display_testing_message(ui_screen);
 }
 
@@ -574,6 +567,7 @@ int main(int argc, char *argv[]) {
     ui_common_screen_init(&theme, &device, TS("SYSTEM DETAILS"));
     ui_init(ui_pnlContent);
     init_elements();
+    load_overlay_image(ui_screen, theme.MISC.IMAGE_OVERLAY);
 
     lv_obj_set_user_data(ui_screen, basename(argv[0]));
 

--- a/muxtask/main.c
+++ b/muxtask/main.c
@@ -327,13 +327,6 @@ void init_elements() {
         lv_obj_clear_flag(ui_lblNavAGlyph, LV_OBJ_FLAG_FLOATING);
     }
 
-    char *overlay = load_overlay_image();
-    if (strlen(overlay) > 0 && theme.MISC.IMAGE_OVERLAY) {
-        lv_obj_t *overlay_img = lv_img_create(ui_screen);
-        lv_img_set_src(overlay_img, overlay);
-        lv_obj_move_foreground(overlay_img);
-    }
-
     if (TEST_IMAGE) display_testing_message(ui_screen);
 }
 
@@ -489,6 +482,7 @@ int main(int argc, char *argv[]) {
 
     ui_common_screen_init(&theme, &device, TS("TASK TOOLKIT"));
     init_elements();
+    load_overlay_image(ui_screen, theme.MISC.IMAGE_OVERLAY);
 
     lv_obj_set_user_data(ui_screen, basename(argv[0]));
 

--- a/muxtester/main.c
+++ b/muxtester/main.c
@@ -127,13 +127,6 @@ void init_elements() {
     process_visual_element(NETWORK, ui_staNetwork);
     process_visual_element(BATTERY, ui_staCapacity);
 
-    char *overlay = load_overlay_image();
-    if (strlen(overlay) > 0 && theme.MISC.IMAGE_OVERLAY) {
-        lv_obj_t *overlay_img = lv_img_create(ui_screen);
-        lv_img_set_src(overlay_img, overlay);
-        lv_obj_move_foreground(overlay_img);
-    }
-
     if (TEST_IMAGE) display_testing_message(ui_screen);
 }
 
@@ -174,6 +167,7 @@ int main(int argc, char *argv[]) {
     ui_common_screen_init(&theme, &device, TS("INPUT TESTER"));
     ui_init(ui_pnlContent);
     init_elements();
+    load_overlay_image(ui_screen, theme.MISC.IMAGE_OVERLAY);
 
     lv_obj_set_user_data(ui_screen, basename(argv[0]));
 

--- a/muxtheme/main.c
+++ b/muxtheme/main.c
@@ -283,13 +283,6 @@ void init_elements() {
         lv_obj_add_flag(nav_hide[i], LV_OBJ_FLAG_FLOATING);
     }
 
-    char *overlay = load_overlay_image();
-    if (strlen(overlay) > 0 && theme.MISC.IMAGE_OVERLAY) {
-        lv_obj_t *overlay_img = lv_img_create(ui_screen);
-        lv_img_set_src(overlay_img, overlay);
-        lv_obj_move_foreground(overlay_img);
-    }
-
     if (TEST_IMAGE) display_testing_message(ui_screen);
 }
 
@@ -431,6 +424,7 @@ int main(int argc, char *argv[]) {
 
     ui_common_screen_init(&theme, &device, TS("THEME PICKER"));
     init_elements();
+    load_overlay_image(ui_screen, theme.MISC.IMAGE_OVERLAY);
     lv_label_set_text(ui_lblScreenMessage, TS("No Themes Found"));
 
     lv_obj_set_user_data(ui_screen, basename(argv[0]));

--- a/muxtimezone/main.c
+++ b/muxtimezone/main.c
@@ -201,13 +201,6 @@ void init_elements() {
         lv_obj_add_flag(nav_hide[i], LV_OBJ_FLAG_FLOATING);
     }
 
-    char *overlay = load_overlay_image();
-    if (strlen(overlay) > 0 && theme.MISC.IMAGE_OVERLAY) {
-        lv_obj_t *overlay_img = lv_img_create(ui_screen);
-        lv_img_set_src(overlay_img, overlay);
-        lv_obj_move_foreground(overlay_img);
-    }
-
     if (TEST_IMAGE) display_testing_message(ui_screen);
 }
 
@@ -352,6 +345,7 @@ int main(int argc, char *argv[]) {
 
     ui_common_screen_init(&theme, &device, TS("TIMEZONE"));
     init_elements();
+    load_overlay_image(ui_screen, theme.MISC.IMAGE_OVERLAY);
 
     lv_obj_set_user_data(ui_screen, basename(argv[0]));
 

--- a/muxtweakadv/main.c
+++ b/muxtweakadv/main.c
@@ -939,13 +939,6 @@ void init_elements() {
         ui_count--;
     }
 
-    char *overlay = load_overlay_image();
-    if (strlen(overlay) > 0 && theme.MISC.IMAGE_OVERLAY) {
-        lv_obj_t *overlay_img = lv_img_create(ui_screen);
-        lv_img_set_src(overlay_img, overlay);
-        lv_obj_move_foreground(overlay_img);
-    }
-
     if (TEST_IMAGE) display_testing_message(ui_screen);
 }
 
@@ -1107,6 +1100,7 @@ int main(int argc, char *argv[]) {
     ui_common_screen_init(&theme, &device, TS("ADVANCED SETTINGS"));
     ui_init(ui_pnlContent);
     init_elements();
+    load_overlay_image(ui_screen, theme.MISC.IMAGE_OVERLAY);
 
     lv_obj_set_user_data(ui_screen, basename(argv[0]));
 

--- a/muxtweakgen/main.c
+++ b/muxtweakgen/main.c
@@ -646,13 +646,6 @@ void init_elements() {
         ui_count--;
     }
 
-    char *overlay = load_overlay_image();
-    if (strlen(overlay) > 0 && theme.MISC.IMAGE_OVERLAY) {
-        lv_obj_t *overlay_img = lv_img_create(ui_screen);
-        lv_img_set_src(overlay_img, overlay);
-        lv_obj_move_foreground(overlay_img);
-    }
-
     if (TEST_IMAGE) display_testing_message(ui_screen);
 }
 
@@ -814,6 +807,7 @@ int main(int argc, char *argv[]) {
     ui_common_screen_init(&theme, &device, TS("GENERAL SETTINGS"));
     ui_init(ui_pnlContent);
     init_elements();
+    load_overlay_image(ui_screen, theme.MISC.IMAGE_OVERLAY);
 
     lv_obj_set_user_data(ui_screen, basename(argv[0]));
 

--- a/muxvisual/main.c
+++ b/muxvisual/main.c
@@ -769,13 +769,6 @@ void init_elements() {
         ui_count -= 1;
     }
 
-    char *overlay = load_overlay_image();
-    if (strlen(overlay) > 0 && theme.MISC.IMAGE_OVERLAY) {
-        lv_obj_t *overlay_img = lv_img_create(ui_screen);
-        lv_img_set_src(overlay_img, overlay);
-        lv_obj_move_foreground(overlay_img);
-    }
-
     if (TEST_IMAGE) display_testing_message(ui_screen);
 }
 
@@ -1000,6 +993,7 @@ int main(int argc, char *argv[]) {
     lv_timer_ready(ui_refresh_timer);
 
     init_elements();
+    load_overlay_image(ui_screen, theme.MISC.IMAGE_OVERLAY);
     refresh_screen();
     mux_input_options input_opts = {
             .gamepad_fd = js_fd,

--- a/muxwebserv/main.c
+++ b/muxwebserv/main.c
@@ -478,13 +478,6 @@ void init_elements() {
     lv_obj_set_user_data(ui_lblResilio, "resilio");
     lv_obj_set_user_data(ui_lblNTP, "ntp");
 
-    char *overlay = load_overlay_image();
-    if (strlen(overlay) > 0 && theme.MISC.IMAGE_OVERLAY) {
-        lv_obj_t *overlay_img = lv_img_create(ui_screen);
-        lv_img_set_src(overlay_img, overlay);
-        lv_obj_move_foreground(overlay_img);
-    }
-
     if (TEST_IMAGE) display_testing_message(ui_screen);
 }
 
@@ -625,6 +618,7 @@ int main(int argc, char *argv[]) {
     ui_common_screen_init(&theme, &device, TS("WEB SERVICES"));
     ui_init(ui_pnlContent);
     init_elements();
+    load_overlay_image(ui_screen, theme.MISC.IMAGE_OVERLAY);
 
     lv_obj_set_user_data(ui_screen, basename(argv[0]));
 


### PR DESCRIPTION
On some screens init elements gets called more than once causing the overlay to be applied multiple times making the screen darker than expected