### PR TITLE
Remove UNION storage name condition

### DIFF
--- a/module/muxsearch.c
+++ b/module/muxsearch.c
@@ -267,9 +267,6 @@ static void process_results(const char *json_results) {
                 snprintf(storage_name_short, sizeof(storage_name_short), "SD2");
             } else if (strcasecmp(storage_name_short, device.STORAGE.USB.MOUNT) == 0) {
                 snprintf(storage_name_short, sizeof(storage_name_short), "USB");
-            } else if (strstr(folder_name, "/mnt/union/")) {
-                snprintf(storage_name_short, sizeof(storage_name_short), "UNION");
-            }
         }
 
         char folder_name_short[MAX_BUFFER_SIZE] = "";


### PR DESCRIPTION
Removed the condition that checks for '/mnt/union/' in folder_name.