### PR TITLE
fix input tester detecting left stick as dpad

### DIFF
--- a/common/theme.c
+++ b/common/theme.c
@@ -897,6 +897,7 @@ void load_theme(struct theme_config *theme, struct mux_config *config, struct mu
     }
 
     theme->GRID.ENABLED = (theme->GRID.COLUMN_COUNT > 0 && theme->GRID.ROW_COUNT > 0);
+    if (theme->MISC.CONTENT.WIDTH == 0) theme->MISC.CONTENT.WIDTH = device->MUX.WIDTH;
     if (theme->MISC.CONTENT.HEIGHT > device->MUX.HEIGHT) theme->MISC.CONTENT.HEIGHT = device->MUX.HEIGHT;
     if (theme->MUX.ITEM.COUNT < 1) theme->MUX.ITEM.COUNT = 1;
     if (theme->MUX.ITEM.HEIGHT > 0) {

--- a/module/muxtester.c
+++ b/module/muxtester.c
@@ -186,6 +186,7 @@ int main(int argc, char *argv[]) {
             .input_handler = handle_input,
     };
     init_input(&input_opts, false);
+    input_opts.stick_nav = false;
     mux_input_task(&input_opts);
 
     return 0;


### PR DESCRIPTION
set content width to screen width when set to 0