### PR TITLE
fix size to content issues

### DIFF
--- a/module/muxapp.c
+++ b/module/muxapp.c
@@ -212,8 +212,8 @@ void create_app_items() {
                 lv_group_add_obj(ui_group_glyph, ui_lblAppItemGlyph);
                 lv_group_add_obj(ui_group_panel, ui_pnlApp);
 
-                apply_size_to_content(&theme, ui_pnlContent, ui_lblAppItem, ui_lblAppItemGlyph, items[i].name);
-                apply_text_long_dot(&theme, ui_pnlContent, ui_lblAppItem, items[i].name);
+                apply_size_to_content(&theme, ui_pnlContent, ui_lblAppItem, ui_lblAppItemGlyph, TS(items[i].name));
+                apply_text_long_dot(&theme, ui_pnlContent, ui_lblAppItem, TS(items[i].name));
                 ui_count++;
             }
         }

--- a/module/muxarchive.c
+++ b/module/muxarchive.c
@@ -185,7 +185,7 @@ void create_archive_items() {
 
         ui_count++;
 
-        add_item(&items, &item_count, base_filename, archive_store, item_glyph, ROM);
+        add_item(&items, &item_count, base_filename, strip_ext(archive_store), item_glyph, ROM);
 
         lv_obj_t *ui_pnlArchive = lv_obj_create(ui_pnlContent);
         apply_theme_list_panel(ui_pnlArchive);

--- a/module/muxconnect.c
+++ b/module/muxconnect.c
@@ -135,7 +135,6 @@ void add_item(lv_obj_t *ui_pnl, lv_obj_t *ui_lbl, lv_obj_t *ui_ico, lv_obj_t *ui
     lv_group_add_obj(ui_group_glyph, ui_ico);
     lv_group_add_obj(ui_group_panel, ui_pnl);
 
-    apply_size_to_content(&theme, ui_pnlContent, ui_lbl, ui_ico, item_text);
     apply_text_long_dot(&theme, ui_pnlContent, ui_lbl, item_text);
 }
 

--- a/module/muxcustom.c
+++ b/module/muxcustom.c
@@ -294,7 +294,6 @@ void init_navigation_group() {
         lv_group_add_obj(ui_group_glyph, ui_icons[i]);
         lv_group_add_obj(ui_group_panel, ui_objects_panel[i]);
 
-        apply_size_to_content(&theme, ui_pnlContent, ui_objects[i], ui_icons[i], lv_label_get_text(ui_objects[i]));
         apply_text_long_dot(&theme, ui_pnlContent, ui_objects[i], lv_label_get_text(ui_objects[i]));
     }
 

--- a/module/muxtask.c
+++ b/module/muxtask.c
@@ -168,7 +168,7 @@ void create_task_items() {
             lv_group_add_obj(ui_group_glyph, ui_lblTaskItemGlyph);
             lv_group_add_obj(ui_group_panel, ui_pnlTask);
 
-            apply_size_to_content(&theme, ui_pnlContent, ui_lblTaskItem, ui_lblTaskItemGlyph, task_store);
+            apply_size_to_content(&theme, ui_pnlContent, ui_lblTaskItem, ui_lblTaskItemGlyph, TS(task_store));
             apply_text_long_dot(&theme, ui_pnlContent, ui_lblTaskItem, TS(task_store));
         }
 


### PR DESCRIPTION
* fixed issue with size to content setting wrong width on Applications and Task Toolkit screens when using language other than English
* fixed issue with size to content not being disabled on Connectivity and Customization screens
* fixed issue with size to content setting incorrect width on Archive Manager due to not excluding file extension