### PR TITLE
Fix implicit-function-declaration in muxnetscan

### DIFF
--- a/muxnetscan/main.c
+++ b/muxnetscan/main.c
@@ -1,3 +1,5 @@
+#define _GNU_SOURCE
+
 #include "../lvgl/lvgl.h"
 #include "../lvgl/drivers/display/fbdev.h"
 #include "../lvgl/drivers/indev/evdev.h"


### PR DESCRIPTION
Missed this one in #113. Need to set _GNU_SOURCE for pthread_tryjoin_np to get defined in pthread.h.