### PR TITLE
Add animation repeat count setting for themes

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -1047,7 +1047,9 @@ void load_wallpaper(lv_obj_t *ui_screen, lv_group_t *ui_group, lv_obj_t *ui_pnlW
                         lv_gif_set_src(wall_img, new_wall);
                         break;
                     case 2:
-                        load_image_animation(ui_imgWall, theme.ANIMATION.ANIMATION_DELAY, new_wall);
+                        load_image_animation(ui_imgWall, theme.ANIMATION.ANIMATION_DELAY, 
+                          theme.ANIMATION.ANIMATION_REPEAT > 0 ? theme.ANIMATION.ANIMATION_REPEAT : LV_ANIM_REPEAT_INFINITE, 
+                          new_wall);
                         break;
                     default:
                         lv_img_set_src(ui_imgWall, new_wall);
@@ -1231,7 +1233,7 @@ void load_image_random(lv_obj_t *ui_imgWall, char *base_image_path) {
     }
 }
 
-void load_image_animation(lv_obj_t *ui_imgWall, int animation_time, char *base_image_path) {
+void load_image_animation(lv_obj_t *ui_imgWall, int animation_time, int repeat_count, char *base_image_path) {
     printf("Load Image Animation: %s\n", base_image_path);
     img_paths_count = 0;
     build_image_array(base_image_path);
@@ -1246,7 +1248,7 @@ void load_image_animation(lv_obj_t *ui_imgWall, int animation_time, char *base_i
         lv_anim_set_values(&animation, 0, img_paths_count - 1);
         lv_anim_set_exec_cb(&animation, (lv_anim_exec_xcb_t) image_anim_cb);
         lv_anim_set_time(&animation, animation_time * img_paths_count);
-        lv_anim_set_repeat_count(&animation, LV_ANIM_REPEAT_INFINITE);
+        lv_anim_set_repeat_count(&animation, repeat_count);
 
         lv_anim_start(&animation);
     } else {

--- a/common/common.h
+++ b/common/common.h
@@ -179,7 +179,7 @@ int load_element_image_specifics(const char *theme_base, const char *mux_dimensi
 
 void load_image_random(lv_obj_t *ui_imgWall, char *base_image_path);
 
-void load_image_animation(lv_obj_t *ui_imgWall, int animation_time, char *current_wall);
+void load_image_animation(lv_obj_t *ui_imgWall, int animation_time, int repeat_count, char *current_wall);
 
 void unload_image_animation();
 

--- a/common/theme.c
+++ b/common/theme.c
@@ -378,7 +378,7 @@ void load_theme_from_scheme(const char *scheme, struct theme_config *theme, stru
 
     theme->ANIMATION.ANIMATION_DELAY = get_ini_int(muos_theme, "animation", "ANIMATION_DELAY", theme->ANIMATION.ANIMATION_DELAY);
     if (theme->ANIMATION.ANIMATION_DELAY < 10) theme->ANIMATION.ANIMATION_DELAY = 10;
-    theme->ANIMATION.ANIMATION_REPEAT = get_ini_int(muos_theme, "animation", "ANIMATION_REPEAT", theme->ANIMATION.ANIMATION_DELAY);
+    theme->ANIMATION.ANIMATION_REPEAT = get_ini_int(muos_theme, "animation", "ANIMATION_REPEAT", theme->ANIMATION.ANIMATION_REPEAT);
 
     theme->FONT.HEADER_PAD_TOP = get_ini_int(muos_theme, "font", "FONT_HEADER_PAD_TOP", theme->FONT.HEADER_PAD_TOP);
     theme->FONT.HEADER_PAD_BOTTOM = get_ini_int(muos_theme, "font", "FONT_HEADER_PAD_BOTTOM", theme->FONT.HEADER_PAD_BOTTOM);

--- a/common/theme.c
+++ b/common/theme.c
@@ -34,6 +34,7 @@ void init_theme_config(struct theme_config *theme, struct mux_device *device) {
     theme->SYSTEM.BACKGROUND_ALPHA = 255;
 
     theme->ANIMATION.ANIMATION_DELAY = 100;
+    theme->ANIMATION.ANIMATION_REPEAT = 0;
 
     theme->FONT.HEADER_PAD_TOP = 0;
     theme->FONT.HEADER_PAD_BOTTOM = 0;
@@ -377,6 +378,7 @@ void load_theme_from_scheme(const char *scheme, struct theme_config *theme, stru
 
     theme->ANIMATION.ANIMATION_DELAY = get_ini_int(muos_theme, "animation", "ANIMATION_DELAY", theme->ANIMATION.ANIMATION_DELAY);
     if (theme->ANIMATION.ANIMATION_DELAY < 10) theme->ANIMATION.ANIMATION_DELAY = 10;
+    theme->ANIMATION.ANIMATION_REPEAT = get_ini_int(muos_theme, "animation", "ANIMATION_REPEAT", theme->ANIMATION.ANIMATION_DELAY);
 
     theme->FONT.HEADER_PAD_TOP = get_ini_int(muos_theme, "font", "FONT_HEADER_PAD_TOP", theme->FONT.HEADER_PAD_TOP);
     theme->FONT.HEADER_PAD_BOTTOM = get_ini_int(muos_theme, "font", "FONT_HEADER_PAD_BOTTOM", theme->FONT.HEADER_PAD_BOTTOM);

--- a/common/theme.h
+++ b/common/theme.h
@@ -32,6 +32,7 @@ struct theme_config {
 
     struct {
         int16_t ANIMATION_DELAY;
+        int16_t ANIMATION_REPEAT;
     } ANIMATION;
 
     struct {


### PR DESCRIPTION
- Added a way to control the repetition count for background animations via ANIMATION_REPEAT property in [animation] section
  - It defaults to 0 which is the previous default behavior (infinite loop)
  - If set to anything bigger than that, the background will loop only that amount of times
  - This setting will do nothing for GIF backgrounds, as LVGL doesn't have a way to control the repeat count in GIFs

This opens up a way to create enter animations in themes.