### PR TITLE
Added support for RGB Screen React mode

### DIFF
--- a/common/language.c
+++ b/common/language.c
@@ -1533,6 +1533,7 @@ static const lang_field lang_fields[] = {
     {"muxrgb", LANG_OFF(muxrgb.mode_name.stick_follow), lang_specific, "Stick Follow"},
     {"muxrgb", LANG_OFF(muxrgb.mode_name.preset_combo), lang_specific, "Preset Combo"},
     {"muxrgb", LANG_OFF(muxrgb.mode_name.theme_supplied), lang_specific, "Theme Supplied"},
+    {"muxrgb", LANG_OFF(muxrgb.mode_name.screen_react), lang_specific, "Screen React"},
     {"muxrgb", LANG_OFF(muxrgb.breath_speed_name.fast), lang_specific, "Fast"},
     {"muxrgb", LANG_OFF(muxrgb.breath_speed_name.medium), lang_specific, "Medium"},
     {"muxrgb", LANG_OFF(muxrgb.breath_speed_name.slow), lang_specific, "Slow"},

--- a/common/language.h
+++ b/common/language.h
@@ -1647,6 +1647,7 @@ struct mux_lang {
             char stick_follow[MAX_BUFFER_SIZE];
             char preset_combo[MAX_BUFFER_SIZE];
             char theme_supplied[MAX_BUFFER_SIZE];
+            char screen_react[MAX_BUFFER_SIZE];
         } mode_name;
         struct {
             char fast[MAX_BUFFER_SIZE];

--- a/common/rgb.h
+++ b/common/rgb.h
@@ -9,6 +9,7 @@ typedef enum {
     RGB_MODE_COLOUR_CYCLE = 7,
     RGB_MODE_RAINBOW = 8,
     RGB_MODE_STICK_FOLLOW = 9,
+    RGB_MODE_SCREEN_REACT = 10,
 } rgb_mode_t;
 
 typedef enum {

--- a/module/murgb.c
+++ b/module/murgb.c
@@ -587,6 +587,18 @@ static int dispatch_restore(void) {
     int saved_bright_raw = st.bright_raw;
     rgb_colour_t col_l = st.col_l, col_r = st.col_r, col_m = st.col_m, col_f1 = st.col_f1, col_f2 = st.col_f2;
 
+    if (saved_mode == 10) {
+        // Screen React: the rgb_react daemon drives the LEDs itself. Start it
+        // if it is not already running (it records its PID and exits on its
+        // own when the mode changes).
+        system(
+            "P=$(cat /run/muos/rgb_react.pid 2>/dev/null); "
+            "{ [ -n \"$P\" ] && kill -0 \"$P\" 2>/dev/null; } || "
+            "setsid -f /opt/muos/script/device/rgb_react.sh </dev/null >/dev/null 2>&1"
+        );
+        return 0;
+    }
+
     if (saved_mode == 6) return 0;
     if (saved_mode == 5) saved_mode = 0;
 

--- a/module/murgb.c
+++ b/module/murgb.c
@@ -589,9 +589,9 @@ static int dispatch_restore(void) {
     rgb_colour_t col_l = st.col_l, col_r = st.col_r, col_m = st.col_m, col_f1 = st.col_f1, col_f2 = st.col_f2;
 
     if (saved_mode == 10) {
-        // Screen React: the rgb_react daemon drives the LEDs itself. It records
-        // its PID and exits on its own if already running or when the mode
-        // changes, so a redundant launch is harmless.
+        // Screen React: the rgb_react daemon drives the LEDs itself. It keeps to
+        // a single instance and exits when the mode changes, so launching it on
+        // every restore is harmless.
         const char *args[] = {OPT_PATH "script/device/rgb_react.sh", NULL};
         run_exec(args, A_SIZE(args), 1, 0, NULL, NULL);
         return 0;

--- a/module/murgb.c
+++ b/module/murgb.c
@@ -10,6 +10,7 @@
 #include <unistd.h>
 #include "../common/colour.h"
 #include "../common/config.h"
+#include "../common/exec.h"
 #include "../common/fileio.h"
 #include "../common/strutil.h"
 #include "../common/theme.h"
@@ -588,14 +589,11 @@ static int dispatch_restore(void) {
     rgb_colour_t col_l = st.col_l, col_r = st.col_r, col_m = st.col_m, col_f1 = st.col_f1, col_f2 = st.col_f2;
 
     if (saved_mode == 10) {
-        // Screen React: the rgb_react daemon drives the LEDs itself. Start it
-        // if it is not already running (it records its PID and exits on its
-        // own when the mode changes).
-        system(
-            "P=$(cat /run/muos/rgb_react.pid 2>/dev/null); "
-            "{ [ -n \"$P\" ] && kill -0 \"$P\" 2>/dev/null; } || "
-            "setsid -f /opt/muos/script/device/rgb_react.sh </dev/null >/dev/null 2>&1"
-        );
+        // Screen React: the rgb_react daemon drives the LEDs itself. It records
+        // its PID and exits on its own if already running or when the mode
+        // changes, so a redundant launch is harmless.
+        const char *args[] = {OPT_PATH "script/device/rgb_react.sh", NULL};
+        run_exec(args, A_SIZE(args), 1, 0, NULL, NULL);
         return 0;
     }
 

--- a/module/muxrgb.c
+++ b/module/muxrgb.c
@@ -162,7 +162,7 @@ static void restore_rgb_options(void) {
         case 9:
             new_mode = RGB_MODE_STICK_FOLLOW;
             break;
-        case RGB_MODE_SCREEN_REACT:
+        case 10:
             new_mode = RGB_MODE_SCREEN_REACT;
             break;
         default:

--- a/module/muxrgb.c
+++ b/module/muxrgb.c
@@ -20,11 +20,11 @@ RGB_ELEMENTS
 
 #define MODES_SERIAL                                                                                                   \
     (M_BIT(RGB_MODE_OFF) | M_BIT(RGB_MODE_STATIC) | M_BIT(RGB_MODE_BREATHING) | M_BIT(RGB_MODE_PRESET_COMBO)           \
-     | M_BIT(RGB_MODE_THEME_SUPPLIED))
+     | M_BIT(RGB_MODE_THEME_SUPPLIED) | M_BIT(RGB_MODE_SCREEN_REACT))
 
 #define MODES_SYSFS                                                                                                    \
     (M_BIT(RGB_MODE_OFF) | M_BIT(RGB_MODE_STATIC) | M_BIT(RGB_MODE_BREATHING) | M_BIT(RGB_MODE_PRESET_COMBO)           \
-     | M_BIT(RGB_MODE_THEME_SUPPLIED))
+     | M_BIT(RGB_MODE_THEME_SUPPLIED) | M_BIT(RGB_MODE_SCREEN_REACT))
 
 #define MODES_JOYPAD                                                                                                   \
     (M_BIT(RGB_MODE_OFF) | M_BIT(RGB_MODE_STATIC) | M_BIT(RGB_MODE_BREATHING) | M_BIT(RGB_MODE_THEME_SUPPLIED)         \
@@ -161,6 +161,9 @@ static void restore_rgb_options(void) {
             break;
         case 9:
             new_mode = RGB_MODE_STICK_FOLLOW;
+            break;
+        case RGB_MODE_SCREEN_REACT:
+            new_mode = RGB_MODE_SCREEN_REACT;
             break;
         default:
             new_mode = RGB_MODE_OFF;
@@ -418,6 +421,7 @@ static char **build_mode_options(int *count) {
         {RGB_MODE_STICK_FOLLOW, 1, lang.muxrgb.mode_name.stick_follow},
         {RGB_MODE_PRESET_COMBO, 1, lang.muxrgb.mode_name.preset_combo},
         {RGB_MODE_THEME_SUPPLIED, 0, lang.muxrgb.mode_name.theme_supplied},
+        {RGB_MODE_SCREEN_REACT, 1, lang.muxrgb.mode_name.screen_react},
     };
     const size_t slot_count = sizeof(slots) / sizeof(slots[0]);
 
@@ -603,6 +607,10 @@ static void apply_mode_visibility(const int ui_mode) {
         case RGB_MODE_STICK_FOLLOW:
             show_bright = 1;
             show_colour_l = is_joypad;
+            show_backend = 1;
+            break;
+        case RGB_MODE_SCREEN_REACT:
+            show_bright = 1;
             show_backend = 1;
             break;
         case RGB_MODE_THEME_SUPPLIED:


### PR DESCRIPTION
New `RGB_MODE_SCREEN_REACT` (10): the sticks follow on-screen colour in real time,
driven by the `rgb_react` daemon (companion internal PR).

- `rgb.h`: mode enum.
- `muxrgb`: offered on sysfs/serial (excluded from `MODES_JOYPAD` — backend unimplemented); exposes Brightness + Backend, matching Rainbow's option set.
- `murgb`: `restore` starts `/opt/muos/script/device/rgb_react.sh` (PID-file guarded); the daemon exits itself on mode change.
- `language`: "Screen React".