### PR TITLE
Fix volume icon getting out of sync with progress bar

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -1619,9 +1619,25 @@ char *get_script_value(const char *filename, const char *key) {
     return value;
 }
 
-void update_bars(lv_obj_t *bright_bar, lv_obj_t *volume_bar) {
+void update_bars(lv_obj_t *bright_bar, lv_obj_t *volume_bar, lv_obj_t *volume_icon) {
     lv_bar_set_value(bright_bar, read_int_from_file(BRIGHT_PERC, 1), LV_ANIM_ON);
-    lv_bar_set_value(volume_bar, read_int_from_file(VOLUME_PERC, 1), LV_ANIM_ON);
+    int volume = read_int_from_file(VOLUME_PERC, 1);
+    lv_bar_set_value(volume_bar, volume, LV_ANIM_ON);
+    switch (volume) {
+        default:
+        case 0:
+            lv_label_set_text(volume_icon, "\uF6A9");
+            break;
+        case 1 ... 46:
+            lv_label_set_text(volume_icon, "\uF026");
+            break;
+        case 47 ... 71:
+            lv_label_set_text(volume_icon, "\uF027");
+            break;
+        case 72 ... 100:
+            lv_label_set_text(volume_icon, "\uF028");
+            break;
+    }
 }
 
 int extract_file_from_zip(const char *zip_path, const char *file_name, const char *output_path) {

--- a/common/common.c
+++ b/common/common.c
@@ -1620,7 +1620,12 @@ char *get_script_value(const char *filename, const char *key) {
 }
 
 void update_bars(lv_obj_t *bright_bar, lv_obj_t *volume_bar, lv_obj_t *volume_icon) {
+    if (!progress_onscreen) {
+        return;
+    }
+
     lv_bar_set_value(bright_bar, read_int_from_file(BRIGHT_PERC, 1), LV_ANIM_ON);
+
     int volume = read_int_from_file(VOLUME_PERC, 1);
     lv_bar_set_value(volume_bar, volume, LV_ANIM_ON);
     switch (volume) {

--- a/common/common.h
+++ b/common/common.h
@@ -212,7 +212,7 @@ char *generate_number_string(int min, int max, int increment, const char *prefix
 
 char *get_script_value(const char *filename, const char *key);
 
-void update_bars(lv_obj_t *bright_bar, lv_obj_t *volume_bar);
+void update_bars(lv_obj_t *bright_bar, lv_obj_t *volume_bar, lv_obj_t *volume_icon);
 
 int extract_file_from_zip(const char *zip_path, const char *file_name, const char *output_path);
 

--- a/common/ui_common.c
+++ b/common/ui_common.c
@@ -693,6 +693,7 @@ void ui_common_handle_bright() {
     progress_onscreen = 1;
     lv_obj_add_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
     lv_obj_clear_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
+    update_bars(ui_barProgressBrightness, ui_barProgressVolume, ui_icoProgressVolume);
 }
 
 void ui_common_handle_vol() {
@@ -703,6 +704,7 @@ void ui_common_handle_vol() {
     progress_onscreen = 2;
     lv_obj_add_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
     lv_obj_clear_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
+    update_bars(ui_barProgressBrightness, ui_barProgressVolume, ui_icoProgressVolume);
 }
 
 void ui_common_handle_idle() {

--- a/common/ui_common.c
+++ b/common/ui_common.c
@@ -599,7 +599,7 @@ void ui_common_screen_init(struct theme_config *theme, struct mux_device *device
     lv_obj_set_x(ui_icoProgressBrightness, -220);
     lv_obj_set_y(ui_icoProgressBrightness, -205);
     lv_obj_set_align(ui_icoProgressBrightness, LV_ALIGN_CENTER);
-    lv_label_set_text(ui_icoProgressBrightness, "");
+    lv_label_set_text(ui_icoProgressBrightness, "\uF185");
     lv_label_set_recolor(ui_icoProgressBrightness, "true");
     lv_obj_set_style_text_color(ui_icoProgressBrightness, lv_color_hex(theme->BAR.ICON),
                                 LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -693,8 +693,6 @@ void ui_common_handle_bright() {
     progress_onscreen = 1;
     lv_obj_add_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
     lv_obj_clear_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
-    lv_label_set_text(ui_icoProgressBrightness, "\uF185");
-    lv_bar_set_value(ui_barProgressBrightness, atoi(read_text_from_file(BRIGHT_PERC)), LV_ANIM_OFF);
 }
 
 void ui_common_handle_vol() {
@@ -705,23 +703,6 @@ void ui_common_handle_vol() {
     progress_onscreen = 2;
     lv_obj_add_flag(ui_pnlProgressBrightness, LV_OBJ_FLAG_HIDDEN);
     lv_obj_clear_flag(ui_pnlProgressVolume, LV_OBJ_FLAG_HIDDEN);
-    int volume = atoi(read_text_from_file(VOLUME_PERC));
-    switch (volume) {
-        default:
-        case 0:
-            lv_label_set_text(ui_icoProgressVolume, "\uF6A9");
-            break;
-        case 1 ... 46:
-            lv_label_set_text(ui_icoProgressVolume, "\uF026");
-            break;
-        case 47 ... 71:
-            lv_label_set_text(ui_icoProgressVolume, "\uF027");
-            break;
-        case 72 ... 100:
-            lv_label_set_text(ui_icoProgressVolume, "\uF028");
-            break;
-    }
-    lv_bar_set_value(ui_barProgressVolume, volume, LV_ANIM_OFF);
 }
 
 void ui_common_handle_idle() {

--- a/muxapp/main.c
+++ b/muxapp/main.c
@@ -354,7 +354,7 @@ void glyph_task() {
 }
 
 void ui_refresh_task() {
-    update_bars(ui_barProgressBrightness, ui_barProgressVolume);
+    update_bars(ui_barProgressBrightness, ui_barProgressVolume, ui_icoProgressVolume);
 
     if (nav_moved) {
         if (lv_group_get_obj_count(ui_group) > 0) {

--- a/muxarchive/main.c
+++ b/muxarchive/main.c
@@ -352,7 +352,7 @@ void glyph_task() {
 }
 
 void ui_refresh_task() {
-    update_bars(ui_barProgressBrightness, ui_barProgressVolume);
+    update_bars(ui_barProgressBrightness, ui_barProgressVolume, ui_icoProgressVolume);
 
     if (nav_moved) {
         if (lv_group_get_obj_count(ui_group) > 0) adjust_wallpaper_element(ui_group, 0);

--- a/muxassign/main.c
+++ b/muxassign/main.c
@@ -764,7 +764,7 @@ void glyph_task() {
 }
 
 void ui_refresh_task() {
-    update_bars(ui_barProgressBrightness, ui_barProgressVolume);
+    update_bars(ui_barProgressBrightness, ui_barProgressVolume, ui_icoProgressVolume);
 
     if (nav_moved) {
         if (lv_group_get_obj_count(ui_group) > 0) adjust_wallpaper_element(ui_group, 0);

--- a/muxconfig/main.c
+++ b/muxconfig/main.c
@@ -304,7 +304,7 @@ void glyph_task() {
 }
 
 void ui_refresh_task() {
-    update_bars(ui_barProgressBrightness, ui_barProgressVolume);
+    update_bars(ui_barProgressBrightness, ui_barProgressVolume, ui_icoProgressVolume);
 
     if (nav_moved) {
         if (lv_group_get_obj_count(ui_group) > 0) adjust_wallpaper_element(ui_group, 0);

--- a/muxgov/main.c
+++ b/muxgov/main.c
@@ -430,7 +430,7 @@ void glyph_task() {
 }
 
 void ui_refresh_task() {
-    update_bars(ui_barProgressBrightness, ui_barProgressVolume);
+    update_bars(ui_barProgressBrightness, ui_barProgressVolume, ui_icoProgressVolume);
 
     if (nav_moved) {
         if (lv_group_get_obj_count(ui_group) > 0) adjust_wallpaper_element(ui_group, 0);

--- a/muxinfo/main.c
+++ b/muxinfo/main.c
@@ -272,7 +272,7 @@ void glyph_task() {
 }
 
 void ui_refresh_task() {
-    update_bars(ui_barProgressBrightness, ui_barProgressVolume);
+    update_bars(ui_barProgressBrightness, ui_barProgressVolume, ui_icoProgressVolume);
 
     if (nav_moved) {
         if (lv_group_get_obj_count(ui_group) > 0) adjust_wallpaper_element(ui_group, 0);

--- a/muxlanguage/main.c
+++ b/muxlanguage/main.c
@@ -259,7 +259,7 @@ void glyph_task() {
 }
 
 void ui_refresh_task() {
-    update_bars(ui_barProgressBrightness, ui_barProgressVolume);
+    update_bars(ui_barProgressBrightness, ui_barProgressVolume, ui_icoProgressVolume);
 
     if (nav_moved) {
         if (lv_group_get_obj_count(ui_group) > 0) adjust_wallpaper_element(ui_group, 0);

--- a/muxlaunch/main.c
+++ b/muxlaunch/main.c
@@ -449,7 +449,7 @@ void glyph_task() {
 }
 
 void ui_refresh_task() {
-    update_bars(ui_barProgressBrightness, ui_barProgressVolume);
+    update_bars(ui_barProgressBrightness, ui_barProgressVolume, ui_icoProgressVolume);
 
     if (nav_moved) {
         if (lv_group_get_obj_count(ui_group) > 0) adjust_wallpaper_element(ui_group, 0);

--- a/muxnetprofile/main.c
+++ b/muxnetprofile/main.c
@@ -454,7 +454,7 @@ void glyph_task() {
 }
 
 void ui_refresh_task() {
-    update_bars(ui_barProgressBrightness, ui_barProgressVolume);
+    update_bars(ui_barProgressBrightness, ui_barProgressVolume, ui_icoProgressVolume);
 
     if (nav_moved) {
         if (lv_group_get_obj_count(ui_group) > 0) adjust_wallpaper_element(ui_group, 0);

--- a/muxnetscan/main.c
+++ b/muxnetscan/main.c
@@ -258,7 +258,7 @@ void glyph_task() {
 }
 
 void ui_refresh_task() {
-    update_bars(ui_barProgressBrightness, ui_barProgressVolume);
+    update_bars(ui_barProgressBrightness, ui_barProgressVolume, ui_icoProgressVolume);
 
     if (nav_moved) {
         if (lv_group_get_obj_count(ui_group) > 0) adjust_wallpaper_element(ui_group, 0);

--- a/muxnetwork/main.c
+++ b/muxnetwork/main.c
@@ -1248,7 +1248,7 @@ void glyph_task() {
 }
 
 void ui_refresh_task() {
-    update_bars(ui_barProgressBrightness, ui_barProgressVolume);
+    update_bars(ui_barProgressBrightness, ui_barProgressVolume, ui_icoProgressVolume);
 
     if (nav_moved) {
         if (lv_group_get_obj_count(ui_group) > 0) adjust_wallpaper_element(ui_group, 0);

--- a/muxoption/main.c
+++ b/muxoption/main.c
@@ -259,7 +259,7 @@ void glyph_task() {
 }
 
 void ui_refresh_task() {
-    update_bars(ui_barProgressBrightness, ui_barProgressVolume);
+    update_bars(ui_barProgressBrightness, ui_barProgressVolume, ui_icoProgressVolume);
 
     if (nav_moved) {
         if (lv_group_get_obj_count(ui_group) > 0) adjust_wallpaper_element(ui_group, 0);

--- a/muxplore/main.c
+++ b/muxplore/main.c
@@ -1777,7 +1777,7 @@ void glyph_task() {
 }
 
 void ui_refresh_task() {
-    update_bars(ui_barProgressBrightness, ui_barProgressVolume);
+    update_bars(ui_barProgressBrightness, ui_barProgressVolume, ui_icoProgressVolume);
 
     if (!nav_moved & !fade_timeout) {
         if (counter_fade > 0) {

--- a/muxpower/main.c
+++ b/muxpower/main.c
@@ -410,7 +410,7 @@ void glyph_task() {
 }
 
 void ui_refresh_task() {
-    update_bars(ui_barProgressBrightness, ui_barProgressVolume);
+    update_bars(ui_barProgressBrightness, ui_barProgressVolume, ui_icoProgressVolume);
 
     if (nav_moved) {
         if (lv_group_get_obj_count(ui_group) > 0) adjust_wallpaper_element(ui_group, 0);

--- a/muxrtc/main.c
+++ b/muxrtc/main.c
@@ -646,7 +646,7 @@ void glyph_task() {
 }
 
 void ui_refresh_task() {
-    update_bars(ui_barProgressBrightness, ui_barProgressVolume);
+    update_bars(ui_barProgressBrightness, ui_barProgressVolume, ui_icoProgressVolume);
 
     if (nav_moved) {
         if (lv_group_get_obj_count(ui_group) > 0) adjust_wallpaper_element(ui_group, 0);

--- a/muxstorage/main.c
+++ b/muxstorage/main.c
@@ -433,7 +433,7 @@ void glyph_task() {
 }
 
 void ui_refresh_task() {
-    update_bars(ui_barProgressBrightness, ui_barProgressVolume);
+    update_bars(ui_barProgressBrightness, ui_barProgressVolume, ui_icoProgressVolume);
 
     if (nav_moved) {
         if (lv_group_get_obj_count(ui_group) > 0) adjust_wallpaper_element(ui_group, 0);

--- a/muxsysinfo/main.c
+++ b/muxsysinfo/main.c
@@ -455,7 +455,7 @@ void glyph_task() {
 }
 
 void ui_refresh_task() {
-    update_bars(ui_barProgressBrightness, ui_barProgressVolume);
+    update_bars(ui_barProgressBrightness, ui_barProgressVolume, ui_icoProgressVolume);
 
     if (nav_moved) {
         if (lv_group_get_obj_count(ui_group) > 0) adjust_wallpaper_element(ui_group, 0);

--- a/muxtask/main.c
+++ b/muxtask/main.c
@@ -368,7 +368,7 @@ void glyph_task() {
 }
 
 void ui_refresh_task() {
-    update_bars(ui_barProgressBrightness, ui_barProgressVolume);
+    update_bars(ui_barProgressBrightness, ui_barProgressVolume, ui_icoProgressVolume);
 
     if (nav_moved) {
         if (lv_group_get_obj_count(ui_group) > 0) {

--- a/muxtheme/main.c
+++ b/muxtheme/main.c
@@ -308,7 +308,7 @@ void glyph_task() {
 }
 
 void ui_refresh_task() {
-    update_bars(ui_barProgressBrightness, ui_barProgressVolume);
+    update_bars(ui_barProgressBrightness, ui_barProgressVolume, ui_icoProgressVolume);
 
     if (nav_moved) {
         image_refresh();

--- a/muxtimezone/main.c
+++ b/muxtimezone/main.c
@@ -228,7 +228,7 @@ void glyph_task() {
 }
 
 void ui_refresh_task() {
-    update_bars(ui_barProgressBrightness, ui_barProgressVolume);
+    update_bars(ui_barProgressBrightness, ui_barProgressVolume, ui_icoProgressVolume);
 
     if (nav_moved) {
         if (lv_group_get_obj_count(ui_group) > 0) adjust_wallpaper_element(ui_group, 0);

--- a/muxtweakadv/main.c
+++ b/muxtweakadv/main.c
@@ -765,7 +765,7 @@ void glyph_task() {
 }
 
 void ui_refresh_task() {
-    update_bars(ui_barProgressBrightness, ui_barProgressVolume);
+    update_bars(ui_barProgressBrightness, ui_barProgressVolume, ui_icoProgressVolume);
 
     if (nav_moved) {
         if (lv_group_get_obj_count(ui_group) > 0) adjust_wallpaper_element(ui_group, 0);

--- a/muxtweakgen/main.c
+++ b/muxtweakgen/main.c
@@ -570,7 +570,7 @@ void glyph_task() {
 }
 
 void ui_refresh_task() {
-    update_bars(ui_barProgressBrightness, ui_barProgressVolume);
+    update_bars(ui_barProgressBrightness, ui_barProgressVolume, ui_icoProgressVolume);
 
     if (nav_moved) {
         if (lv_group_get_obj_count(ui_group) > 0) adjust_wallpaper_element(ui_group, 0);

--- a/muxvisual/main.c
+++ b/muxvisual/main.c
@@ -603,7 +603,7 @@ void glyph_task() {
 }
 
 void ui_refresh_task() {
-    update_bars(ui_barProgressBrightness, ui_barProgressVolume);
+    update_bars(ui_barProgressBrightness, ui_barProgressVolume, ui_icoProgressVolume);
 
     if (nav_moved) {
         if (lv_group_get_obj_count(ui_group) > 0) adjust_wallpaper_element(ui_group, 0);

--- a/muxwebserv/main.c
+++ b/muxwebserv/main.c
@@ -413,7 +413,7 @@ void glyph_task() {
 }
 
 void ui_refresh_task() {
-    update_bars(ui_barProgressBrightness, ui_barProgressVolume);
+    update_bars(ui_barProgressBrightness, ui_barProgressVolume, ui_icoProgressVolume);
 
     if (nav_moved) {
         if (lv_group_get_obj_count(ui_group) > 0) adjust_wallpaper_element(ui_group, 0);


### PR DESCRIPTION
As [reported on Discord](https://discord.com/channels/1152022492001603615/1297926619838550048), the icon in the volume popup gets one step out of sync with the progress bar. (It's most noticeable with the "mute" icon when the volume gets turned out to zero.)

Happens because we update the volume _level_ on every file, but we only update the _icon_ in the input handler. We're already reading the volume file in `update_bars`, so moving the icon update there resolves that issue. Now the "mute" icon shows up only when the volume bar is showing zero.

Additionally, we may as well skip reading `brightness.txt` and `volume.txt` when the relevant bar isn't onscreen. (It's not super expensive, but saving two file reads each frame can't hurt.)