### PR TITLE
Add 'lastapp' as an option for startup

### DIFF
--- a/common/language.c
+++ b/common/language.c
@@ -885,6 +885,7 @@ void load_lang(struct mux_lang *lang) {
     SPECIFIC_FIELD(lang->MUXTWEAKGEN.STARTUP.HISTORY, "History");
     SPECIFIC_FIELD(lang->MUXTWEAKGEN.STARTUP.LAST, "Last Game");
     SPECIFIC_FIELD(lang->MUXTWEAKGEN.STARTUP.RESUME, "Resume Game");
+    SPECIFIC_FIELD(lang->MUXTWEAKGEN.STARTUP.LASTAPP, "Last App");
     SPECIFIC_FIELD(lang->MUXTWEAKGEN.HELP.DATETIME, "Change your current date, time, and timezone");
     SPECIFIC_FIELD(lang->MUXTWEAKGEN.HELP.TEMP, "Change the colour temperature of the display if the device supports it");
     SPECIFIC_FIELD(lang->MUXTWEAKGEN.HELP.BRIGHT, "Change the brightness of the device to a specific level");

--- a/module/muxtweakgen.c
+++ b/module/muxtweakgen.c
@@ -57,7 +57,8 @@ static void restore_tweak_options(void) {
                              !strcasecmp(config.SETTINGS.GENERAL.STARTUP, "collection") ? 2 :
                              !strcasecmp(config.SETTINGS.GENERAL.STARTUP, "history") ? 3 :
                              !strcasecmp(config.SETTINGS.GENERAL.STARTUP, "last") ? 4 :
-                             !strcasecmp(config.SETTINGS.GENERAL.STARTUP, "resume") ? 5 : 0);
+                             !strcasecmp(config.SETTINGS.GENERAL.STARTUP, "resume") ? 5 :
+                             !strcasecmp(config.SETTINGS.GENERAL.STARTUP, "lastapp") ? 6 : 0);
 }
 
 static void set_setting_value(const char *script_name, int value, int offset) {
@@ -86,7 +87,8 @@ static void save_tweak_options(void) {
             "collection",
             "history",
             "last",
-            "resume"
+            "resume",
+            "lastapp"
     };
 
     CHECK_AND_SAVE_VAL(tweakgen, Startup, "settings/general/startup", CHAR, startup_options);
@@ -131,7 +133,8 @@ static void init_navigation_group(void) {
             lang.MUXTWEAKGEN.STARTUP.COLLECTION,
             lang.MUXTWEAKGEN.STARTUP.HISTORY,
             lang.MUXTWEAKGEN.STARTUP.LAST,
-            lang.MUXTWEAKGEN.STARTUP.RESUME
+            lang.MUXTWEAKGEN.STARTUP.RESUME,
+            lang.MUXTWEAKGEN.STARTUP.LASTAPP
     };
 
     INIT_OPTION_ITEM(-1, tweakgen, Rtc, lang.MUXTWEAKGEN.DATETIME, "clock", NULL, 0);
@@ -141,7 +144,7 @@ static void init_navigation_group(void) {
     INIT_OPTION_ITEM(-1, tweakgen, Volume, lang.MUXTWEAKGEN.VOLUME, "volume", NULL, 0);
     INIT_OPTION_ITEM(-1, tweakgen, Colour, lang.MUXTWEAKGEN.TEMP, "colour", NULL, 0);
     INIT_OPTION_ITEM(-1, tweakgen, Rgb, lang.MUXTWEAKGEN.RGB, "rgb", disabled_enabled, 2);
-    INIT_OPTION_ITEM(-1, tweakgen, Startup, lang.MUXTWEAKGEN.STARTUP.TITLE, "startup", startup_options, 6);
+    INIT_OPTION_ITEM(-1, tweakgen, Startup, lang.MUXTWEAKGEN.STARTUP.TITLE, "startup", startup_options, 7);
 
     char *brightness_values = generate_number_string(1, device.SCREEN.BRIGHT, 1, NULL, NULL, NULL, 0);
     apply_theme_list_drop_down(&theme, ui_droBrightness_tweakgen, brightness_values);


### PR DESCRIPTION
1. Add last app as a field 
2. Add last app as a startup option


Corresponding internal change: https://github.com/MustardOS/internal/pull/616

Is there any info on how to build frontend? I have test internal (since it's a *.sh change I can just push to my device) but haven't tested this PR as I'm unsure how to build MustardOS/frontend