### PR TITLE
Increase upper bound on random image range

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -1188,7 +1188,7 @@ void load_image_random(lv_obj_t *ui_imgWall, char *base_image_path) {
     img_obj = ui_imgWall;
 
     if (img_paths_count > 0) {
-        lv_img_set_src(ui_imgWall, img_paths[arc4random() % (img_paths_count - 1)]);
+        lv_img_set_src(ui_imgWall, img_paths[arc4random() % img_paths_count]);
     } else {
         lv_img_set_src(ui_imgWall, &ui_image_Nothing);
     }


### PR DESCRIPTION
For the display of random backgrounds based on PNG sequences, this change puts the last image in the sequence within range for random selection