### PR TITLE
Add /active suffix to fallback theme path

### DIFF
--- a/common/options.h
+++ b/common/options.h
@@ -11,7 +11,7 @@
 #define TIME_STRING_24 "%H:%M"
 
 #define INTERNAL_PATH  "/opt/muos"
-#define INTERNAL_THEME "/opt/muos/default/MUOS/theme"
+#define INTERNAL_THEME "/opt/muos/default/MUOS/theme/active"
 
 #define STORAGE_PATH   "/run/muos/storage"
 #define ACTIVE_THEME   "/run/muos/storage/theme/active"


### PR DESCRIPTION
`/opt/muos/default/MUOS/theme` is a full copy of the default themes (plural) for the [restore script](https://github.com/MustardOS/internal/blob/3f4f5e726e9ab6fe2dddca757417b86fd7cbad28/init/MUOS/task/Restore%20Themes.sh).

So the unzipped copy of the initially active theme for fallback purposes lives in the subdirectory at `/opt/muos/default/MUOS/theme/active`.

---

For reference, here is where `default/MUOS/theme` is populated for the [rootfs](https://github.com/MustardOS/tool/blob/3d26eb2980cc312aea4eb9fb7f2d1cbef7ea1465/update_rootfs.sh#L62) and [updates](https://github.com/MustardOS/tool/blob/3d26eb2980cc312aea4eb9fb7f2d1cbef7ea1465/gen_update.sh#L140).