### PR TITLE
Remove muhotkey on `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ info:
 	$(info Modules: $(MODULES))
 
 clean:
-	@rm -rf bin/mux* .build_count
+	@rm -rf bin/mu* .build_count
 
 $(MODULES):
 	@if [ -f "$@/Makefile" ]; then \


### PR DESCRIPTION
Alternatively, should I rename `muhotkey` to `muxhotkey`? I initially thought the `mux` binaries were the GUI apps, whereas the `mu` binaries (like `mushutdown` we used to have) where CLI utilities, but now I'm not so sure. :)