### PR TITLE
Parse from JSON and auto-sort combos in muhotkey

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -393,7 +393,7 @@ char *read_battery_voltage() {
     return form_voltage;
 }
 
-char *read_text_from_file(char *filename) {
+char *read_text_from_file(const char *filename) {
     char *text = NULL;
     FILE *file = fopen(filename, "r");
 

--- a/common/common.h
+++ b/common/common.h
@@ -103,7 +103,7 @@ char *read_battery_health();
 
 char *read_battery_voltage();
 
-char *read_text_from_file(char *filename);
+char *read_text_from_file(const char *filename);
 
 char *read_line_from_file(const char *filename, size_t line_number);
 

--- a/common/input.h
+++ b/common/input.h
@@ -75,8 +75,9 @@ typedef void (*mux_input_catchall_combo_handler)(int, mux_input_action);
 
 // Configuration for a multi-input combo.
 typedef struct {
-    // Bitmask of input types included in the combo. Every input in this mask must be pressed for
-    // the combo to activate.
+    // Bitmask of input types. Every input in this mask must be pressed for the combo to activate.
+    // (The combo can activate even when inputs _not_ in the mask are _also_ pressed. This allows
+    // hotkeys to function in cases like pressing volume while holding the D-pad in a game.)
     uint64_t type_mask;
 
     // Callback functions for combo. Fired in sequence: one press, zero or more holds, one release.

--- a/muhotkey/Makefile
+++ b/muhotkey/Makefile
@@ -50,6 +50,7 @@ compile: $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS)
 	@printf "Building: %s... " "$(TARGET)"
 	@START=$(START_TIME); \
 	$(CC) -D$(DEVICE) $(MAINOBJ) $(AOBJS) $(COBJS) $(SOBJS) -o $(TARGET) \
+		../common/json/json.c \
 		../common/config.c \
 		../common/device.c \
 		../common/common.c \


### PR DESCRIPTION
Now that system hotkeys are configured via a JSON file, it makes sense for `muhotkey` to parse them directly rather than `hotkey.sh` having to convert the JSON file to the existing command-line format.

Additionally, it's inconvenient to need to order the hotkeys correctly by hand. (And in case we ever do want to have a GUI app to configure hotkeys, we won't be able to rely on a specific ordering.)

Instead, this change makes `muhotkey` sort combos from longest (most keys) to shortest (least keys), so that e.g. VOL_UP+MENU_LONG is always checked before VOL_UP (regardless of their order in the JSON file).

I also made a few other minor code cleanups while I'm in here.