### PR TITLE
Add 12h and 24h options for sleep timer 

### DIFF
--- a/common/language.c
+++ b/common/language.c
@@ -328,6 +328,8 @@ void load_lang(struct mux_lang *lang) {
     SPECIFIC_FIELD(lang->MUXPOWER.SLEEP.t15m, "Sleep 15m + Shutdown");
     SPECIFIC_FIELD(lang->MUXPOWER.SLEEP.t30m, "Sleep 30m + Shutdown");
     SPECIFIC_FIELD(lang->MUXPOWER.SLEEP.t60m, "Sleep 60m + Shutdown");
+    SPECIFIC_FIELD(lang->MUXPOWER.SLEEP.t12h, "Sleep 12h + Shutdown");
+    SPECIFIC_FIELD(lang->MUXPOWER.SLEEP.t24h, "Sleep 24h + Shutdown");
     SPECIFIC_FIELD(lang->MUXPOWER.HELP.IDLE_SLEEP, "Configure the time the device will sleep when no input is detected");
     SPECIFIC_FIELD(lang->MUXPOWER.HELP.IDLE_DISPLAY, "Configure the time the screen will dim when no input is detected");
     SPECIFIC_FIELD(lang->MUXPOWER.HELP.LOW_BATTERY, "Configure when the red LED will display based on the current capacity percentage");

--- a/common/language.h
+++ b/common/language.h
@@ -370,6 +370,8 @@ struct mux_lang {
             char t15m[MAX_BUFFER_SIZE];
             char t30m[MAX_BUFFER_SIZE];
             char t60m[MAX_BUFFER_SIZE];
+            char t12h[MAX_BUFFER_SIZE];
+            char t24h[MAX_BUFFER_SIZE];
         } SLEEP;
         struct {
             char IDLE_DISPLAY[MAX_BUFFER_SIZE];

--- a/module/muxpower.c
+++ b/module/muxpower.c
@@ -119,7 +119,7 @@ void init_dropdown_settings() {
 
 void restore_tweak_options() {
     map_drop_down_to_index(ui_droShutdown, config.SETTINGS.POWER.SHUTDOWN,
-                           (int[]) {-2, -1, 2, 10, 30, 60, 120, 300, 600, 1800, 3600}, 11, 0);
+                           (int[]) {-2, -1, 2, 10, 30, 60, 120, 300, 600, 1800, 3600, 43200, 86400}, 13, 0);
 
     map_drop_down_to_index(ui_droBattery, config.SETTINGS.POWER.LOW_BATTERY,
                            (int[]) {-255, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50}, 11, 5);
@@ -133,7 +133,7 @@ void restore_tweak_options() {
 
 void save_tweak_options() {
     int idx_shutdown = map_drop_down_to_value(lv_dropdown_get_selected(ui_droShutdown),
-                                              (int[]) {-2, -1, 2, 10, 30, 60, 120, 300, 600, 900, 1800, 3600}, 12, -2);
+                                              (int[]) {-2, -1, 2, 10, 30, 60, 120, 300, 600, 900, 1800, 3600, 43200, 86400}, 14, -2);
 
     int idx_battery = map_drop_down_to_value(lv_dropdown_get_selected(ui_droBattery),
                                              (int[]) {-255, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50}, 11, 25);
@@ -229,9 +229,10 @@ void init_navigation_group() {
             lang.GENERIC.DISABLED, lang.MUXPOWER.SLEEP.SUSPEND, lang.MUXPOWER.SLEEP.INSTANT,
             lang.MUXPOWER.SLEEP.t10s, lang.MUXPOWER.SLEEP.t30s, lang.MUXPOWER.SLEEP.t60s,
             lang.MUXPOWER.SLEEP.t2m, lang.MUXPOWER.SLEEP.t5m, lang.MUXPOWER.SLEEP.t10m,
-            lang.MUXPOWER.SLEEP.t15m, lang.MUXPOWER.SLEEP.t30m, lang.MUXPOWER.SLEEP.t60m
+            lang.MUXPOWER.SLEEP.t15m, lang.MUXPOWER.SLEEP.t30m, lang.MUXPOWER.SLEEP.t60m,
+            lang.MUXPOWER.SLEEP.t12h, lang.MUXPOWER.SLEEP.t24h
     };
-    add_drop_down_options(ui_droShutdown, sleep_timer, 11);
+    add_drop_down_options(ui_droShutdown, sleep_timer, 13);
 
     char *idle_timer[] = {
             lang.GENERIC.DISABLED, lang.MUXPOWER.IDLE.t10s, lang.MUXPOWER.IDLE.t30s,


### PR DESCRIPTION
Allows the selection of 12 hours and 24 hours as the maximum length the device will sleep for before automatically shutting down.